### PR TITLE
Selected example

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@readme/api-explorer",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8229,7 +8229,7 @@
       }
     },
     "react-jsonschema-form": {
-      "version": "github:domharrington/react-jsonschema-form#115e75dbbf9b64a107ffb98ec410a8fd6ce1ced5",
+      "version": "github:domharrington/react-jsonschema-form#f056a1ed34d2d0841ae897303e9d29b9e8143687",
       "from": "github:domharrington/react-jsonschema-form#dist-committed",
       "requires": {
         "ajv": "^5.2.3",

--- a/packages/api-explorer/src/CodeSample.jsx
+++ b/packages/api-explorer/src/CodeSample.jsx
@@ -12,25 +12,17 @@ const syntaxHighlighter = require('@readme/syntax-highlighter');
 const generateCodeSnippet = require('./lib/generate-code-snippet');
 
 class CodeSample extends React.Component {
-  constructor(props) {
-    super(props);
-
-    const { examples, language } = props;
-    const selectedExample = examples.find(example => example.language === language);
-
-    this.state = {
-      selectedExample,
-    };
-  }
-
   getKey(example, index) {
     const key = `${example.language}-${index}`;
-    const selected = this.state.selectedExample === example;
+    const selected = this.isSelected(example, index);
     return { key, selected };
   }
 
-  selectExample(example) {
-    this.setState({ selectedExample: example });
+  isSelected(source, index) {
+    const { example } = this.props;
+    const defaultSelection = index === 0 && !example.language;
+    const isSame = source.language === example.language && source.name === example.name;
+    return defaultSelection || isSame;
   }
 
   renderSelected(examples, setLanguage) {
@@ -51,7 +43,7 @@ class CodeSample extends React.Component {
                     onClick={e => {
                       e.preventDefault();
                       setLanguage(example.language);
-                      this.selectExample(example);
+                      this.props.setExample(example);
                     }}
                   >
                     {example.name || generateCodeSnippet.getLangName(example.language)}
@@ -70,7 +62,7 @@ class CodeSample extends React.Component {
                 <pre
                   className="tomorrow-night tabber-body"
                   key={key} // eslint-disable-line react/no-array-index-key
-                  style={{ display: this.state.selectedExample === example ? 'block' : '' }}
+                  style={{ display: selected ? 'block' : '' }}
                 >
                   {syntaxHighlighter(example.code || '', example.language, { dark: true })}
                 </pre>
@@ -132,6 +124,7 @@ class CodeSample extends React.Component {
 CodeSample.propTypes = {
   oas: PropTypes.instanceOf(Oas).isRequired,
   setLanguage: PropTypes.func.isRequired,
+  setExample: PropTypes.func.isRequired,
   operation: PropTypes.instanceOf(Operation).isRequired,
   formData: PropTypes.shape({}).isRequired,
   examples: PropTypes.arrayOf(
@@ -141,10 +134,12 @@ CodeSample.propTypes = {
     }),
   ),
   language: PropTypes.string.isRequired,
+  example: PropTypes.shape({}),
 };
 
 CodeSample.defaultProps = {
   examples: [],
+  example: {},
 };
 
 module.exports = CodeSample;

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -200,9 +200,11 @@ class Doc extends React.Component {
       <CodeSample
         oas={this.oas}
         setLanguage={this.props.setLanguage}
+        setExample={this.props.setExample}
         operation={this.getOperation()}
         formData={this.state.formData}
         language={this.props.language}
+        example={this.props.example}
         examples={examples}
       />
     );
@@ -388,6 +390,7 @@ Doc.propTypes = {
   Logs: PropTypes.func,
   oas: PropTypes.shape({}),
   setLanguage: PropTypes.func.isRequired,
+  setExample: PropTypes.func.isRequired,
   flags: PropTypes.shape({
     correctnewlines: PropTypes.bool,
   }).isRequired,
@@ -396,6 +399,7 @@ Doc.propTypes = {
     splitReferenceDocs: PropTypes.bool,
   }).isRequired,
   language: PropTypes.string.isRequired,
+  example: PropTypes.shape({}),
   baseUrl: PropTypes.string,
   oauth: PropTypes.bool.isRequired,
   suggestedEdits: PropTypes.bool.isRequired,
@@ -415,5 +419,6 @@ Doc.defaultProps = {
   apiKey: undefined,
   Logs: undefined,
   user: undefined,
+  example: {},
   baseUrl: '/',
 };

--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -15,6 +15,7 @@ class ApiExplorer extends React.Component {
     super(props);
 
     this.setLanguage = this.setLanguage.bind(this);
+    this.setExample = this.setExample.bind(this);
     this.getDefaultLanguage = this.getDefaultLanguage.bind(this);
     this.changeSelected = this.changeSelected.bind(this);
 
@@ -56,6 +57,10 @@ class ApiExplorer extends React.Component {
   setLanguage(language) {
     this.setState({ language });
     Cookie.set('readme_language', language);
+  }
+
+  setExample(example) {
+    this.setState({ example });
   }
 
   getDefaultLanguage() {
@@ -102,12 +107,14 @@ class ApiExplorer extends React.Component {
                       doc={doc}
                       oas={this.getOas(doc)}
                       setLanguage={this.setLanguage}
+                      setExample={this.setExample}
                       flags={this.props.flags}
                       user={this.props.variables.user}
                       Logs={this.props.Logs}
                       baseUrl={this.props.baseUrl}
                       appearance={this.props.appearance}
                       language={this.state.language}
+                      example={this.state.example}
                       oauth={this.props.oauth}
                       suggestedEdits={this.props.suggestedEdits}
                       apiKey={this.state.apiKey}

--- a/packages/api-logs/package-lock.json
+++ b/packages/api-logs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@readme/api-logs",
-  "version": "2.2.11",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
https://app.asana.com/0/681252538274980/801649456511557/f

### Currently a work in progress

Problem: Selected manual code samples does not change for everything else, once code sample is selected.
- There is also the issue of duplicate languages; if a language is specified twice, what will determine what is selected?

Solution: Use top-level state for the CodeSample component, to manage selection.
- Using the prop `.language` is not enough to determine what is selected. There may be a CodeSample with examples `TypeScript` and `JavaScript` (names) that have language of `JavaScript` specified. Because of this, we need to be more specific.

How to debug: 
- Uncomment [these](https://github.com/readmeio/api-explorer/blob/master/packages/api-explorer/lib/create-docs.js#L51-L62) lines

Question
- How should we persist this data? Should we save it in cookies, like we do with the prop `language`? @domharrington 
