### PR TITLE
feat: disable auth input on apikey

### DIFF
--- a/packages/api-explorer/src/security-input-types/ApiKey.jsx
+++ b/packages/api-explorer/src/security-input-types/ApiKey.jsx
@@ -15,6 +15,7 @@ function ApiKey({ scheme, authInputRef, change }) {
           ref={authInputRef}
           type="text"
           onChange={e => change(e.currentTarget.value)}
+          disabled={apiKeyCookie}
           value={apiKeyCookie}
         />
       </div>


### PR DESCRIPTION
closes #126 

Also I have found this. Is it a bug on OAuth? `header` is changing but form input is not changing
![peek 2018-11-17 17-45](https://user-images.githubusercontent.com/6043510/48662266-b1901480-ea90-11e8-94e1-e95fad62096d.gif)
