### PR TITLE
strip out the string format that we do not support.

### DIFF
--- a/example/swagger-files/petstore.json
+++ b/example/swagger-files/petstore.json
@@ -222,8 +222,7 @@
           "in": "formData",
           "description": "Updated name of the pet",
           "required": false,
-          "type": "string",
-          "format": "some-unknown-format"
+          "type": "string"
         }, {
           "name": "status",
           "in": "formData",

--- a/example/swagger-files/petstore.json
+++ b/example/swagger-files/petstore.json
@@ -222,7 +222,8 @@
           "in": "formData",
           "description": "Updated name of the pet",
           "required": false,
-          "type": "string"
+          "type": "string",
+          "format": "some-unknown-format"
         }, {
           "name": "status",
           "in": "formData",

--- a/example/swagger-files/types.json
+++ b/example/swagger-files/types.json
@@ -58,6 +58,10 @@
                     "type": "string",
                     "format": "string"
                   },
+                  "string (format: unknown-format)": {
+                    "type": "string",
+                    "format": "unknown-format"
+                  },
                   "integer": {
                     "type": "integer",
                     "format": "int64",

--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -62,6 +62,17 @@ test('boolean should render as <select>', () => {
   expect(select.find('option').map(el => el.text())).toEqual(['', 'true', 'false']);
 });
 
+test('should strip out unknown format for string type', () => {
+  const params = mount(
+    <div>
+      <Params {...props} operation={oas.operation('/pet/{petId}', 'post')} />
+    </div>,
+  );
+
+  expect(params.find('input[label="unknown format"]').length).toBe(1);
+  expect(params.find('input[format="unknown format"]').length).toBe(0);
+});
+
 const jsonOperation = new Operation(oas, '/path', 'post', {
   requestBody: {
     content: {

--- a/packages/api-explorer/__tests__/fixtures/petstore/oas.json
+++ b/packages/api-explorer/__tests__/fixtures/petstore/oas.json
@@ -289,6 +289,10 @@
                   "status": {
                     "description": "Updated status of the pet",
                     "type": "string"
+                  },
+                  "unknown format": {
+                    "type": "string",
+                    "format": "unknown format"
                   }
                 }
               }

--- a/packages/api-explorer/src/form-components/SchemaField.jsx
+++ b/packages/api-explorer/src/form-components/SchemaField.jsx
@@ -9,21 +9,8 @@ function getDefaultNumFormat(type) {
   return '';
 }
 
-function doesFormatExist(type, format) {
-  const availableFormats = [
-    'int64',
-    'int32',
-    'double',
-    'float',
-    'binary',
-    'byte',
-    'string',
-    'uuid',
-    'duration',
-    'dateTime',
-    'integer',
-    'json',
-  ];
+function doesFormatExist(widgets, type, format) {
+  const availableFormats = Object.keys(widgets);
 
   return type === 'string' && availableFormats.includes(format);
 }
@@ -47,7 +34,8 @@ function getCustomType(schema) {
 }
 
 function SchemaField(props) {
-  if (!doesFormatExist(props.schema.type, props.schema.format)) props.schema.format = undefined;
+  if (!doesFormatExist(props.registry.widgets, props.schema.type, props.schema.format))
+    props.schema.format = undefined;
 
   if (props.schema.readOnly) {
     // Maybe use this when it's been merged?
@@ -84,6 +72,9 @@ SchemaField.propTypes = {
     format: PropTypes.string,
     enumNames: PropTypes.array,
     readOnly: PropTypes.bool,
+  }).isRequired,
+  registry: PropTypes.shape({
+    widgets: PropTypes.object,
   }).isRequired,
   uiSchema: PropTypes.shape({}),
 };

--- a/packages/api-explorer/src/form-components/SchemaField.jsx
+++ b/packages/api-explorer/src/form-components/SchemaField.jsx
@@ -9,6 +9,25 @@ function getDefaultNumFormat(type) {
   return '';
 }
 
+function doesFormatExist(type, format) {
+  const availableFormats = [
+    'int64',
+    'int32',
+    'double',
+    'float',
+    'binary',
+    'byte',
+    'string',
+    'uuid',
+    'duration',
+    'dateTime',
+    'integer',
+    'json',
+  ];
+
+  return type === 'string' && availableFormats.includes(format);
+}
+
 function isNumType(schema, type, format) {
   schema.format = schema.format || getDefaultNumFormat(schema.type);
   return schema.type === type && schema.format.match(format);
@@ -28,6 +47,8 @@ function getCustomType(schema) {
 }
 
 function SchemaField(props) {
+  if (!doesFormatExist(props.schema.type, props.schema.format)) props.schema.format = undefined;
+
   if (props.schema.readOnly) {
     // Maybe use this when it's been merged?
     // Though that just sets `input[readonly]` which still shows


### PR DESCRIPTION
closes #197
`before`
![image](https://user-images.githubusercontent.com/6043510/55575371-63b23b00-5717-11e9-9409-5bc3bdfd9712.png)
`after`
![image](https://user-images.githubusercontent.com/6043510/55575325-4da47a80-5717-11e9-9c6a-1132dd4f181e.png)
