### PR TITLE
Feature/react error boundary

### DIFF
--- a/example/src/Demo.jsx
+++ b/example/src/Demo.jsx
@@ -61,6 +61,8 @@ class Demo extends React.Component {
         {
           this.state.status.length === 0 && (
             <ApiExplorer
+              // // To test the top level error boundary, uncomment this
+              // docs={[null, null]}
               docs={this.state.docs}
               oasFiles={{
                 'api-setting': Object.assign(extensions.defaults, this.state.oas),

--- a/example/swagger-files/endpoint-error-boundary.json
+++ b/example/swagger-files/endpoint-error-boundary.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "http://httpbin.org"
+    }
+  ],
+  "info": {
+    "version": "1.0.0",
+    "title": "Boolean without double description"
+  },
+  "paths": {
+    "/anything/error-boundary": {
+      "post": {
+        "summary": "Demo for error boundary if there is an error rendering the endpoint",
+        "description": "",
+        "parameters": [],
+        "responses": {},
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnknownSchema"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/example/swagger-files/types.json
+++ b/example/swagger-files/types.json
@@ -363,6 +363,23 @@
           }
         }
       }
+    },
+    "/anything/error-boundary": {
+      "post": {
+        "summary": "Demo for error boundary if there is an error rendering the endpoint",
+        "description": "",
+        "parameters": [],
+        "responses": {},
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnknownSchema"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "x-explorer-enabled": true,

--- a/example/swagger-files/types.json
+++ b/example/swagger-files/types.json
@@ -363,23 +363,6 @@
           }
         }
       }
-    },
-    "/anything/error-boundary": {
-      "post": {
-        "summary": "Demo for error boundary if there is an error rendering the endpoint",
-        "description": "",
-        "parameters": [],
-        "responses": {},
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UnknownSchema"
-              }
-            }
-          }
-        }
-      }
     }
   },
   "x-explorer-enabled": true,

--- a/packages/api-explorer/__tests__/Doc.test.jsx
+++ b/packages/api-explorer/__tests__/Doc.test.jsx
@@ -1,4 +1,4 @@
-const extensions = require('@readme/oas-extensions/');
+const extensions = require('@readme/oas-extensions');
 const { Request, Response } = require('node-fetch');
 
 global.Request = Request;
@@ -302,4 +302,30 @@ describe('`apiKey`', () => {
 
     expect(doc.state('formData').auth).toEqual({ api_key: apiKey });
   });
+});
+
+test('should output with an error message if the endpoint fails to load', () => {
+  const brokenOas = {
+    paths: {
+      '/path': {
+        'post': {
+          requestBody: {
+            $ref: '#/components/schemas/UnknownSchema',
+          },
+        }
+      }
+    }
+  };
+
+  const doc = mount(
+    <Doc
+      {...props}
+      oas={brokenOas}
+      doc={{ title: 'title', slug: 'slug', type: 'endpoint', swagger: { path: '/path' }, api: { method: 'post' } }}
+    />
+  );
+
+  doc.setState({ showEndpoint: true });
+
+  expect(doc.find('EndpointErrorBoundary').length).toBe(1);
 });

--- a/packages/api-explorer/__tests__/Doc.test.jsx
+++ b/packages/api-explorer/__tests__/Doc.test.jsx
@@ -308,21 +308,27 @@ test('should output with an error message if the endpoint fails to load', () => 
   const brokenOas = {
     paths: {
       '/path': {
-        'post': {
+        post: {
           requestBody: {
             $ref: '#/components/schemas/UnknownSchema',
           },
-        }
-      }
-    }
+        },
+      },
+    },
   };
 
   const doc = mount(
     <Doc
       {...props}
       oas={brokenOas}
-      doc={{ title: 'title', slug: 'slug', type: 'endpoint', swagger: { path: '/path' }, api: { method: 'post' } }}
-    />
+      doc={{
+        title: 'title',
+        slug: 'slug',
+        type: 'endpoint',
+        swagger: { path: '/path' },
+        api: { method: 'post' },
+      }}
+    />,
   );
 
   doc.setState({ showEndpoint: true });

--- a/packages/api-explorer/__tests__/index.test.jsx
+++ b/packages/api-explorer/__tests__/index.test.jsx
@@ -33,7 +33,7 @@ test('ApiExplorer renders a doc for each', () => {
 test('Should display an error message if it fails to render (wrapped in ErrorBoundary)', () => {
   // Prompting an error with an array of nulls instead of Docs
   // This is to simulate some unknown error state during initial render
-  const explorer = shallow(<WrappedApiExplorer {...props} docs={[null, null]} />);
+  const explorer = mount(<WrappedApiExplorer {...props} docs={[null, null]} />);
 
   expect(explorer.find('ErrorBoundary').length).toBe(1);
 });

--- a/packages/api-explorer/__tests__/index.test.jsx
+++ b/packages/api-explorer/__tests__/index.test.jsx
@@ -2,7 +2,9 @@ const React = require('react');
 const { shallow, mount } = require('enzyme');
 const Cookie = require('js-cookie');
 const extensions = require('@readme/oas-extensions');
-const ApiExplorer = require('../src');
+const WrappedApiExplorer = require('../src');
+
+const { ApiExplorer } = WrappedApiExplorer;
 
 const oas = require('./fixtures/petstore/oas');
 
@@ -26,6 +28,14 @@ test('ApiExplorer renders a doc for each', () => {
   const explorer = shallow(<ApiExplorer {...props} />);
 
   expect(explorer.find('Doc').length).toBe(docs.length);
+});
+
+test('Should display an error message if it fails to render (wrapped in ErrorBoundary)', () => {
+  // Prompting an error with an array of nulls instead of Docs
+  // This is to simulate some unknown error state during initial render
+  const explorer = shallow(<WrappedApiExplorer {...props} docs={[null, null]} />);
+
+  expect(explorer.find('ErrorBoundary').length).toBe(1);
 });
 
 describe('selected language', () => {

--- a/packages/api-explorer/src/BoundaryStackTrace.jsx
+++ b/packages/api-explorer/src/BoundaryStackTrace.jsx
@@ -1,0 +1,20 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+
+function BoundaryStackTrace({ error, info }) {
+  return (
+    <pre style={{ whiteSpace: 'pre-wrap' }}>
+      {error.toString()}
+      {info.componentStack}
+    </pre>
+  );
+}
+
+BoundaryStackTrace.propTypes = {
+  error: PropTypes.instanceOf(Error).isRequired,
+  info: PropTypes.shape({
+    componentStack: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+module.exports = BoundaryStackTrace;

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -13,6 +13,7 @@ const createParams = require('./Params');
 const CodeSample = require('./CodeSample');
 const Response = require('./Response');
 const ResponseSchema = require('./ResponseSchema');
+const EndpointErrorBoundary = require('./EndpointErrorBoundary');
 
 const Oas = require('./lib/Oas');
 // const showCode = require('./lib/show-code');
@@ -227,11 +228,11 @@ class Doc extends React.Component {
   renderEndpoint() {
     const { doc } = this.props;
 
-    if (this.props.flags.stripe) {
-      return this.themeStripe(doc);
-    }
-
-    return this.themeMain(doc);
+    return (
+      <EndpointErrorBoundary>
+        { this.props.flags.stripe ? this.themeStripe(doc) : this.themeMain(doc) }
+      </EndpointErrorBoundary>
+    );
   }
 
   renderParams() {

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -230,7 +230,7 @@ class Doc extends React.Component {
 
     return (
       <EndpointErrorBoundary>
-        { this.props.flags.stripe ? this.themeStripe(doc) : this.themeMain(doc) }
+        {this.props.flags.stripe ? this.themeStripe(doc) : this.themeMain(doc)}
       </EndpointErrorBoundary>
     );
   }

--- a/packages/api-explorer/src/EndpointErrorBoundary.jsx
+++ b/packages/api-explorer/src/EndpointErrorBoundary.jsx
@@ -27,7 +27,7 @@ class EndpointErrorBoundary extends React.Component {
               </a>{' '}
               with the following error:
             </h3>
-            <pre>
+            <pre style={{ whiteSpace: 'pre-wrap' }}>
               {this.state.error && this.state.error.toString()}
               {this.state.info.componentStack}
             </pre>

--- a/packages/api-explorer/src/EndpointErrorBoundary.jsx
+++ b/packages/api-explorer/src/EndpointErrorBoundary.jsx
@@ -19,7 +19,13 @@ class EndpointErrorBoundary extends React.Component {
       return (
         <div className="hub-reference-section">
           <div className="hub-reference-left" style={{ paddingLeft: '2%' }}>
-            <h3>There was an error rendering this endpoint. Please contact <a href="mailto:support@readme.io?subject=API Explorer Error">support@readme.io</a> with the following error:</h3>
+            <h3>
+              There was an error rendering this endpoint. Please contact{' '}
+              <a href="mailto:support@readme.io?subject=API Explorer Error">
+                support@readme.io
+              </a>{' '}
+              with the following error:
+            </h3>
             <pre>
               {this.state.error && this.state.error.toString()}
               {this.state.info.componentStack}
@@ -27,7 +33,7 @@ class EndpointErrorBoundary extends React.Component {
           </div>
           <div className="hub-reference-right" />
         </div>
-      )
+      );
     }
     return this.props.children;
   }
@@ -35,6 +41,6 @@ class EndpointErrorBoundary extends React.Component {
 
 EndpointErrorBoundary.propTypes = {
   children: PropTypes.node.isRequired,
-}
+};
 
 module.exports = EndpointErrorBoundary;

--- a/packages/api-explorer/src/EndpointErrorBoundary.jsx
+++ b/packages/api-explorer/src/EndpointErrorBoundary.jsx
@@ -1,0 +1,40 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+
+class EndpointErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: false };
+  }
+
+  componentDidCatch(error, info) {
+    this.setState({ error, info });
+    // TODO add bugsnag here?
+    // You can also log the error to an error reporting service
+    // logErrorToMyService(error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="hub-reference-section">
+          <div className="hub-reference-left" style={{ paddingLeft: '2%' }}>
+            <h3>There was an error rendering this endpoint. Please contact <a href="mailto:support@readme.io?subject=API Explorer Error">support@readme.io</a> with the following error:</h3>
+            <pre>
+              {this.state.error && this.state.error.toString()}
+              {this.state.info.componentStack}
+            </pre>
+          </div>
+          <div className="hub-reference-right" />
+        </div>
+      )
+    }
+    return this.props.children;
+  }
+}
+
+EndpointErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+module.exports = EndpointErrorBoundary;

--- a/packages/api-explorer/src/EndpointErrorBoundary.jsx
+++ b/packages/api-explorer/src/EndpointErrorBoundary.jsx
@@ -1,6 +1,8 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 
+const BoundaryStackTrace = require('./BoundaryStackTrace');
+
 class EndpointErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
@@ -27,10 +29,7 @@ class EndpointErrorBoundary extends React.Component {
               </a>{' '}
               with the following error:
             </h3>
-            <pre style={{ whiteSpace: 'pre-wrap' }}>
-              {this.state.error && this.state.error.toString()}
-              {this.state.info.componentStack}
-            </pre>
+            <BoundaryStackTrace error={this.state.error} info={this.state.info} />
           </div>
           <div className="hub-reference-right" />
         </div>

--- a/packages/api-explorer/src/EndpointErrorBoundary.jsx
+++ b/packages/api-explorer/src/EndpointErrorBoundary.jsx
@@ -20,7 +20,8 @@ class EndpointErrorBoundary extends React.Component {
         <div className="hub-reference-section">
           <div className="hub-reference-left" style={{ paddingLeft: '2%' }}>
             <h3>
-              There was an error rendering this endpoint. Please contact{' '}
+              There was an error rendering this endpoint. If you are the owner of this project
+              please contact{' '}
               <a href="mailto:support@readme.io?subject=API Explorer Error">
                 support@readme.io
               </a>{' '}

--- a/packages/api-explorer/src/ErrorBoundary.jsx
+++ b/packages/api-explorer/src/ErrorBoundary.jsx
@@ -17,14 +17,14 @@ class ErrorBoundary extends React.Component {
   render() {
     if (this.state.error) {
       return (
-        <div style={{ paddingLeft: '2%' }}>
+        <div style={{ paddingLeft: '2%', width: '75%' }}>
           <h3>
             There was an error rendering the API Explorer. If you are the owner of this project
             please contact{' '}
             <a href="mailto:support@readme.io?subject=API Explorer Error">support@readme.io</a> with
             the following error:
           </h3>
-          <pre>
+          <pre style={{ whiteSpace: 'pre-wrap' }}>
             {this.state.error && this.state.error.toString()}
             {this.state.info.componentStack}
           </pre>

--- a/packages/api-explorer/src/ErrorBoundary.jsx
+++ b/packages/api-explorer/src/ErrorBoundary.jsx
@@ -1,0 +1,42 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: false };
+  }
+
+  componentDidCatch(error, info) {
+    this.setState({ error, info });
+    // TODO add bugsnag here?
+    // You can also log the error to an error reporting service
+    // logErrorToMyService(error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ paddingLeft: '2%' }}>
+          <h3>
+            There was an error rendering the API Explorer. If you are the owner of this project
+            please contact{' '}
+            <a href="mailto:support@readme.io?subject=API Explorer Error">support@readme.io</a> with
+            the following error:
+          </h3>
+          <pre>
+            {this.state.error && this.state.error.toString()}
+            {this.state.info.componentStack}
+          </pre>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+module.exports = ErrorBoundary;

--- a/packages/api-explorer/src/ErrorBoundary.jsx
+++ b/packages/api-explorer/src/ErrorBoundary.jsx
@@ -1,6 +1,8 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 
+const BoundaryStackTrace = require('./BoundaryStackTrace');
+
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
@@ -24,10 +26,7 @@ class ErrorBoundary extends React.Component {
             <a href="mailto:support@readme.io?subject=API Explorer Error">support@readme.io</a> with
             the following error:
           </h3>
-          <pre style={{ whiteSpace: 'pre-wrap' }}>
-            {this.state.error && this.state.error.toString()}
-            {this.state.info.componentStack}
-          </pre>
+          <BoundaryStackTrace error={this.state.error} info={this.state.info} />
         </div>
       );
     }

--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -3,6 +3,7 @@ const Cookie = require('js-cookie');
 const PropTypes = require('prop-types');
 const extensions = require('@readme/oas-extensions');
 
+const ErrorBoundary = require('./ErrorBoundary');
 const Doc = require('./Doc');
 
 class ApiExplorer extends React.Component {
@@ -99,4 +100,9 @@ ApiExplorer.defaultProps = {
   tryItMetrics: () => {},
 };
 
-module.exports = ApiExplorer;
+module.exports = props => (
+  <ErrorBoundary>
+    <ApiExplorer {...props} />
+  </ErrorBoundary>
+);
+module.exports.ApiExplorer = ApiExplorer;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,5 +17,5 @@ module.exports = merge(common, {
     new webpack.NamedModulesPlugin(),
     new webpack.HotModuleReplacementPlugin(),
   ],
-  devtool: 'eval-source-map',
+  devtool: 'cheap-module-source-map',
 });


### PR DESCRIPTION
Example:
<img width="1527" alt="screen shot 2018-08-28 at 09 56 36" src="https://user-images.githubusercontent.com/848223/44738041-8bb62d80-aaa8-11e8-9a4a-2b3da936ba29.png">


Example within readme:
Top level error boundary:
<img width="1434" alt="screen shot 2018-08-30 at 15 37 41" src="https://user-images.githubusercontent.com/848223/44883073-c5cf2d00-ac6a-11e8-8a9d-c995a1b1d86c.png">

Endpoint error boundary:
<img width="1434" alt="screen shot 2018-08-30 at 15 38 12" src="https://user-images.githubusercontent.com/848223/44883080-cd8ed180-ac6a-11e8-9fd1-f83302e54ee0.png">

I'm hoping that the only reason the stack traces are bad is due to React being in development.

In future i'd like for this to report to bugsnag or something, but I think this is okay for now.