### PR TITLE
Bug/fix syntax highlighting

### DIFF
--- a/example/index.jsx
+++ b/example/index.jsx
@@ -13,5 +13,5 @@ render(require('./src/Demo'));
 
 // Webpack Hot Module Replacement API
 if (module.hot) {
-  module.hot.accept('./src/Demo', () => render(require('./src/Demo')));
+  module.hot.accept('./src/Demo', () => render(require('./src/Demo'))); // eslint-disable-line global-require
 }

--- a/example/src/Demo.jsx
+++ b/example/src/Demo.jsx
@@ -67,7 +67,7 @@ class Demo extends React.Component {
               }}
               flags={{ correctnewlines: false }}
               suggestedEdits
-              oauthUrl={this.props.oauthUrl}
+              oauth={this.props.oauth}
             />
           )
         }
@@ -77,10 +77,10 @@ class Demo extends React.Component {
 }
 
 Demo.propTypes = {
-  oauthUrl: PropTypes.string,
+  oauth: PropTypes.bool,
 };
 
 Demo.defaultProps = {
-  oauthUrl: '',
+  oauth: false,
 };
 module.exports = Demo;

--- a/packages/api-explorer/__tests__/Example.test.jsx
+++ b/packages/api-explorer/__tests__/Example.test.jsx
@@ -50,8 +50,20 @@ test('should correctly highlight syntax', () => {
   );
 
   // Asserting all JSON keys from the example oas.json
-  expect(example.find('pre').at(0).render().find('.cm-property').length).toBe(3);
+  expect(
+    example
+      .find('pre')
+      .at(0)
+      .render()
+      .find('.cm-property').length,
+  ).toBe(3);
 
   // Asserting that there are XML tags
-  expect(example.find('pre').at(1).render().find('.cm-tag').length).toBe(25);
+  expect(
+    example
+      .find('pre')
+      .at(1)
+      .render()
+      .find('.cm-tag').length,
+  ).toBe(25);
 });

--- a/packages/api-explorer/__tests__/Example.test.jsx
+++ b/packages/api-explorer/__tests__/Example.test.jsx
@@ -42,3 +42,16 @@ test('should show each example', () => {
 
   expect(example.find('pre').length).toEqual(2);
 });
+
+test('should correctly highlight syntax', () => {
+  const exampleOas = new Oas(exampleResults);
+  const example = shallow(
+    <Example {...props} oas={exampleOas} operation={exampleOas.operation('/results', 'get')} />,
+  );
+
+  // Asserting all JSON keys from the example oas.json
+  expect(example.find('pre').at(0).render().find('.cm-property').length).toBe(3);
+
+  // Asserting that there are XML tags
+  expect(example.find('pre').at(1).render().find('.cm-tag').length).toBe(25);
+});

--- a/packages/api-explorer/lib/create-docs.js
+++ b/packages/api-explorer/lib/create-docs.js
@@ -35,6 +35,16 @@ module.exports = (oas, apiSetting) => {
           //       {
           //         "code": "var a = 1;",
           //         "language": "javascript"
+          //       },
+          //       {
+          //         "code": "System.out.println('Hello World!');",
+          //         "language": "java",
+          //         "name": "Java"
+          //       },
+          //       {
+          //         "code": "<h1>HTML</h1>",
+          //         "language": "html",
+          //         "name": "HTML"
           //       }
           //     ]
           //   }

--- a/packages/api-explorer/src/Example.jsx
+++ b/packages/api-explorer/src/Example.jsx
@@ -22,7 +22,7 @@ function Example({ operation, result, oas, selected, setExampleTab }) {
             {showCodeResults(operation).map((example, index) => {
               return (
                 <pre
-                  className={`tomorrow night tabber-body tabber-body-${index}`}
+                  className={`tomorrow-night tabber-body tabber-body-${index}`}
                   style={{ display: index === selected ? 'block' : '' }}
                   key={index} // eslint-disable-line react/no-array-index-key
                 >

--- a/packages/api-explorer/src/Example.jsx
+++ b/packages/api-explorer/src/Example.jsx
@@ -26,7 +26,9 @@ function Example({ operation, result, oas, selected, setExampleTab }) {
                   style={{ display: index === selected ? 'block' : '' }}
                   key={index} // eslint-disable-line react/no-array-index-key
                   // eslint-disable-next-line react/no-danger
-                  dangerouslySetInnerHTML={{ __html: syntaxHighlighter(example.code, example.language, true) }}
+                  dangerouslySetInnerHTML={{
+                    __html: syntaxHighlighter(example.code, example.language, true),
+                  }}
                 />
               );
             })}

--- a/packages/api-explorer/src/Example.jsx
+++ b/packages/api-explorer/src/Example.jsx
@@ -3,7 +3,7 @@ const PropTypes = require('prop-types');
 const showCodeResults = require('./lib/show-code-results');
 
 // const { replaceVars } = require('./lib/replace-vars');
-const codemirror = require('@readme/syntax-highlighter/codemirror');
+const syntaxHighlighter = require('@readme/syntax-highlighter');
 const extensions = require('@readme/oas-extensions');
 
 const ExampleTabs = require('./ExampleTabs');
@@ -25,9 +25,9 @@ function Example({ operation, result, oas, selected, setExampleTab }) {
                   className={`tomorrow-night tabber-body tabber-body-${index}`}
                   style={{ display: index === selected ? 'block' : '' }}
                   key={index} // eslint-disable-line react/no-array-index-key
-                >
-                  {codemirror(example.code, example.language, true)}
-                </pre>
+                  // eslint-disable-next-line react/no-danger
+                  dangerouslySetInnerHTML={{ __html: syntaxHighlighter(example.code, example.language, true) }}
+                />
               );
             })}
           </div>

--- a/packages/syntax-highlighter/codemirror.js
+++ b/packages/syntax-highlighter/codemirror.js
@@ -6,14 +6,67 @@ require('codemirror/mode/shell/shell');
 require('codemirror/mode/javascript/javascript');
 require('codemirror/mode/ruby/ruby');
 require('codemirror/mode/python/python');
+require('codemirror/mode/clike/clike');
+require('codemirror/mode/htmlmixed/htmlmixed');
 
 function esc(str) {
   return str.replace(/[<&]/g, ch => (ch === '&' ? '&amp;' : '&lt;'));
 }
 
+// This is a mapping of potential languages
+// that do not have a direct codemirror mode for them
+// so we need to do a lookup to see what the appropriate
+// mode is.
+//
+// There are 2 types of lookup, single and array.
+// e.g. `html` needs to be rendered using `htmlmixed`, but
+// `java`, needs to be rendered using the `clike` mode.
+//
+// We also have the mimeType to potentially in future load
+// in new types dynamically
+const modes = {
+  html: 'htmlmixed',
+  json: ['javascript', 'application/ld+json'],
+  text: ['null', 'text/plain'],
+  markdown: 'gfm',
+  stylus: 'scss',
+  bash: 'shell',
+  mysql: 'sql',
+  sql: ['sql', 'text/x-sql'],
+  curl: 'shell',
+  asp: 'clike',
+  csharp: ['clike', 'text/x-csharp'],
+  cplusplus: ['clike', 'text/x-c++src'],
+  c: 'clike',
+  java: ['clike', 'text/x-java'],
+  scala: ['clike', 'text/x-scala'],
+  objectivec: ['clike', 'text/x-objectivec'],
+  liquid: 'htmlmixed',
+  scss: 'css',
+};
+
 module.exports = (code, lang) => {
   let output = '';
+  let mode = lang;
 
+  if (mode in modes) {
+    mode = modes[mode];
+    // lang = mode;
+    if (Array.isArray(mode)) {
+      // lang = mode[0];
+      mode = mode[1];
+    }
+  }
+
+  // TODO https://github.com/readmeio/api-explorer/issues/101
+  // CodeMirror.modeInfo.forEach((info) => {
+  //   if (info.mime == lang) {
+  //     modeName = info.mode;
+  //   } else if (info.name.toLowerCase() === lang) {
+  //     modeName = info.mode;
+  //     lang = info.mime;
+  //   }
+  // });
   // if (!CodeMirror.modes[lang]) {
   //   require(`codemirror/mode/${lang}/${lang}.js`);
   // }
@@ -29,7 +82,7 @@ module.exports = (code, lang) => {
     }
   }
 
-  CodeMirror.runMode(code, lang, (text, style) => {
+  CodeMirror.runMode(code, mode, (text, style) => {
     if (style !== curStyle) {
       flush();
       curStyle = style;

--- a/packages/syntax-highlighter/codemirror.js
+++ b/packages/syntax-highlighter/codemirror.js
@@ -45,8 +45,7 @@ const modes = {
   scss: 'css',
 };
 
-module.exports = (code, lang) => {
-  let output = '';
+function getMode(lang) {
   let mode = lang;
 
   if (mode in modes) {
@@ -57,6 +56,13 @@ module.exports = (code, lang) => {
       mode = mode[1];
     }
   }
+
+  return mode;
+}
+
+module.exports = (code, lang) => {
+  let output = '';
+  const mode = getMode(lang);
 
   // TODO https://github.com/readmeio/api-explorer/issues/101
   // CodeMirror.modeInfo.forEach((info) => {

--- a/packages/syntax-highlighter/index.js
+++ b/packages/syntax-highlighter/index.js
@@ -20,27 +20,6 @@ module.exports = (code, lang, dark) => {
 
   const theme = dark ? 'cm-s-tomorrow-night' : 'cm-s-neo';
 
-  const modes = {
-    html: 'htmlmixed',
-    json: 'application/ld+json',
-    text: 'text/plain',
-    markdown: 'gfm',
-    stylus: 'scss',
-    bash: 'shell',
-    mysql: 'sql',
-    sql: 'text/x-sql',
-    curl: 'shell',
-    asp: 'clike',
-    csharp: 'text/x-csharp',
-    cplusplus: 'text/x-c++src',
-    c: 'clike',
-    java: 'text/x-java',
-    scala: 'text/x-scala',
-    objectivec: 'text/x-objectivec',
-    liquid: 'htmlmixed',
-    scss: 'css',
-  };
-
   // let highlighted = ;
 
   // // Kind of a hack, but no other way to sanitize angular code
@@ -48,8 +27,7 @@ module.exports = (code, lang, dark) => {
   // highlighted = highlighted.replace(/{{/g, '&#123;<span></span>&#123;');
   // highlighted = highlighted.replace(/}}/g, '&#125;<span></span>&#125;');
 
-  return `<span class="${theme}">${codemirror(code, modes[lang] ? modes[lang] : lang)}</span>`;
+  return `<span class="${theme}">${codemirror(code, lang)}</span>`;
 };
-
 
 module.exports.uppercase = require('./uppercase');

--- a/packages/syntax-highlighter/test/index.test.js
+++ b/packages/syntax-highlighter/test/index.test.js
@@ -30,3 +30,15 @@ test('should work with modes', () => {
 test('should have a dark theme', () => {
   expect(syntaxHighlighter('{ "a": 1 }', 'json', true)).toContain('<span class="cm-s-tomorrow-night">');
 });
+
+test('should work for modes with an array like java', () => {
+  expect(syntaxHighlighter('service = client.service().messaging();', 'java')).toBe(
+    '<span class="cm-s-neo"><span class="cm-variable">service</span> <span class="cm-operator">=</span> <span class="cm-variable">client</span>.<span class="cm-variable">service</span>().<span class="cm-variable">messaging</span>();</span>',
+  );
+});
+
+test('should work for html', () => {
+  expect(syntaxHighlighter('<p>test</p>', 'html')).toBe(
+    '<span class="cm-s-neo"><span class="cm-tag cm-bracket">&lt;</span><span class="cm-tag">p</span><span class="cm-tag cm-bracket">></span>test<span class="cm-tag cm-bracket">&lt;/</span><span class="cm-tag">p</span><span class="cm-tag cm-bracket">></span></span>',
+  );
+});


### PR DESCRIPTION
There was a bug in the syntax highlighter which meant it couldn't syntax highlight java and HTML. I've fixed that and also made sure the Examples are correctly syntax highlighting.