### PR TITLE
Add support for bearer auth

### DIFF
--- a/example/swagger-files/auth-types.json
+++ b/example/swagger-files/auth-types.json
@@ -23,19 +23,6 @@
         ]
       }
     },
-    "/anything/oauth2-another": {
-      "post": {
-        "summary": "Oauth2 security type",
-        "description": "",
-        "parameters": [],
-        "responses": {},
-        "security": [
-          {
-            "oauth2": []
-          }
-        ]
-      }
-    },
     "/anything/basic": {
       "post": {
         "summary": "Basic security type",
@@ -49,15 +36,15 @@
         ]
       }
     },
-    "/anything/basic-another": {
+    "/anything/bearer": {
       "post": {
-        "summary": "Basic security type",
+        "summary": "Bearer security type",
         "description": "",
         "parameters": [],
         "responses": {},
         "security": [
           {
-            "basic": []
+            "bearer": []
           }
         ]
       }
@@ -84,6 +71,10 @@
       "basic": {
         "type": "http",
         "scheme": "basic"
+      },
+      "bearer": {
+        "type": "http",
+        "scheme": "bearer"
       },
       "apiKey": {
         "type": "apiKey",

--- a/packages/api-explorer/__tests__/lib/get-auth.test.js
+++ b/packages/api-explorer/__tests__/lib/get-auth.test.js
@@ -92,6 +92,7 @@ it('should return emptystring for anything else', () => {
   expect(getSingle(topLevelUser, { type: 'unknown' })).toBe('');
   expect(getSingle({}, { type: 'http', scheme: 'basic' })).toEqual({ user: '', pass: '' });
   expect(getSingle({}, { type: 'http', scheme: 'bearer' })).toEqual('');
+  expect(getSingle({}, { type: 'http', scheme: 'unknown' })).toEqual('');
   expect(getSingle(keysUser, { type: 'unknown' })).toBe('');
   expect(getSingle(keysUser, { type: 'unknown' }, 'app-2')).toBe('');
 });

--- a/packages/api-explorer/__tests__/lib/get-auth.test.js
+++ b/packages/api-explorer/__tests__/lib/get-auth.test.js
@@ -77,12 +77,16 @@ it('should return selected app from keys array if app provided', () => {
 
 it('should return item by scheme name if no apiKey/user/pass', () => {
   expect(getSingle(topLevelSchemeUser, { type: 'oauth2', _key: 'schemeName' })).toBe('scheme-key');
-  expect(getSingle(topLevelSchemeUser, { type: 'http', scheme: 'bearer', _key: 'schemeName' })).toBe('scheme-key');
+  expect(
+    getSingle(topLevelSchemeUser, { type: 'http', scheme: 'bearer', _key: 'schemeName' }),
+  ).toBe('scheme-key');
   expect(getSingle(keysSchemeUser, { type: 'oauth2', _key: 'schemeName' })).toBe('scheme-key-1');
   expect(getSingle(keysSchemeUser, { type: 'oauth2', _key: 'schemeName' }, 'app-2')).toBe(
     'scheme-key-2',
   );
-  expect(getSingle(keysSchemeUser, { type: 'http', scheme: 'basic', _key: 'schemeName' }, 'app-3')).toEqual({
+  expect(
+    getSingle(keysSchemeUser, { type: 'http', scheme: 'basic', _key: 'schemeName' }, 'app-3'),
+  ).toEqual({
     user: 'user',
     pass: 'pass',
   });

--- a/packages/api-explorer/__tests__/lib/get-auth.test.js
+++ b/packages/api-explorer/__tests__/lib/get-auth.test.js
@@ -56,6 +56,10 @@ it('should return apiKey property for apiKey', () => {
   expect(getSingle(topLevelUser, { type: 'oauth2' })).toBe('123456');
 });
 
+it('should return apiKey property for bearer', () => {
+  expect(getSingle(topLevelUser, { type: 'http', scheme: 'bearer' })).toBe('123456');
+});
+
 it('should return user/pass properties for basic auth', () => {
   expect(getSingle(topLevelUser, { type: 'http', scheme: 'basic' })).toEqual({
     user: 'user',
@@ -73,11 +77,12 @@ it('should return selected app from keys array if app provided', () => {
 
 it('should return item by scheme name if no apiKey/user/pass', () => {
   expect(getSingle(topLevelSchemeUser, { type: 'oauth2', _key: 'schemeName' })).toBe('scheme-key');
+  expect(getSingle(topLevelSchemeUser, { type: 'http', scheme: 'bearer', _key: 'schemeName' })).toBe('scheme-key');
   expect(getSingle(keysSchemeUser, { type: 'oauth2', _key: 'schemeName' })).toBe('scheme-key-1');
   expect(getSingle(keysSchemeUser, { type: 'oauth2', _key: 'schemeName' }, 'app-2')).toBe(
     'scheme-key-2',
   );
-  expect(getSingle(keysSchemeUser, { type: 'http', _key: 'schemeName' }, 'app-3')).toEqual({
+  expect(getSingle(keysSchemeUser, { type: 'http', scheme: 'basic', _key: 'schemeName' }, 'app-3')).toEqual({
     user: 'user',
     pass: 'pass',
   });
@@ -86,6 +91,7 @@ it('should return item by scheme name if no apiKey/user/pass', () => {
 it('should return emptystring for anything else', () => {
   expect(getSingle(topLevelUser, { type: 'unknown' })).toBe('');
   expect(getSingle({}, { type: 'http', scheme: 'basic' })).toEqual({ user: '', pass: '' });
+  expect(getSingle({}, { type: 'http', scheme: 'bearer' })).toEqual('');
   expect(getSingle(keysUser, { type: 'unknown' })).toBe('');
   expect(getSingle(keysUser, { type: 'unknown' }, 'app-2')).toBe('');
 });

--- a/packages/api-explorer/src/lib/get-auth.js
+++ b/packages/api-explorer/src/lib/get-auth.js
@@ -11,7 +11,7 @@ function getKey(user, scheme) {
       if (scheme.scheme === 'bearer') {
         return user[scheme._key] || user.apiKey || '';
       }
-      break;
+      return '';
     default:
       return '';
   }

--- a/packages/api-explorer/src/lib/get-auth.js
+++ b/packages/api-explorer/src/lib/get-auth.js
@@ -4,7 +4,14 @@ function getKey(user, scheme) {
     case 'apiKey':
       return user[scheme._key] || user.apiKey || '';
     case 'http':
-      return user[scheme._key] || { user: user.user || '', pass: user.pass || '' };
+      if (scheme.scheme === 'basic') {
+        return user[scheme._key] || { user: user.user || '', pass: user.pass || '' };
+      }
+
+      if (scheme.scheme === 'bearer') {
+        return user[scheme._key] || user.apiKey || '';
+      }
+      break;
     default:
       return '';
   }


### PR DESCRIPTION
Bearer authentication is just a regular API key:
https://swagger.io/docs/specification/authentication/bearer-authentication/

But it comes through like this:

```
{
  type: 'http',
  scheme: 'bearer'
}
```

Which `getAuth()` incorrectly picked up as though it should be HTTP auth.

This adds support for bearer to `getAuth()`