### PR TITLE
🐛 manual endpoints may not have a URL specified in the OAS spec

### DIFF
--- a/packages/api-explorer/__tests__/Doc.test.jsx
+++ b/packages/api-explorer/__tests__/Doc.test.jsx
@@ -65,6 +65,37 @@ test('should render straight away if `appearance.splitReferenceDocs` is true', (
   expect(doc.find('Waypoint').length).toBe(0);
 });
 
+test('should render a manual endpoint', () => {
+  const myProps = JSON.parse(JSON.stringify(props));
+  myProps.doc.swagger.path = '/nonexistant';
+  myProps.doc.api.examples = {
+    codes: [],
+  };
+  myProps.doc.api.params = [
+    {
+      default: 'test',
+      desc: 'test',
+      in: 'path',
+      name: 'test',
+      ref: '',
+      required: false,
+      type: 'string',
+    },
+  ];
+
+  const doc = mount(
+    <Doc
+      {...myProps}
+      appearance={{
+        splitReferenceDocs: true,
+      }}
+    />,
+  );
+
+  assertDocElements(doc, props.doc);
+  expect(doc.find('Params').length).toBe(1);
+});
+
 test('should work without a doc.swagger/doc.path/oas', () => {
   const doc = { title: 'title', slug: 'slug', type: 'basic' };
   const docComponent = shallow(

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -17,6 +17,8 @@ const EndpointErrorBoundary = require('./EndpointErrorBoundary');
 const markdown = require('@readme/markdown');
 
 const Oas = require('./lib/Oas');
+const { Operation } = require('./lib/Oas');
+const getPath = require('./lib/get-path');
 // const showCode = require('./lib/show-code');
 const parseResponse = require('./lib/parse-response');
 const Content = require('./block-types/Content');
@@ -82,7 +84,12 @@ class Doc extends React.Component {
     if (this.operation) return this.operation;
 
     const { doc } = this.props;
-    const operation = doc.swagger ? this.oas.operation(doc.swagger.path, doc.api.method) : null;
+    let operation = doc.swagger ? this.oas.operation(doc.swagger.path, doc.api.method) : null;
+    if (!getPath(this.oas, doc)) {
+      operation = new Operation(this.oas, doc.swagger.path, doc.api.method, {
+        parameters: doc.api.params,
+      });
+    }
     this.operation = operation;
     return operation;
   }

--- a/packages/api-explorer/src/lib/get-path-operation.js
+++ b/packages/api-explorer/src/lib/get-path-operation.js
@@ -1,7 +1,7 @@
 const getPath = require('./get-path');
 
 module.exports = function getPathOperation(swagger, doc) {
-  if (swagger.paths && doc.swagger) {
+  if (swagger.paths && doc.swagger && getPath(swagger, doc)) {
     return getPath(swagger, doc)[doc.api.method];
   }
 

--- a/packages/api-explorer/src/lib/get-path-operation.js
+++ b/packages/api-explorer/src/lib/get-path-operation.js
@@ -1,8 +1,9 @@
 const getPath = require('./get-path');
 
 module.exports = function getPathOperation(swagger, doc) {
-  if (swagger.paths && doc.swagger && getPath(swagger, doc)) {
-    return getPath(swagger, doc)[doc.api.method];
+  if (swagger.paths && doc.swagger) {
+    const path = getPath(swagger, doc);
+    if (path) return path[doc.api.method];
   }
 
   return { parameters: [] };


### PR DESCRIPTION
Resolves a bug where projects load pages that are synced from a spec file in addition to pages that are manually added. 