### PR TITLE
🐛 we need to check if swagger.paths exists

### DIFF
--- a/packages/api-explorer/src/lib/get-path.js
+++ b/packages/api-explorer/src/lib/get-path.js
@@ -1,3 +1,6 @@
 module.exports = function getPath(swagger, doc) {
-  return doc.swagger ? swagger.paths[doc.swagger.path] : { parameters: [] };
+  if (!swagger.paths || !doc.swagger) {
+    return { parameters: [] };
+  }
+  return swagger.paths[doc.swagger.path];
 };


### PR DESCRIPTION
this is covering the case where an invalid apisetting is being passed.