### PR TITLE
Build with TravisCi for Linux and macOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,18 @@
 language: node_js
 sudo: false
 node_js:
-  - 6.0
-  - 8.0
+  - 8.4
+  - 10.0
+
+os:
+  - osx
+  - linux
+
+install:
+  - npm install
+  - npm install -g npx
+  - npx lerna bootstrap
+
+cache:
+  directories:
+  - $HOME/.npm

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Open source components that make up ReadMe's API explorer
 
-[![CircleCI](https://circleci.com/gh/readmeio/api-explorer.svg?style=svg&circle-token=2a91256819c6da2e388896859d4f7fbb34ec9d84)](https://circleci.com/gh/readmeio/api-explorer)
+[![CircleCI](https://circleci.com/gh/readmeio/api-explorer.svg?style=svg&circle-token=2a91256819c6da2e388896859d4f7fbb34ec9d84)](https://circleci.com/gh/readmeio/api-explorer) [![Travis](https://img.shields.io/travis/readmeio/api-explorer.svg?logo=travis)](https://travis-ci.org/readmeio/api-explorer)
 
 [![](https://d3vv6lp55qjaqc.cloudfront.net/items/1M3C3j0I0s0j3T362344/Untitled-2.png)](https://readme.io)
 


### PR DESCRIPTION
Builds and tests on Linux and macOS for 8.4 and 10.0.
Please enable TravisCI for the [readmeio/api-explorer](https://travis-ci.org/readmeio/api-explorer) project. The badge was already linked appropriately.