### PR TITLE
Fix problem where nested objects would appear empty

### DIFF
--- a/packages/api-explorer/__tests__/lib/oas-to-har.test.js
+++ b/packages/api-explorer/__tests__/lib/oas-to-har.test.js
@@ -652,7 +652,7 @@ describe('body values', () => {
         },
         { body: { RAW_BODY: {} } },
       ).log.entries[0].request.postData.text,
-    ).toEqual(JSON.stringify({}));
+    ).toEqual(undefined);
   });
 
   it('should return nothing for undefined body property', () => {
@@ -679,7 +679,7 @@ describe('body values', () => {
         },
         { body: { a: undefined } },
       ).log.entries[0].request.postData.text,
-    ).toEqual(JSON.stringify({}));
+    ).toEqual(undefined);
   });
 
   it('should work for schemas that require a lookup', () => {
@@ -862,6 +862,46 @@ describe('body values', () => {
         ).log.entries[0].request.postData.text,
       ).toEqual(JSON.stringify({ a: JSON.parse('{ "b": "valid json" }') }));
     });
+  });
+
+  it('should not include objects with undefined sub properties', () => {
+    expect(
+      oasToHar(
+        {},
+        {
+          path: '/body',
+          method: 'get',
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    a: {
+                      type: 'object',
+                      properties: {
+                        b: {
+                          type: 'string',
+                        },
+                        c: {
+                          type: 'object',
+                          properties: {
+                            d: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        { body: { a: { b: undefined, c: { d: undefined } } } },
+      ).log.entries[0].request.postData.text,
+    ).toEqual(undefined);
   });
 });
 

--- a/packages/api-explorer/src/lib/oas-to-har.js
+++ b/packages/api-explorer/src/lib/oas-to-har.js
@@ -74,6 +74,42 @@ function isPrimitive(val) {
   return typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean';
 }
 
+function isEmptyObject(obj) {
+  // Then remove all empty objects from the top level object
+  return typeof obj === 'object' && Object.keys(obj).length === 0;
+}
+
+// Modified from here: https://stackoverflow.com/a/43781499
+function stripEmptyObjects(obj) {
+  Object.keys(obj).forEach(key => {
+    const value = obj[key];
+    if (typeof value === 'object') {
+      // Recurse, strip out empty objects from children
+      stripEmptyObjects(value);
+      // Then remove all empty objects from the top level object
+      if (isEmptyObject(value)) {
+        delete obj[key];
+      }
+    }
+  });
+}
+
+function removeUndefinedObjects(obj) {
+  // JSON.stringify removes undefined values
+  const withoutUndefined = JSON.parse(JSON.stringify(obj));
+
+  // Then we recursively remove all empty objects
+  stripEmptyObjects(withoutUndefined);
+
+  // If the only thing that's leftover is an empty object
+  // then return nothing so we don't end up with default
+  // code samples with:
+  // --data '{}'
+  if (isEmptyObject(withoutUndefined)) return undefined;
+
+  return withoutUndefined;
+}
+
 module.exports = (
   oas,
   pathOperation = { path: '', method: '' },
@@ -174,7 +210,9 @@ module.exports = (
 
   function stringify(json) {
     // Default to JSON.stringify
-    har.postData.text = JSON.stringify(typeof json.RAW_BODY !== 'undefined' ? json.RAW_BODY : json);
+    har.postData.text = JSON.stringify(
+      removeUndefinedObjects(typeof json.RAW_BODY !== 'undefined' ? json.RAW_BODY : json),
+    );
   }
 
   if (schema.schema && Object.keys(schema.schema).length) {


### PR DESCRIPTION
On production right now if there's a nested object in a form, it always get
in the code sample even if the form values are not set:

```
--data '{"category":{}}'
```

This PR recursively removes empty objects from the form values so they
do not get set when making the request.

This problem was slightly exacerbated by #179 which auto applied default
values from the form to the samples.