### PR TITLE
Fix regression introduced in #202

### DIFF
--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -178,7 +178,7 @@ function renderParams(schema, customProps) {
 }
 
 function testNumberClass(schema) {
-  const clonedSchema = JSON.parse(JSON.stringify(schema))
+  const clonedSchema = JSON.parse(JSON.stringify(schema));
   test(`${JSON.stringify(schema)} should have correct class`, () => {
     const params = renderParams(schema);
 

--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -178,10 +178,11 @@ function renderParams(schema, customProps) {
 }
 
 function testNumberClass(schema) {
+  const clonedSchema = JSON.parse(JSON.stringify(schema))
   test(`${JSON.stringify(schema)} should have correct class`, () => {
     const params = renderParams(schema);
 
-    expect(params.find(`.field-${schema.type}.field-${schema.format}`).length).toBe(1);
+    expect(params.find(`.field-${clonedSchema.type}.field-${clonedSchema.format}`).length).toBe(1);
   });
 }
 

--- a/packages/api-explorer/src/form-components/SchemaField.jsx
+++ b/packages/api-explorer/src/form-components/SchemaField.jsx
@@ -12,7 +12,7 @@ function getDefaultNumFormat(type) {
 function doesFormatExist(widgets, type, format) {
   const availableFormats = Object.keys(widgets);
 
-  return type === 'string' && availableFormats.includes(format);
+  return typeof type === 'string' && availableFormats.includes(format);
 }
 
 function isNumType(schema, type, format) {


### PR DESCRIPTION
This caused some formats to get removed, which meant that for integers
we were setting the default `int32` instead of `int64`.

We did have tests for this, but because the module was mutating the data
we were testing against the broken schema!

https://github.com/readmeio/api-explorer/pull/202