### PR TITLE
Fix issue where default values wouldn't be saved into the formData until edited

### DIFF
--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -234,7 +234,7 @@ describe('readOnly', () => {
   });
 });
 
-test('defaults should be applied on first render', (done) => {
+test('defaults should be applied on first render', done => {
   const defaultValue = 'this is a default value';
   function onChange(formData) {
     expect(formData.body).toEqual({ a: defaultValue });

--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -103,11 +103,12 @@ test('{ type: string, format: binary } should render as <input type="file">', ()
   expect(params.find('.field-file').length).toBe(1);
 });
 
-function renderParams(schema) {
+function renderParams(schema, customProps) {
   return mount(
     <div>
       <Params
         {...props}
+        {...customProps}
         operation={
           new Operation(oas, '/path', 'post', {
             requestBody: {
@@ -231,4 +232,14 @@ describe('readOnly', () => {
       ).find('input#addPet_id[type="hidden"]').length,
     ).toBe(1);
   });
+});
+
+test('defaults should be applied on first render', (done) => {
+  const defaultValue = 'this is a default value';
+  function onChange(formData) {
+    expect(formData.body).toEqual({ a: defaultValue });
+    return done();
+  }
+
+  renderParams({ type: 'string', default: defaultValue }, { onChange });
 });

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@readme/api-explorer",
-  "version": "2.4.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2103,7 +2103,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
         "duplexer": "~0.1.1",
@@ -8229,7 +8229,7 @@
       }
     },
     "react-jsonschema-form": {
-      "version": "github:domharrington/react-jsonschema-form#f056a1ed34d2d0841ae897303e9d29b9e8143687",
+      "version": "github:domharrington/react-jsonschema-form#115e75dbbf9b64a107ffb98ec410a8fd6ce1ced5",
       "from": "github:domharrington/react-jsonschema-form#dist-committed",
       "requires": {
         "ajv": "^5.2.3",
@@ -8251,9 +8251,9 @@
           }
         },
         "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
+          "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw=="
         }
       }
     },


### PR DESCRIPTION
You can test this locally here: http://localhost:9966/?selected=swagger-files%2Ftypes.json
Search for "default value" and see that it is already in the code sample.

This issue luckily got fixed upstream:
https://github.com/mozilla-services/react-jsonschema-form/pull/1034

So to bring that in I needed to update my fork of the module.

I would love to get off of my fork and get back onto the main release,
but there's some outstanding work on my PR which means we can't right now:
https://github.com/mozilla-services/react-jsonschema-form/pull/954