### PR TITLE
Add error handling around `await response.json()` call

### DIFF
--- a/packages/api-explorer/__tests__/lib/oas-to-har.test.js
+++ b/packages/api-explorer/__tests__/lib/oas-to-har.test.js
@@ -13,7 +13,7 @@ test('should output a har format', () => {
             method: '',
             postData: {},
             queryString: [],
-            url: '',
+            url: 'https://example.com',
           },
         },
       ],
@@ -26,9 +26,13 @@ test('should uppercase the method', () => {
 });
 
 describe('url', () => {
-  test('should default to ""', () => {
-    expect(oasToHar({}, { path: '', method: '' }).log.entries[0].request.url).toBe('');
-    expect(oasToHar({}, { path: '/path', method: '' }).log.entries[0].request.url).toBe('/path');
+  test('should default to "https://example.com"', () => {
+    expect(oasToHar({}, { path: '', method: '' }).log.entries[0].request.url).toBe(
+      'https://example.com',
+    );
+    expect(oasToHar({}, { path: '/path', method: '' }).log.entries[0].request.url).toBe(
+      'https://example.com/path',
+    );
   });
 
   test('should be constructed from servers[0]', () => {
@@ -96,7 +100,7 @@ describe('url', () => {
 describe('path values', () => {
   test('should pass through unknown path params', () => {
     expect(oasToHar({}, { path: '/param-path/{id}', method: '' }).log.entries[0].request.url).toBe(
-      '/param-path/id',
+      'https://example.com/param-path/id',
     );
     expect(
       oasToHar(
@@ -113,7 +117,7 @@ describe('path values', () => {
           ],
         },
       ).log.entries[0].request.url,
-    ).toBe('/param-path/id');
+    ).toBe('https://example.com/param-path/id');
   });
 
   test('should not error if empty object passed in for values', () => {
@@ -133,7 +137,7 @@ describe('path values', () => {
         },
         {},
       ).log.entries[0].request.url,
-    ).toBe('/param-path/id');
+    ).toBe('https://example.com/param-path/id');
   });
 
   test('should use example if no value', () => {
@@ -153,7 +157,7 @@ describe('path values', () => {
           ],
         },
       ).log.entries[0].request.url,
-    ).toBe('/param-path/123');
+    ).toBe('https://example.com/param-path/123');
   });
 
   test('should add path values to the url', () => {
@@ -173,7 +177,7 @@ describe('path values', () => {
         },
         { path: { id: '456' } },
       ).log.entries[0].request.url,
-    ).toBe('/param-path/456');
+    ).toBe('https://example.com/param-path/456');
   });
 });
 

--- a/packages/api-explorer/__tests__/lib/parse-response.test.js
+++ b/packages/api-explorer/__tests__/lib/parse-response.test.js
@@ -137,3 +137,13 @@ test('should parse non-json response as text', async () => {
     nonJsonResponseBody,
   );
 });
+
+test('should not error if invalid json is returned', async () => {
+  const invalidJsonResponse = new Response('plain text', {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  expect((await codeSampleResponse(har, invalidJsonResponse)).responseBody).toEqual('plain text');
+});

--- a/packages/api-explorer/src/lib/oas-to-har.js
+++ b/packages/api-explorer/src/lib/oas-to-har.js
@@ -82,7 +82,10 @@ module.exports = (
     queryString: [],
     postData: {},
     method: pathOperation.method.toUpperCase(),
-    url: `${oas.servers ? oas.servers[0].url : ''}${pathOperation.path}`.replace(/\s/g, '%20'),
+    url: `${oas.servers ? oas.servers[0].url : 'https://example.com'}${pathOperation.path}`.replace(
+      /\s/g,
+      '%20',
+    ),
   };
 
   // Add protocol to urls starting with // e.g. //example.com

--- a/packages/api-explorer/src/lib/parse-response.js
+++ b/packages/api-explorer/src/lib/parse-response.js
@@ -1,29 +1,36 @@
 const { stringify } = require('querystring');
 
-async function parseResponse(har, response) {
-  const contentDisposition = response.headers.get('Content-Disposition');
-  const contentType = response.headers.get('Content-Type');
-  const isJson = contentType && contentType.includes('application/json');
-
+function getQuerystring(har) {
   // Converting [{ name: a, value: '123456' }] => { a: '123456' } so we can use querystring.stringify
   const convertedQueryString = (har.log.entries[0].request.queryString || [])
     .map(qs => ({ [qs.name]: qs.value }))
     .reduce((a, b) => Object.assign(a, b), {});
 
-  const querystring =
-    Object.keys(convertedQueryString).length > 0 ? `?${stringify(convertedQueryString)}` : '';
+  return Object.keys(convertedQueryString).length > 0 ? `?${stringify(convertedQueryString)}` : '';
+}
 
-  let responseBody;
+async function getResponseBody(response) {
+  const contentType = response.headers.get('Content-Type');
+  const isJson = contentType && contentType.includes('application/json');
+
   // We have to clone it before reading, just incase
   // we cannot parse it as JSON later, then we can
   // re-read again as plain text
   const clonedResponse = response.clone();
+  let responseBody;
 
   try {
     responseBody = await response[isJson ? 'json' : 'text']();
   } catch (e) {
     responseBody = await clonedResponse.text();
   }
+
+  return responseBody;
+}
+
+async function parseResponse(har, response) {
+  const contentDisposition = response.headers.get('Content-Disposition');
+  const querystring = getQuerystring(har);
 
   return {
     method: har.log.entries[0].request.method,
@@ -36,7 +43,7 @@ async function parseResponse(har, response) {
     isBinary: !!(contentDisposition && contentDisposition.match(/attachment/)),
     url: har.log.entries[0].request.url.replace('https://try.readme.io/', '') + querystring,
     status: response.status,
-    responseBody,
+    responseBody: await getResponseBody(response),
   };
 }
 


### PR DESCRIPTION
This is to catch cases where they return `content-type: application/json` but do not return valid JSON

We have to clone the object first before we parse, as the objects can only be read once