### PR TITLE
Use password input type for basic auth

### DIFF
--- a/legacy-stuff/mixins.jade
+++ b/legacy-stuff/mixins.jade
@@ -76,7 +76,7 @@ mixin securityInput(security, multipleOauths)
         input(type="text" ng-model="apiAuth.auth._basic_username" focus-me="authFocus")
       .col-xs-6
         label password
-        input(type="text" ng-model="apiAuth.auth._basic_password")
+        input(type="password" ng-model="apiAuth.auth._basic_password")
   if security.type == 'apiKey'
     .row
       .col-xs-5


### PR DESCRIPTION
Updated *mixins.jade* to use an input type of `password` instead of `text` to not show the password on-screen when demoing to others, etc.