### PR TITLE
Fix issue with page refreshing on auth box open

### DIFF
--- a/packages/api-explorer/src/AuthBox.jsx
+++ b/packages/api-explorer/src/AuthBox.jsx
@@ -72,8 +72,8 @@ class AuthBox extends React.Component {
     return (
       <div className={classNames('hub-auth-dropdown', 'simple-dropdown', { open })}>
         {
-          // eslint-disable-next-line jsx-a11y/anchor-has-content
-          <a href="" className="icon icon-user-lock" onClick={toggle} />
+          // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/href-no-hash
+          <a href="#" className="icon icon-user-lock" onClick={toggle} />
         }
         <div className="nopad">
           <div className="triangle" />


### PR DESCRIPTION
This was really difficult to debug and I couldn't reproduce it but suspected
it was something to do with this <a> tag missing a href.

Greg figured it out yesterday that it was when you start on another page of ReadMe
then navigate to a reference page, this issue occurs.

I'm not 100% sure of the cause of the bug, i'm guessing it's something to do with
the pjax library highjacking all clicks on anchors, and because this is missing
an href, it gets highjacked instead of delegating to React.

I've demoed this working to Marc over slack.