### PR TITLE
Do not strip trailing slashes and instead create unique key for path URL

### DIFF
--- a/packages/api-explorer/__tests__/PathUrl.test.jsx
+++ b/packages/api-explorer/__tests__/PathUrl.test.jsx
@@ -86,4 +86,12 @@ describe('splitPath()', () => {
       4,
     );
   });
+
+  test('should create unique keys for duplicate values', () => {
+    expect(splitPath('/{test}/')).toEqual([
+      { key: '/-0', type: 'text', value: '/' },
+      { key: 'test-0', type: 'variable', value: 'test' },
+      { key: '/-1', type: 'text', value: '/' },
+    ]);
+  });
 });

--- a/packages/api-explorer/__tests__/lib/Oas.test.js
+++ b/packages/api-explorer/__tests__/lib/Oas.test.js
@@ -13,13 +13,6 @@ describe('operation()', () => {
     expect(operation.method).toBe('get');
   });
 
-  test('should strip trailing slashes from path', () => {
-    const oas = { paths: { '/path/': { get: { a: 1 } } } };
-    const operation = new Oas(oas).operation('/path/', 'get');
-    expect(operation).toBeInstanceOf(Operation);
-    expect(operation.path).toBe('/path');
-  });
-
   test('should return a default when no operation', () => {
     expect(new Oas({}).operation('/unknown', 'get')).toMatchSnapshot();
   });

--- a/packages/api-explorer/src/PathUrl.jsx
+++ b/packages/api-explorer/src/PathUrl.jsx
@@ -9,11 +9,20 @@ const { Operation } = Oas;
 const extensions = require('@readme/oas-extensions');
 
 function splitPath(path) {
+  const keys = [];
   return path
     .split(/({.+?})/)
     .filter(Boolean)
     .map(part => {
       return { type: part.match(/[{}]/) ? 'variable' : 'text', value: part.replace(/[{}]/g, '') };
+    })
+    .map(part => {
+      // To ensure unique keys, we're going to create a key with
+      // the value concatenated to the count of the value.
+      const keyCount = keys.filter(key => key === part.value).length;
+      keys.push(part.value);
+      part.key = `${part.value}-${keyCount}`;
+      return part;
     });
 }
 function PathUrl({
@@ -73,7 +82,7 @@ function PathUrl({
             <span className="definition-url">
               <span className="url">{oas.url()}</span>
               {splitPath(operation.path).map(part => (
-                <span key={part.value} className={`api-${part.type}`}>
+                <span key={part.key} className={`api-${part.type}`}>
                   {part.value}
                 </span>
               ))}

--- a/packages/api-explorer/src/lib/Oas.js
+++ b/packages/api-explorer/src/lib/Oas.js
@@ -5,8 +5,7 @@ class Operation {
   constructor(oas, path, method, operation) {
     Object.assign(this, operation);
     this.oas = oas;
-    // strips trailing slash
-    this.path = path.endsWith('/') ? path.slice(0, -1) : path;
+    this.path = path;
     this.method = method;
   }
 


### PR DESCRIPTION
In #196, we stripped trailing slashes from path URLs, primarily because it would throw a React key uniqueness error.

<img width="1424" alt="Screenshot 2019-03-29 12 27 03" src="https://user-images.githubusercontent.com/8854718/57658859-f14e3980-75a5-11e9-87ee-055daf4c9319.png">

Instead of simply using the value of each part to designate the key, this PR will instead create a separate key for each part of the path URL that appends a value count. For example, if there are two values of `/`, they will have respective key values of `/-0` and `/-1`.