### PR TITLE
Redesigning the error and loading states in the reference demo

### DIFF
--- a/example/reference/index.html
+++ b/example/reference/index.html
@@ -11,78 +11,260 @@
   <!-- Custom CSS-->
   <style>
     a{color:#2283c9}a:hover{color:#134a72}a.text-muted:hover{color:#2283c9}.btn.btn-primary{background-color:#2283c9}.btn.btn-primary:hover{background-color:#134a72}.theme-line #hub-landing-top h2{color:#2283c9}#hub-landing-top .btn:hover{color:#2283c9}.theme-line #hub-landing-top .btn:hover{color:#fff}.theme-solid header#hub-header #header-top{background-color:#2283c9}.theme-solid.header-gradient header#hub-header #header-top{background:linear-gradient(to bottom,#2283c9,#175888)}.theme-solid.header-custom header#hub-header #header-top{background-image:url(undefined)}.theme-line header#hub-header #header-top{border-bottom-color:#2283c9}.theme-line header#hub-header #header-top .btn{background-color:#2283c9}header#hub-header #header-top #header-logo{width:146px;height:40px;margin-top:0;background-image:url(https://files.readme.io/1e0e8cc-white-logo.png)}nav#hub-sidebar ul a.active{background-color:#2283c9}#hub-subheader-parent #hub-subheader .hub-subheader-breadcrumbs .dropdown-menu a:hover{background-color:#2283c9}.discussion .submit-vote.submit-vote-parent.voted a.submit-vote-button{background-color:#2283c9}section#hub-discuss .discussion a .discuss-body h4{color:#2283c9}section#hub-discuss .discussion a:hover .discuss-body h4{color:#134a72}#hub-subheader-parent #hub-subheader.sticky-header.sticky{border-bottom-color:#2283c9}#hub-subheader-parent #hub-subheader.sticky-header.sticky .search-box{border-bottom-color:#2283c9}#hub-search-results h3 em{color:#2283c9}.main_background,.tag-item{background:#2283c9!important}.main_background:hover{background:#134a72!important}.main_color{color:#2283c9!important}.main_color_hover:hover{color:#2283c9!important}section#hub-discuss h1{color:#2283c9}#hub-reference .hub-api .api-manager .param-table .param-item .param-item-info .param-item-table .param-item-input input[type=number]:focus,#hub-reference .hub-api .api-manager .param-table .param-item .param-item-info .param-item-table .param-item-input input[type=text]:focus,#hub-reference .hub-api .api-manager .param-table .param-item .param-item-info .param-item-table .param-item-input textarea:focus{border:1px solid #2283c9}#hub-reference .hub-api .api-definition .api-try-it-out.active{border-color:#2283c9;background-color:#2283c9}#hub-reference .hub-api .api-definition .api-try-it-out.active:hover{background-color:#134a72;border-color:#134a72}#hub-reference .hub-api .api-definition .api-try-it-out:hover{border-color:#2283c9;color:#2283c9}#hub-reference .hub-reference .hub-reference-section .hub-reference-left header .hub-reference-edit:hover{color:#2283c9}.main-color-accent{border-bottom:3px solid #2283c9;padding-bottom:8px}
+
+    #main {
+      display: none;
+    }
+
+    #main.is-loaded {
+      display: block;
+    }
+
+    #hub-reference-loading-error {
+      margin-right: 246px;
+      padding-top: 25px;
+    }
+
+    #hub-reference-loading-error .hub-reference-loading-error-box {
+      background-color: #f0f7fd;
+      border-left: 4px solid #2283c9;
+      padding: 13px 13px 13px 23px;
+      position: relative;
+      margin-bottom: 1em;
+    }
+
+    #hub-reference-loading-error .hub-reference-loading-error-header {
+      color: #2283c9;
+    }
+
+    #hub-reference-loading-error pre {
+      padding: 23px 23px 23px 23px;
+      background-color: #F9F9F9;
+    }
+
+    #loading-screen {
+      position: fixed;
+      top: 200px;
+      left: 0;
+      width: 100%;
+      z-index: 10000;
+      width: 300px;
+      height: 120px;
+      left: 50%;
+      margin-left: -150px;
+      text-align: center;
+      color: #fff;
+    }
+
+    #loading-screen svg path {
+      fill: #e3e3e3;
+    }
+
+    /** Loading bar styles pulled from bundle-dash.css */
+    #loading-screen .loaderbar {
+      background-color: #fff;
+      border-radius: 2px;
+      position: absolute;
+      width: 38px;
+      height: 7px;
+      -webkit-transform-origin: 0 0;
+      -moz-transform-origin: 0 0;
+      -o-transform-origin: 0 0;
+      -ms-transform-origin: 0 0;
+      transform-origin: 0 0
+    }
+
+    #loading-screen .loaderbar.loaderbar0 {
+      top: 28px;
+      left: 101px;
+      -webkit-animation: remove-loaderbar0 2s infinite;
+      -moz-animation: remove-loaderbar0 2s infinite;
+      -o-animation: remove-loaderbar0 2s infinite;
+      -ms-animation: remove-loaderbar0 2s infinite;
+      animation: remove-loaderbar0 2s infinite
+    }
+
+    @-moz-keyframes remove-loaderbar0 {0%{width:0}0%{width:0}20%{width:38px}100%{width:38px}}
+    @-webkit-keyframes remove-loaderbar0 {0%{width:0}0%{width:0}20%{width:38px}100%{width:38px}}
+    @-o-keyframes remove-loaderbar0{0%{width:0}0%{width:0}20%{width:38px}100%{width:38px}}
+    @keyframes remove-loaderbar0{0%{width:0}0%{width:0}20%{width:38px}100%{width:38px}}
+
+    #loading-screen .loaderbar.loaderbar1 {
+      top: 42px;
+      left: 101px;
+      -webkit-animation:remove-loaderbar1 2s infinite;
+      -moz-animation: remove-loaderbar1 2s infinite;
+      -o-animation: remove-loaderbar1 2s infinite;
+      -ms-animation: remove-loaderbar1 2s infinite;
+      animation: remove-loaderbar1 2s infinite
+    }
+
+    @-moz-keyframes remove-loaderbar1{0%{width:0}10%{width:0}30%{width:38px}100%{width:38px}}
+    @-webkit-keyframes remove-loaderbar1{0%{width:0}10%{width:0}30%{width:38px}100%{width:38px}}
+    @-o-keyframes remove-loaderbar1{0%{width:0}10%{width:0}30%{width:38px}100%{width:38px}}
+    @keyframes remove-loaderbar1{0%{width:0}10%{width:0}30%{width:38px}100%{width:38px}}
+
+    #loading-screen .loaderbar.loaderbar2 {
+      top: 56px;
+      left: 101px;
+      -webkit-animation: remove-loaderbar2 2s infinite;
+      -moz-animation: remove-loaderbar2 2s infinite;
+      -o-animation: remove-loaderbar2 2s infinite;
+      -ms-animation: remove-loaderbar2 2s infinite;
+      animation: remove-loaderbar2 2s infinite
+    }
+
+    @-moz-keyframes remove-loaderbar2{0%{width:0}20%{width:0}40%{width:38px}100%{width:38px}}
+    @-webkit-keyframes remove-loaderbar2{0%{width:0}20%{width:0}40%{width:38px}100%{width:38px}}
+    @-o-keyframes remove-loaderbar2{0%{width:0}20%{width:0}40%{width:38px}100%{width:38px}}
+    @keyframes remove-loaderbar2{0%{width:0}20%{width:0}40%{width:38px}100%{width:38px}}
+
+    #loading-screen .loaderbar.loaderbar3 {
+      top: 28px;
+      left: 158px;
+      -webkit-animation: remove-loaderbar3 2s infinite;
+      -moz-animation: remove-loaderbar3 2s infinite;
+      -o-animation: remove-loaderbar3 2s infinite;
+      -ms-animation: remove-loaderbar3 2s infinite;
+      animation: remove-loaderbar3 2s infinite
+    }
+
+    @-moz-keyframes remove-loaderbar3{0%{width:0}30%{width:0}50%{width:38px}100%{width:38px}}
+    @-webkit-keyframes remove-loaderbar3{0%{width:0}30%{width:0}50%{width:38px}100%{width:38px}}
+    @-o-keyframes remove-loaderbar3{0%{width:0}30%{width:0}50%{width:38px}100%{width:38px}}
+    @keyframes remove-loaderbar3{0%{width:0}30%{width:0}50%{width:38px}100%{width:38px}}
+
+    #loading-screen .loaderbar.loaderbar4 {
+      top: 42px;
+      left: 158px;
+      -webkit-animation: remove-loaderbar4 2s infinite;
+      -moz-animation: remove-loaderbar4 2s infinite;
+      -o-animation: remove-loaderbar4 2s infinite;
+      -ms-animation: remove-loaderbar4 2s infinite;
+      animation: remove-loaderbar4 2s infinite
+    }
+
+    @-moz-keyframes remove-loaderbar4{0%{width:0}40%{width:0}60%{width:38px}100%{width:38px}}
+    @-webkit-keyframes remove-loaderbar4{0%{width:0}40%{width:0}60%{width:38px}100%{width:38px}}
+    @-o-keyframes remove-loaderbar4{0%{width:0}40%{width:0}60%{width:38px}100%{width:38px}}
+    @keyframes remove-loaderbar4{0%{width:0}40%{width:0}60%{width:38px}100%{width:38px}}
+
+    #loading-screen .loaderbar.loaderbar5 {
+      top: 56px;
+      left: 158px;
+      -webkit-animation: remove-loaderbar5 2s infinite;
+      -moz-animation: remove-loaderbar5 2s infinite;
+      -o-animation: remove-loaderbar5 2s infinite;
+      -ms-animation: remove-loaderbar5 2s infinite;
+      animation: remove-loaderbar5 2s infinite
+    }
+
+    @-moz-keyframes remove-loaderbar5{0%{width:0}50%{width:0}70%{width:38px}100%{width:38px}}
+    @-webkit-keyframes remove-loaderbar5{0%{width:0}50%{width:0}70%{width:38px}100%{width:38px}}
+    @-o-keyframes remove-loaderbar5{0%{width:0}50%{width:0}70%{width:38px}100%{width:38px}}
+    @keyframes remove-loaderbar5{0%{width:0}50%{width:0}70%{width:38px}100%{width:38px}}
+
+    #loading-screen p {
+      margin-top: 20px;
+      color: rgba(0, 0, 0, 0.3);
+    }
+
+    #loading-screen #loading-screen-brandmark {
+      margin: auto;
+    }
+
+    #loading-screen.is-loaded {
+      display: none;
+    }
   </style>
 </head>
 
 <body class="body-none theme-solid header-solid header-bg-size-auto header-bg-pos-tl header-overlay-triangles lumosity-normal hub-full is-lang-curl">
-  <header id="hub-header">
-    <div id="header-top">
-      <div class="hub-container">
-        <div class="clearfix">
-          <a href="#" class="header-link">
-            <h1 id="header-logo">Swagger Preview</h1>
-          </a>
+  <div id="loading-screen">
+    <div class="loaderbar loaderbar0"></div>
+    <div class="loaderbar loaderbar1"></div>
+    <div class="loaderbar loaderbar2"></div>
+    <div class="loaderbar loaderbar3"></div>
+    <div class="loaderbar loaderbar4"></div>
+    <div class="loaderbar loaderbar5"></div>
+    <svg id="loading-screen-brandmark" viewBox="0 0 60.1 43.7" width="130px" height="100px">
+      <path fill="#eee" class="path1" d="M55.1,0H40.5c-5,0-9.4,3.5-10.5,8.4C28.9,3.5,24.6,0,19.6,0H5C2.3,0,0,2.2,0,5v25.6c0,2.8,2.2,5,5,5h9.3 c10.6,0,13.8,2.6,15.3,7.8c0,0.1,0.1,0.2,0.3,0.2h0.1c0.1,0,0.2-0.1,0.3-0.2c1.5-5.3,4.7-7.8,15.3-7.8H55c2.8,0,5-2.2,5-5V5 C60,2.3,57.8,0,55.1,0z" />
+    </svg>
+    <p>Reticulating splines...</p>
+  </div>
+  <div id="main">
+    <header id="hub-header">
+      <div id="header-top">
+        <div class="hub-container">
+          <div class="clearfix">
+            <a href="#" class="header-link">
+              <h1 id="header-logo">Swagger Preview</h1>
+            </a>
+          </div>
         </div>
       </div>
-    </div>
-    <div id="hub-subheader-parent">
-      <div id="hub-subheader">
-        <div class="hub-container">
-          <nav id="header-bottom-nav">
-            <div id="header-icon-nav">
-              <div class="icons">
-                <div class="hub-subheader-breadcrumbs">
-                  <span class="hub-breadcrumb-item"><span id="oas-version"></span></span>
+      <div id="hub-subheader-parent">
+        <div id="hub-subheader">
+          <div class="hub-container">
+            <nav id="header-bottom-nav">
+              <div id="header-icon-nav">
+                <div class="icons">
+                  <div class="hub-subheader-breadcrumbs">
+                    <span class="hub-breadcrumb-item"><span id="oas-version"></span></span>
+                  </div>
                 </div>
+              </div>
+            </nav>
+          </div>
+        </div>
+      </div>
+    </header>
+    <div class="hub-loading-indicator"></div>
+    <div id="hub-container">
+      <div class="hub-container">
+        <style type="text/css">
+          #hub-sidebar-parent {
+            position: sticky;
+          }
+          nav#hub-sidebar {
+            position: initial;
+            padding-bottom: 0px;
+          }
+          section#hub-content {
+            border-left: 1px solid #ddd;
+            margin-left: 246px;
+            padding-left: 0px;
+            width: unset;
+          }
+          section#hub-content.with-errors {
+            border-left: none;
+          }
+          @media (max-width: 768px) {
+            section#hub-content {
+              margin-left: 0 !important;
+            }
+          }
+        </style>
+        <div id="hub-sidebar-parent" class="hub-sidebar-sticky">
+          <nav id="hub-sidebar">
+            <div class="scrollable-parent">
+              <div id="hub-sidebar-content">
               </div>
             </div>
           </nav>
         </div>
+        <section id="hub-content">
+        </section>
       </div>
     </div>
-  </header>
-  <div class="hub-loading-indicator"></div>
-  <div id="hub-container">
-    <div class="hub-container">
-      <style type="text/css">
-        #hub-sidebar-parent {
-          position: sticky;
-        }
-        nav#hub-sidebar {
-          position: initial;
-          padding-bottom: 0px;
-        }
-        section#hub-content {
-          border-left: 1px solid #ddd;
-          margin-left: 246px;
-          padding-left: 0px;
-          width: unset;
-        }
-        @media (max-width: 768px) {
-          section#hub-content {
-            margin-left: 0 !important;
-          }
-        }
-      </style>
-      <div id="hub-sidebar-parent" class="hub-sidebar-sticky">
-        <nav id="hub-sidebar">
-          <div class="scrollable-parent">
-            <div id="hub-sidebar-content">
-            </div>
-          </div>
-        </nav>
+    <footer>
+      <div class="hub-container">
+        <div id="readmeLogo">
+          <a href="https://readme.io/?ref_src=hub&amp;project=swagger" class="icon icon-readme"></a>
+        </div>
       </div>
-      <section id="hub-content">
-      </section>
-    </div>
+    </footer>
   </div>
-  <footer>
-    <div class="hub-container">
-      <div id="readmeLogo">
-        <a href="https://readme.io/?ref_src=hub&amp;project=swagger" class="icon icon-readme"></a>
-      </div>
-    </div>
-  </footer>
 </body>
 
 <script src="../example/reference-bundle.js"></script>

--- a/example/reference/src/Preview.jsx
+++ b/example/reference/src/Preview.jsx
@@ -32,7 +32,7 @@ class Preview extends React.Component {
   }
 
   render() {
-    const { status, docs, oas, oauth } = this.props;
+    const { status, docs, invalidSpec, invalidSpecPath, oas, oauth } = this.props;
 
     return (
       <div>
@@ -53,13 +53,25 @@ class Preview extends React.Component {
                 <div className="hub-reference-section">
                   <div id="hub-reference-loading-error">
                     <div className="hub-reference-loading-error-box">
-                      <h3 className="hub-reference-loading-error-header">
-                        Couldn&apos;t be loaded
-                      </h3>
-                      <p>There was an error fetching your API Specification.</p>
+                      {invalidSpec ? (
+                        <div>
+                          <h3 className="hub-reference-loading-error-header">
+                            Invalid API Specification
+                          </h3>
+                          <p>{invalidSpec}</p>
+                          <p>
+                            <a className="btn btn-primary btn-lg" href={`http://openap.is/validate?url=${invalidSpecPath}`}>View Validation Report</a>
+                          </p>
+                        </div>
+                      ) : (
+                        <div>
+                          <h3 className="hub-reference-loading-error-header">
+                            Couldn&apos;t be loaded
+                          </h3>
+                          <p>There was an error fetching your API Specification.</p>
+                        </div>
+                      )}
                     </div>
-
-                    <pre>{status.join('\n')}</pre>
                   </div>
                 </div>
               )}
@@ -92,6 +104,8 @@ class Preview extends React.Component {
 }
 
 Preview.propTypes = {
+  invalidSpec: PropTypes.string,
+  invalidSpecPath: PropTypes.string,
   isLoading: PropTypes.bool,
   oauth: PropTypes.bool,
   oas: PropTypes.shape({}).isRequired,
@@ -101,6 +115,8 @@ Preview.propTypes = {
 };
 
 Preview.defaultProps = {
+  invalidSpec: null,
+  invalidSpecPath: null,
   isLoading: true,
   oauth: false,
 };

--- a/example/reference/src/Preview.jsx
+++ b/example/reference/src/Preview.jsx
@@ -14,6 +14,23 @@ class Preview extends React.Component {
     const searchParams = new URLSearchParams(window.location.search);
     this.props.fetchSwagger(searchParams.get('url') || '../swagger-files/petstore.json');
   }
+
+  componentDidUpdate() {
+    if (!this.props.isLoading) {
+      // Introduce some artifical loading so if we have a bad spec cached, we don't flash a loading
+      // screen upon the user for a split second.
+      setTimeout(() => {
+        document.getElementById('main').classList.add('is-loaded');
+        document.getElementById('loading-screen').classList.add('is-loaded');
+        document.getElementById('hub-sidebar-parent').display = 'none';
+
+        if (this.props.status.length) {
+          document.getElementById('hub-content').classList.add('with-errors');
+        }
+      }, 250);
+    }
+  }
+
   render() {
     const { status, docs, oas, oauth } = this.props;
 
@@ -21,26 +38,33 @@ class Preview extends React.Component {
       <div>
         <div id="hub-reference">
           <div className="hub-reference">
-            <div className="hub-reference-section">
-              <div className="hub-reference-left">
-                <div className="hub-preview">
-                  <div className="hub-preview-owlbert" /><i className="icon icon-readme" />
-                  <p><strong>Like what you see?</strong> ReadMe makes it easy to create beautiful documentation for your API! You can import a Swagger/OAS file&hellip; but that&apos;s not all! ReadMe also helps you build a community, document non-API references and much more! Sign up now to get awesome docs for your Swagger/OAS file!</p><a className="btn btn-primary btn-lg" href="https://dash.readme.io/signup">Sign Up for ReadMe</a>
-                </div>
-              </div>
-              <div className="hub-reference-right">&nbsp;</div>
-            </div>
-
-            {
-              status.length ? (
+            {!status.length
+              ? (
                 <div className="hub-reference-section">
                   <div className="hub-reference-left">
-                    <pre style={{ marginLeft: '20px' }}>{status.join('\n')}</pre>
+                    <div className="hub-preview">
+                      <div className="hub-preview-owlbert" /><i className="icon icon-readme" />
+                      <p><strong>Like what you see?</strong> ReadMe makes it easy to create beautiful documentation for your API! You can import a Swagger/OAS file&hellip; but that&apos;s not all! ReadMe also helps you build a community, document non-API references and much more! Sign up now to get awesome docs for your Swagger/OAS file!</p><a className="btn btn-primary btn-lg" href="https://dash.readme.io/signup">Sign Up for ReadMe</a>
+                    </div>
                   </div>
                   <div className="hub-reference-right">&nbsp;</div>
                 </div>
-              ) : null
-            }
+              ) : (
+                <div className="hub-reference-section">
+                  <div id="hub-reference-loading-error">
+                    <div className="hub-reference-loading-error-box">
+                      <h3 className="hub-reference-loading-error-header">
+                        Couldn&apos;t be loaded
+                      </h3>
+                      <p>
+                        TKTK Lorem ipsum dolor sit amet, consectetur adipiscing elit TKTK
+                      </p>
+                    </div>
+
+                    <pre>{status.join('\n')}</pre>
+                  </div>
+                </div>
+              )}
           </div>
         </div>
 
@@ -70,6 +94,7 @@ class Preview extends React.Component {
 }
 
 Preview.propTypes = {
+  isLoading: PropTypes.bool,
   oauth: PropTypes.bool,
   oas: PropTypes.shape({}).isRequired,
   docs: PropTypes.arrayOf(PropTypes.shape).isRequired,
@@ -78,6 +103,7 @@ Preview.propTypes = {
 };
 
 Preview.defaultProps = {
+  isLoading: true,
   oauth: false,
 };
 

--- a/example/reference/src/Preview.jsx
+++ b/example/reference/src/Preview.jsx
@@ -56,9 +56,7 @@ class Preview extends React.Component {
                       <h3 className="hub-reference-loading-error-header">
                         Couldn&apos;t be loaded
                       </h3>
-                      <p>
-                        TKTK Lorem ipsum dolor sit amet, consectetur adipiscing elit TKTK
-                      </p>
+                      <p>There was an error fetching your API Specification.</p>
                     </div>
 
                     <pre>{status.join('\n')}</pre>

--- a/example/src/ApiList.jsx
+++ b/example/src/ApiList.jsx
@@ -34,6 +34,7 @@ class ApiList extends React.Component {
   changeApi(e) {
     this.setState({ selected: e.currentTarget.value });
   }
+
   render() {
     return (
       <h3>

--- a/example/src/SpecFetcher.jsx
+++ b/example/src/SpecFetcher.jsx
@@ -7,45 +7,70 @@ function withSpecFetching(Component) {
   return class extends React.Component {
     constructor(props) {
       super(props);
-      this.state = { status: [], oas: {}, docs: [] };
+      this.state = {
+        docs: [],
+        failure: null,
+        isLoading: false,
+        oas: {},
+        status: [],
+      };
+
       this.fetchSwagger = this.fetchSwagger.bind(this);
       this.convertSwagger = this.convertSwagger.bind(this);
       this.updateStatus = this.updateStatus.bind(this);
     }
+
     updateStatus(status, next) {
       this.setState(prev => ({ status: [...prev.status, status] }), next);
     }
+
     fetchSwagger(url) {
-      this.updateStatus('Fetching swagger file', () => {
+      this.setState({ isLoading: true }, () => {
+        this.updateStatus('Fetching Swagger/OAS file');
         fetch(url)
-          .then(res => res.json())
+          .then((res) => {
+            if (!res.ok) {
+              throw new Error('Failed to fetch.');
+            } else if (url.match(/\.(yaml|yml)/)) {
+              // @todo Should just try to automaticaly convert the spec if it isn't JSON.
+              throw new Error('Please convert your specification to JSON first.');
+            }
+
+            return res.json();
+          })
           .then((json) => {
             if (json.swagger) return this.convertSwagger(json);
 
             return this.dereference(json);
           }).catch((e) => {
+            this.setState({ isLoading: false });
+
             this.updateStatus(`There was an error fetching your specification:\n\n${e.message}`);
           });
       });
     }
+
     dereference(oas) {
       this.createDocs(oas);
       this.setState({ oas });
       this.updateStatus('Done!', () => {
         setTimeout(() => {
-          this.setState({ status: [] });
+          this.setState({ isLoading: false, status: [] });
         }, 1000);
       });
     }
+
     convertSwagger(swagger) {
-      this.updateStatus('Converting swagger file to OAS 3', () => {
+      this.updateStatus('Converting Swagger file to OAS 3', () => {
         swagger2openapi.convertObj(swagger, {})
           .then(({ openapi }) => this.dereference(openapi));
       });
     }
+
     createDocs(oas) {
       this.setState({ docs: createDocs(oas, 'api-setting') });
     }
+
     render() {
       return <Component {...this.state} {...this.props} fetchSwagger={this.fetchSwagger} />;
     }

--- a/example/src/SpecFetcher.jsx
+++ b/example/src/SpecFetcher.jsx
@@ -39,7 +39,7 @@ function withSpecFetching(Component) {
             return res.json();
           })
           .then((json) => {
-            if (json.swagger) return this.convertSwagger(json);
+            if (json.swagger) return this.convertSwagger(url, json);
 
             return this.dereference(json);
           }).catch((e) => {
@@ -59,12 +59,12 @@ function withSpecFetching(Component) {
       });
     }
 
-    convertSwagger(swagger) {
+    convertSwagger(url, swagger) {
       this.updateStatus('Converting Swagger file to OAS 3', () => {
         swagger2openapi.convertObj(swagger, {})
           .then(({ openapi }) => this.dereference(openapi))
           .catch((e) => {
-            this.setState({ isLoading: false });
+            this.setState({ isLoading: false, invalidSpec: e.message, invalidSpecPath: url });
             this.updateStatus(`There was an error fetching your specification:\n\n${e.message}`);
           });
       });

--- a/example/src/SpecFetcher.jsx
+++ b/example/src/SpecFetcher.jsx
@@ -44,7 +44,6 @@ function withSpecFetching(Component) {
             return this.dereference(json);
           }).catch((e) => {
             this.setState({ isLoading: false });
-
             this.updateStatus(`There was an error fetching your specification:\n\n${e.message}`);
           });
       });
@@ -63,7 +62,11 @@ function withSpecFetching(Component) {
     convertSwagger(swagger) {
       this.updateStatus('Converting Swagger file to OAS 3', () => {
         swagger2openapi.convertObj(swagger, {})
-          .then(({ openapi }) => this.dereference(openapi));
+          .then(({ openapi }) => this.dereference(openapi))
+          .catch((e) => {
+            this.setState({ isLoading: false });
+            this.updateStatus(`There was an error fetching your specification:\n\n${e.message}`);
+          });
       });
     }
 

--- a/example/swagger-files/petstore.json
+++ b/example/swagger-files/petstore.json
@@ -274,7 +274,7 @@
     "/pet/{petId}/uploadImage": {
       "post": {
         "tags": ["pet"],
-        "summary": "uploads an image",
+        "summary": "Uploads an image",
         "description": "",
         "operationId": "uploadFile",
         "consumes": ["multipart/form-data"],


### PR DESCRIPTION
This introduces a few minor redesigns to our https://preview.readme.io/reference/ page and introduces:

* A loading state.
* Handling error states a little differently and removing the "Like what you see?" box if errors are present.

#### Loading state
![Screen Shot 2019-07-02 at 2 32 31 PM](https://user-images.githubusercontent.com/33762/60548146-3e14dd80-9cd6-11e9-8aba-8cfef5d63fd8.png)

#### Better error handling
Old:
![Screen Shot 2019-07-02 at 2 30 57 PM](https://user-images.githubusercontent.com/33762/60548074-132a8980-9cd6-11e9-8818-a429e60a7c74.png)

Refreshed:
![Screen Shot 2019-07-02 at 2 30 18 PM](https://user-images.githubusercontent.com/33762/60548090-1c1b5b00-9cd6-11e9-8d13-b2d71115e7da.png)
