### PR TITLE
Feed baseUrl to anchor

### DIFF
--- a/example/src/Demo.jsx
+++ b/example/src/Demo.jsx
@@ -31,6 +31,8 @@ function Demo({ fetchSwagger, status, docs, oas, oauth }) {
               'api-setting': Object.assign(extensions.defaults, oas),
             }}
             baseUrl={'/'}
+            // Uncomment this if you want to test enterprise-structured URLs
+            // baseUrl={'/child/v1.0/'}
             Logs={Logs}
             flags={{ correctnewlines: false }}
             // Uncomment this in for column layout

--- a/packages/api-explorer/lib/create-docs.js
+++ b/packages/api-explorer/lib/create-docs.js
@@ -5,6 +5,8 @@
 // \`\`\`
 // This is your <<apiKey>>.
 
+// [link](doc:link)
+
 // [block:code]
 // {
 //   "codes": [

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "lint": "eslint -f unix . --ext js --ext jsx",
     "inspect": "jsinspect",
+    "prettier:write": "node_modules/.bin/prettier --write \"./**/**.{js,jsx}\"",
     "prettier": "prettier --list-different \"./**/**.{js,jsx}\"",
     "pretest": "npm run lint && npm run inspect && npm run prettier",
     "test": "jest --coverage --runInBand",

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -147,7 +147,12 @@ class Doc extends React.Component {
           </div>
         )}
 
-        <Content body={doc.body} flags={this.props.flags} isThreeColumn />
+        <Content
+          baseUrl={this.props.baseUrl}
+          body={doc.body}
+          flags={this.props.flags}
+          isThreeColumn
+        />
       </Fragment>
     );
   }
@@ -165,7 +170,12 @@ class Doc extends React.Component {
                   {this.renderParams()}
                 </Fragment>
               )}
-              <Content body={doc.body} flags={this.props.flags} isThreeColumn="left" />
+              <Content
+                baseUrl={this.props.baseUrl}
+                body={doc.body}
+                flags={this.props.flags}
+                isThreeColumn="left"
+              />
             </div>
 
             <div className="hub-reference-right">
@@ -176,7 +186,12 @@ class Doc extends React.Component {
                   <div className="hub-reference-results tabber-parent">{this.renderResponse()}</div>
                 </div>
               )}
-              <Content body={doc.body} flags={this.props.flags} isThreeColumn="right" />
+              <Content
+                baseUrl={this.props.baseUrl}
+                body={doc.body}
+                flags={this.props.flags}
+                isThreeColumn="right"
+              />
             </div>
           </Fragment>
         </div>

--- a/packages/api-explorer/src/block-types/Content.jsx
+++ b/packages/api-explorer/src/block-types/Content.jsx
@@ -12,9 +12,9 @@ const PropTypes = require('prop-types');
 
 const parseBlocks = require('../lib/parse-magic-blocks');
 
-const Loop = ({ content, column, flags }) => {
+const Loop = ({ content, column, flags, baseUrl }) => {
   const elements = content.map((block, key) => {
-    const props = { key, block, flags };
+    const props = { key, block, flags, baseUrl };
     switch (block.type) {
       case 'textarea':
         // eslint-disable-next-line react/no-array-index-key
@@ -83,6 +83,7 @@ const Content = props => {
       content={isThreeColumn === 'left' ? left : right}
       flags={props.flags}
       column={isThreeColumn}
+      baseUrl={props.baseUrl}
     />
   );
 };
@@ -97,23 +98,27 @@ Loop.propTypes = {
   flags: PropTypes.shape({
     correctnewlines: PropTypes.bool,
   }).isRequired,
+  baseUrl: PropTypes.string,
 };
 
 Loop.defaultProps = {
   column: 'left',
   flags: {},
+  baseUrl: '/',
 };
 
 Content.propTypes = {
   isThreeColumn: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   body: PropTypes.string,
   flags: PropTypes.shape({}),
+  baseUrl: PropTypes.string,
 };
 
 Content.defaultProps = {
   isThreeColumn: true,
   body: '',
   flags: {},
+  baseUrl: '/',
 };
 
 module.exports = Content;

--- a/packages/api-explorer/src/block-types/Content.jsx
+++ b/packages/api-explorer/src/block-types/Content.jsx
@@ -66,12 +66,12 @@ const Content = props => {
       <div className="hub-reference-section">
         <div className="hub-reference-left">
           <div className="content-body">
-            <Loop content={left} column="left" flags={props.flags} />
+            <Loop content={left} column="left" flags={props.flags} baseUrl={props.baseUrl} />
           </div>
         </div>
         <div className="hub-reference-right">
           <div className="content-body">
-            <Loop content={right} column="right" />
+            <Loop content={right} column="right" baseUrl={props.baseUrl} />
           </div>
         </div>
       </div>

--- a/packages/api-explorer/src/block-types/TextArea.jsx
+++ b/packages/api-explorer/src/block-types/TextArea.jsx
@@ -2,8 +2,15 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const markdown = require('@readme/markdown');
 
-const Textarea = ({ block, flags }) => {
-  return <div className="magic-block-textarea">{markdown(block.text, flags)}</div>;
+const Textarea = ({ block, flags, baseUrl }) => {
+  const combined = Object.assign(
+    {
+      baseUrl,
+    },
+    flags,
+  );
+
+  return <div className="magic-block-textarea">{markdown(block.text, combined)}</div>;
 };
 
 Textarea.propTypes = {
@@ -11,9 +18,11 @@ Textarea.propTypes = {
     text: PropTypes.string.isRequired,
   }).isRequired,
   flags: PropTypes.shape({}),
+  baseUrl: PropTypes.string,
 };
 
 Textarea.defaultProps = {
   flags: {},
+  baseUrl: '/',
 };
 module.exports = Textarea;

--- a/packages/markdown/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/markdown/__tests__/__snapshots__/index.test.js.snap
@@ -10,6 +10,14 @@ exports[`anchors 1`] = `
 </p>"
 `;
 
+exports[`anchors with baseUrl 1`] = `
+"<p><a href=\\"/child/v1.0/docs/slug\\" target=\\"_self\\" class=\\"doc-link\\" data-sidebar=\\"slug\\">doc</a><br/>
+<a href=\\"/child/v1.0/reference#slug\\" target=\\"_self\\">ref</a><br/>
+<a href=\\"/child/v1.0/blog/slug\\" target=\\"_self\\">blog</a><br/>
+<a href=\\"/child/v1.0/page/slug\\" target=\\"_self\\">page</a><br/>
+</p>"
+`;
+
 exports[`check list items 1`] = `
 "<ul>
 <li><input type=\\"checkbox\\" disabled=\\"\\"/> checklistitem1</li>

--- a/packages/markdown/__tests__/index.test.js
+++ b/packages/markdown/__tests__/index.test.js
@@ -64,6 +64,23 @@ test('anchors', () => {
   ).toMatchSnapshot();
 });
 
+test('anchors with baseUrl', () => {
+  const opts = { baseUrl: '/child/v1.0' };
+  expect(
+    shallow(
+      markdown(
+        `
+[doc](doc:slug)
+[ref](ref:slug)
+[blog](blog:slug)
+[page](page:slug)
+  `,
+        opts,
+      ),
+    ).html(),
+  ).toMatchSnapshot();
+});
+
 test('emojis', () => {
   expect(
     shallow(

--- a/packages/markdown/components/Anchor.jsx
+++ b/packages/markdown/components/Anchor.jsx
@@ -3,10 +3,11 @@ const PropTypes = require('prop-types');
 
 // Nabbed from here:
 // https://github.com/readmeio/api-explorer/blob/0dedafcf71102feedaa4145040d3f57d79d95752/packages/api-explorer/src/lib/markdown/renderer.js#L52
-function getHref(href) {
+function getHref(href, baseUrl) {
+  const base = baseUrl === '/' ? '' : baseUrl;
   const doc = href.match(/^doc:([-_a-zA-Z0-9#]*)$/);
   if (doc) {
-    return `/docs/${doc[1]}`;
+    return `${base}/docs/${doc[1]}`;
   }
 
   const ref = href.match(/^ref:([-_a-zA-Z0-9#]*)$/);
@@ -16,17 +17,17 @@ function getHref(href) {
     // if (req && req.project.appearance.categoriesAsDropdown) {
     //   cat = `/${req._referenceCategoryMap[ref[1]]}`;
     // }
-    return `/reference${cat}#${ref[1]}`;
+    return `${base}/reference${cat}#${ref[1]}`;
   }
 
   const blog = href.match(/^blog:([-_a-zA-Z0-9#]*)$/);
   if (blog) {
-    return `/blog/${blog[1]}`;
+    return `${base}/blog/${blog[1]}`;
   }
 
   const custompage = href.match(/^page:([-_a-zA-Z0-9#]*)$/);
   if (custompage) {
-    return `/page/${custompage[1]}`;
+    return `${base}/page/${custompage[1]}`;
   }
 
   return href;
@@ -43,21 +44,36 @@ function docLink(href) {
 }
 
 function Anchor(props) {
-  // eslint-disable-next-line jsx-a11y/anchor-has-content
-  return <a {...props} target="_self" href={getHref(props.href)} {...docLink(props.href)} />;
+  const data = Object.assign({}, props);
+  delete data.baseUrl;
+  return (
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
+    <a
+      {...data}
+      target="_self"
+      href={getHref(props.href, props.baseUrl)}
+      {...docLink(props.href)}
+    />
+  );
 }
 
 Anchor.propTypes = {
   href: PropTypes.string,
+  baseUrl: PropTypes.string,
 };
 
 Anchor.defaultProps = {
   href: '',
+  baseUrl: '/',
 };
 
-module.exports = sanitizeSchema => {
+function createAnchor(options) {
+  return props => <Anchor baseUrl={options.baseUrl} {...props} />;
+}
+
+module.exports = (options, sanitizeSchema) => {
   // This is for our custom link formats
   sanitizeSchema.protocols.href.push('doc', 'ref', 'blog', 'page');
 
-  return Anchor;
+  return createAnchor(options);
 };

--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -38,7 +38,7 @@ module.exports = function markdown(text, opts = {}) {
         h4: heading('h4', sanitize),
         h5: heading('h5', sanitize),
         h6: heading('h6', sanitize),
-        a: anchor(sanitize),
+        a: anchor(opts, sanitize),
         code: code(sanitize),
         // Remove enclosing <div>
         // https://github.com/mapbox/remark-react/issues/54


### PR DESCRIPTION
Enterprise styled URLs will have a baseUrl such as '/child/v1.0'
- Versions are optional
- Children are optional
- Language is optional

This PR will resolve and optionally add that URL structure to anchor tags when they render.

To test this, you must do two things
- Create custom body with `create-docs`. Uncomment the body variable.
- Change the `baseUrl` in demo to something else.