### PR TITLE
Add some tests and fix regression in code to remove undefined objects

### DIFF
--- a/packages/api-explorer/__tests__/lib/remove-undefined-objects.test.js
+++ b/packages/api-explorer/__tests__/lib/remove-undefined-objects.test.js
@@ -1,0 +1,9 @@
+const removeUndefinedObjects = require('../../src/lib/remove-undefined-objects');
+
+test('should remove empty objects with only undefined properties', () => {
+  expect(removeUndefinedObjects({ a: { b: undefined, c: { d: undefined } } })).toEqual(undefined);
+});
+
+test('should not throw on arrays of primitives', () => {
+  expect(removeUndefinedObjects([null])).toEqual([null]);
+});

--- a/packages/api-explorer/src/lib/oas-to-har.js
+++ b/packages/api-explorer/src/lib/oas-to-har.js
@@ -3,6 +3,7 @@ const querystring = require('querystring');
 const extensions = require('@readme/oas-extensions');
 const getSchema = require('./get-schema');
 const configureSecurity = require('./configure-security');
+const removeUndefinedObjects = require('./remove-undefined-objects');
 
 // const format = {
 //   value: v => `__START_VALUE__${v}__END__`,
@@ -72,42 +73,6 @@ function getResponseContentType(content) {
 
 function isPrimitive(val) {
   return typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean';
-}
-
-function isEmptyObject(obj) {
-  // Then remove all empty objects from the top level object
-  return typeof obj === 'object' && Object.keys(obj).length === 0;
-}
-
-// Modified from here: https://stackoverflow.com/a/43781499
-function stripEmptyObjects(obj) {
-  Object.keys(obj).forEach(key => {
-    const value = obj[key];
-    if (typeof value === 'object') {
-      // Recurse, strip out empty objects from children
-      stripEmptyObjects(value);
-      // Then remove all empty objects from the top level object
-      if (isEmptyObject(value)) {
-        delete obj[key];
-      }
-    }
-  });
-}
-
-function removeUndefinedObjects(obj) {
-  // JSON.stringify removes undefined values
-  const withoutUndefined = JSON.parse(JSON.stringify(obj));
-
-  // Then we recursively remove all empty objects
-  stripEmptyObjects(withoutUndefined);
-
-  // If the only thing that's leftover is an empty object
-  // then return nothing so we don't end up with default
-  // code samples with:
-  // --data '{}'
-  if (isEmptyObject(withoutUndefined)) return undefined;
-
-  return withoutUndefined;
 }
 
 module.exports = (

--- a/packages/api-explorer/src/lib/remove-undefined-objects.js
+++ b/packages/api-explorer/src/lib/remove-undefined-objects.js
@@ -7,7 +7,7 @@ function isEmptyObject(obj) {
 function stripEmptyObjects(obj) {
   Object.keys(obj).forEach(key => {
     const value = obj[key];
-    if (typeof value === 'object') {
+    if (typeof value === 'object' && !Array.isArray(obj)) {
       // Recurse, strip out empty objects from children
       stripEmptyObjects(value);
       // Then remove all empty objects from the top level object

--- a/packages/api-explorer/src/lib/remove-undefined-objects.js
+++ b/packages/api-explorer/src/lib/remove-undefined-objects.js
@@ -1,0 +1,37 @@
+function isEmptyObject(obj) {
+  // Then remove all empty objects from the top level object
+  return typeof obj === 'object' && Object.keys(obj).length === 0;
+}
+
+// Modified from here: https://stackoverflow.com/a/43781499
+function stripEmptyObjects(obj) {
+  Object.keys(obj).forEach(key => {
+    const value = obj[key];
+    if (typeof value === 'object') {
+      // Recurse, strip out empty objects from children
+      stripEmptyObjects(value);
+      // Then remove all empty objects from the top level object
+      if (isEmptyObject(value)) {
+        delete obj[key];
+      }
+    }
+  });
+}
+
+function removeUndefinedObjects(obj) {
+  // JSON.stringify removes undefined values
+  const withoutUndefined = JSON.parse(JSON.stringify(obj));
+
+  // Then we recursively remove all empty objects
+  stripEmptyObjects(withoutUndefined);
+
+  // If the only thing that's leftover is an empty object
+  // then return nothing so we don't end up with default
+  // code samples with:
+  // --data '{}'
+  if (isEmptyObject(withoutUndefined)) return undefined;
+
+  return withoutUndefined;
+}
+
+module.exports = removeUndefinedObjects;


### PR DESCRIPTION
The following code throws:

```
Object.keys(null)
```

Because the recursive code to strip all undefined's calls Object.keys
first on `[null]` then `typeof [] === 'object'` causes it to recurse
another layer. The code then threw!

You can see the issue here:
https://preview.readme.io/?selected=swagger-files%2Ftypes.json
Go to: Top level array of primitives

Can see it fixed here:
http://localhost:9966/?selected=swagger-files%2Ftypes.json