### PR TITLE
Adding support for parameters that may have child `$ref` pointers.

### DIFF
--- a/example/swagger-files/parameters-with-refs.json
+++ b/example/swagger-files/parameters-with-refs.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "http://httpbin.org"
+    }
+  ],
+  "info": {
+    "version": "1.0.0",
+    "title": "An example of how we render $ref usage on resource parameters"
+  },
+  "paths": {
+    "/anything": {
+      "get": {
+        "summary": "Query param with a child $ref",
+        "description": "",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "array (with a $ref)",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/string_enum"
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "post": {
+        "summary": "Query param pointing to a $ref",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limitParam"
+          }
+        ],
+        "responses": {}
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "limitParam": {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 50,
+          "default": 20
+        },
+        "description": "The numbers of items to return."
+      }
+    },
+    "schemas": {
+      "string_enum": {
+        "name": "string",
+        "enum": [
+          "available",
+          "pending",
+          "sold"
+        ],
+        "type": "string"
+      }
+    }
+  }
+}

--- a/example/swagger-files/types.json
+++ b/example/swagger-files/types.json
@@ -59,12 +59,21 @@
                     "format": "string"
                   },
                   "string (format: url)": {
-                      "type": "string",
-                      "format": "url"
+                    "type": "string",
+                    "format": "url"
                   },
                   "string (format: unknown-format)": {
                     "type": "string",
                     "format": "unknown-format"
+                  },
+                  "string (enum)": {
+                    "type": "string",
+                    "enum": ["available", "pending", "sold"]
+                  },
+                  "string (enum, with default)": {
+                    "type": "string",
+                    "enum": ["available", "pending", "sold"],
+                    "default": "available"
                   },
                   "integer": {
                     "type": "integer",
@@ -103,6 +112,18 @@
                   },
                   "boolean without description": {
                     "type": "boolean"
+                  },
+                  "array (of strings)": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "array (with a $ref)": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/string_enum"
+                    }
                   },
                   "object": {
                     "type": "object",
@@ -400,6 +421,17 @@
   "x-samples-enabled": true,
   "x-samples-languages": ["curl", "node", "ruby", "javascript", "python"],
   "components": {
+    "schemas": {
+      "string_enum": {
+        "name": "string",
+        "enum": [
+          "available",
+          "pending",
+          "sold"
+        ],
+        "type": "string"
+      }
+    },
     "requestBodies": {
       "Circular": {
         "type": "object",

--- a/packages/api-explorer/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/api-explorer/__tests__/lib/parameters-to-json-schema.test.js
@@ -219,6 +219,25 @@ test('it should pass through type for non-body parameters', () => {
   ).toEqual('boolean');
 });
 
+test('it should pass through type for non-body parameters that are arrays', () => {
+  expect(
+    parametersToJsonSchema({
+      parameters: [
+        {
+          in: 'query',
+          name: 'options',
+          schema: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+      ],
+    })[0].schema.properties.options.type,
+  ).toEqual('array');
+});
+
 test('it should pass through format', () => {
   expect(
     parametersToJsonSchema({
@@ -395,4 +414,38 @@ test('it should fetch $ref parameters', () => {
       oas,
     )[0].schema.properties.param,
   ).toEqual(oas.components.parameters.Param.schema);
+});
+
+test('it should fetch parameters that have a child $ref', () => {
+  const oas = {
+    components: {
+      schemas: {
+        string_enum: {
+          name: 'string',
+          enum: ['available', 'pending', 'sold'],
+          type: 'string',
+        },
+      },
+    },
+  };
+
+  expect(
+    parametersToJsonSchema(
+      {
+        parameters: [
+          {
+            in: 'query',
+            name: 'param',
+            schema: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/string_enum',
+              },
+            },
+          },
+        ],
+      },
+      oas,
+    )[0].schema.properties.param.items,
+  ).toEqual(oas.components.schemas.string_enum);
 });

--- a/packages/api-explorer/src/lib/parameters-to-json-schema.js
+++ b/packages/api-explorer/src/lib/parameters-to-json-schema.js
@@ -47,7 +47,15 @@ function getOtherParams(pathOperation, oas) {
       if (current.schema) {
         if (current.schema.type === 'array') {
           schema.type = 'array';
-          schema.items = current.schema.items;
+
+          if (
+            Object.keys(current.schema.items).length === 1 &&
+            typeof current.schema.items.$ref !== 'undefined'
+          ) {
+            schema.items = findSchemaDefinition(current.schema.items.$ref, oas);
+          } else {
+            schema.items = current.schema.items;
+          }
         }
 
         if (typeof current.schema.default !== 'undefined') schema.default = current.schema.default;


### PR DESCRIPTION
This fixes a bug in our handling of parameters with child `$ref` pointers where we'd fail to resolve those linked definitions, and ultimately fail out while rendering the resource with an error that looked like the following:

![Screen Shot 2019-06-26 at 11 17 13 AM](https://user-images.githubusercontent.com/33762/60204574-fd175780-9803-11e9-972f-e50614a83326.png)

I also added a few more test cases into our `types.json` example schema for `$ref` accessors.