### PR TITLE
Remove trailing slashes from paths and header parameter improvements

### DIFF
--- a/packages/api-explorer/__tests__/lib/Oas.test.js
+++ b/packages/api-explorer/__tests__/lib/Oas.test.js
@@ -13,6 +13,13 @@ describe('operation()', () => {
     expect(operation.method).toBe('get');
   });
 
+  test.only('should strip trailing slashes from path', () => {
+    const oas = { paths: { '/path/': { get: { a: 1 } } } };
+    const operation = new Oas(oas).operation('/path/', 'get');
+    expect(operation).toBeInstanceOf(Operation);
+    expect(operation.path).toBe('/path');
+  });
+
   test('should return a default when no operation', () => {
     expect(new Oas({}).operation('/unknown', 'get')).toMatchSnapshot();
   });

--- a/packages/api-explorer/__tests__/lib/Oas.test.js
+++ b/packages/api-explorer/__tests__/lib/Oas.test.js
@@ -13,7 +13,7 @@ describe('operation()', () => {
     expect(operation.method).toBe('get');
   });
 
-  test.only('should strip trailing slashes from path', () => {
+  test('should strip trailing slashes from path', () => {
     const oas = { paths: { '/path/': { get: { a: 1 } } } };
     const operation = new Oas(oas).operation('/path/', 'get');
     expect(operation).toBeInstanceOf(Operation);

--- a/packages/api-explorer/__tests__/lib/oas-to-har.test.js
+++ b/packages/api-explorer/__tests__/lib/oas-to-har.test.js
@@ -337,6 +337,33 @@ describe('header values', () => {
     ).toEqual([{ name: 'Accept', value: 'application/xml' }]);
   });
 
+  it('should only receive one accept header if specified in values', () => {
+    expect(
+      oasToHar(
+        oas,
+        {
+          path: '/header',
+          method: 'get',
+          parameters: [
+            {
+              name: 'Accept',
+              in: 'header',
+            },
+          ],
+          responses: {
+            200: {
+              content: {
+                'application/json': {},
+                'application/xml': {},
+              },
+            },
+          },
+        },
+        { header: { Accept: 'application/xml' } },
+      ).log.entries[0].request.headers,
+    ).toEqual([{ name: 'Accept', value: 'application/xml' }]);
+  });
+
   test('should add falsy values to the headers', () => {
     expect(
       oasToHar(

--- a/packages/api-explorer/__tests__/lib/oas-to-har.test.js
+++ b/packages/api-explorer/__tests__/lib/oas-to-har.test.js
@@ -662,6 +662,32 @@ describe('body values', () => {
     ).toEqual(JSON.stringify({ a: 123 }));
   });
 
+  it('should work for schemas that require a parameters lookup', () => {
+    expect(
+      oasToHar(
+        new Oas({
+          components: {
+            parameters: {
+              authorization: {
+                name: 'Authorization',
+                in: 'header',
+              },
+            },
+          },
+        }),
+        {
+          method: 'get',
+          parameters: [
+            {
+              $ref: '#/components/parameters/authorization',
+            },
+          ],
+        },
+        { header: { Authorization: 'test' } },
+      ).log.entries[0].request.headers[0].value,
+    ).toEqual('test');
+  });
+
   it('should work for top level primitives', () => {
     expect(
       oasToHar(

--- a/packages/api-explorer/src/lib/Oas.js
+++ b/packages/api-explorer/src/lib/Oas.js
@@ -5,7 +5,8 @@ class Operation {
   constructor(oas, path, method, operation) {
     Object.assign(this, operation);
     this.oas = oas;
-    this.path = path;
+    // strips trailing slash
+    this.path = path.endsWith('/') ? path.slice(0, -1) : path;
     this.method = method;
   }
 

--- a/packages/api-explorer/src/lib/oas-to-har.js
+++ b/packages/api-explorer/src/lib/oas-to-har.js
@@ -4,6 +4,7 @@ const extensions = require('@readme/oas-extensions');
 const getSchema = require('./get-schema');
 const configureSecurity = require('./configure-security');
 const removeUndefinedObjects = require('./remove-undefined-objects');
+const findSchemaDefinition = require('./find-schema-definition');
 
 // const format = {
 //   value: v => `__START_VALUE__${v}__END__`,
@@ -94,6 +95,14 @@ module.exports = (
   // TODO look to move this to Oas class as well
   if (oas[extensions.PROXY_ENABLED] && opts.proxyUrl) {
     har.url = `https://try.readme.io/${har.url}`;
+  }
+
+  if (pathOperation.parameters) {
+    pathOperation.parameters.forEach((param, i, params) => {
+      if (param.$ref) {
+        params[i] = findSchemaDefinition(param.$ref, oas);
+      }
+    });
   }
 
   har.url = har.url.replace(/{([-_a-zA-Z0-9[\]]+)}/g, (full, key) => {

--- a/packages/api-explorer/src/lib/oas-to-har.js
+++ b/packages/api-explorer/src/lib/oas-to-har.js
@@ -129,6 +129,9 @@ module.exports = (
     Object.keys(pathOperation.responses).some(response => {
       if (!pathOperation.responses[response].content) return false;
 
+      // if there is an Accept header specified in the form, we'll use that instead.
+      if (formData.header.Accept) return true;
+
       har.headers.push({
         name: 'Accept',
         value: getResponseContentType(pathOperation.responses[response].content),


### PR DESCRIPTION
Adds the following (with corresponding tests):
- Removes trailing slashes from the paths when operations are created
- Overrides Accept header types found in response definitions if an Accept header is sent in the form data
- Added a `$ref` lookup to path operation parameters

Asana tasks:
- https://app.asana.com/0/681252538274980/1108254356757915/f
- https://app.asana.com/0/681252538274980/977151049856241/f