### PR TITLE
Expanding our support for integer formats to a wider variety.

### DIFF
--- a/example/swagger-files/types.json
+++ b/example/swagger-files/types.json
@@ -84,13 +84,37 @@
                     "type": "integer",
                     "format": "int64"
                   },
+                  "integer (format: int8)": {
+                    "type": "integer",
+                    "format": "int8"
+                  },
+                  "integer (format: uint8)": {
+                    "type": "integer",
+                    "format": "uint8"
+                  },
+                  "integer (format: int16)": {
+                    "type": "integer",
+                    "format": "int16"
+                  },
+                  "integer (format: uint16)": {
+                    "type": "integer",
+                    "format": "uint16"
+                  },
                   "integer (format: int32)": {
                     "type": "integer",
                     "format": "int32"
                   },
+                  "integer (format: uint32)": {
+                    "type": "integer",
+                    "format": "uint32"
+                  },
                   "integer (format: int64)": {
                     "type": "integer",
                     "format": "int64"
+                  },
+                  "integer (format: uint64)": {
+                    "type": "integer",
+                    "format": "uint64"
                   },
                   "integer without `format`": {
                     "type": "integer"

--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -186,8 +186,14 @@ function testNumberClass(schema) {
   });
 }
 
+testNumberClass({ type: 'integer', format: 'int8' });
+testNumberClass({ type: 'integer', format: 'uint8' });
+testNumberClass({ type: 'integer', format: 'int16' });
+testNumberClass({ type: 'integer', format: 'uint16' });
 testNumberClass({ type: 'integer', format: 'int32' });
+testNumberClass({ type: 'integer', format: 'uint32' });
 testNumberClass({ type: 'integer', format: 'int64' });
+testNumberClass({ type: 'integer', format: 'uint64' });
 testNumberClass({ type: 'number', format: 'float' });
 testNumberClass({ type: 'number', format: 'double' });
 

--- a/packages/api-explorer/api-explorer.css
+++ b/packages/api-explorer/api-explorer.css
@@ -347,6 +347,54 @@ fieldset[id^='root_array of objects_'] > legend::after {
   padding: 3px 6px;
 }
 
+.field.field-integer.field-int8 label::after {
+  color: rgba(0, 0, 0, 0.6);
+  content: 'integer: int8';
+  background: #f2f2f2;
+  border-radius: 3px;
+  font-family: 'Proxima Nova', sans-serif;
+  font-size: 11px;
+  font-weight: lighter;
+  margin-left: 10px;
+  padding: 3px 6px;
+}
+
+.field.field-integer.field-uint8 label::after {
+  color: rgba(0, 0, 0, 0.6);
+  content: 'integer: uint8';
+  background: #f2f2f2;
+  border-radius: 3px;
+  font-family: 'Proxima Nova', sans-serif;
+  font-size: 11px;
+  font-weight: lighter;
+  margin-left: 10px;
+  padding: 3px 6px;
+}
+
+.field.field-integer.field-int16 label::after {
+  color: rgba(0, 0, 0, 0.6);
+  content: 'integer: int16';
+  background: #f2f2f2;
+  border-radius: 3px;
+  font-family: 'Proxima Nova', sans-serif;
+  font-size: 11px;
+  font-weight: lighter;
+  margin-left: 10px;
+  padding: 3px 6px;
+}
+
+.field.field-integer.field-uint16 label::after {
+  color: rgba(0, 0, 0, 0.6);
+  content: 'integer: uint16';
+  background: #f2f2f2;
+  border-radius: 3px;
+  font-family: 'Proxima Nova', sans-serif;
+  font-size: 11px;
+  font-weight: lighter;
+  margin-left: 10px;
+  padding: 3px 6px;
+}
+
 .field.field-integer.field-int32 label::after {
   color: rgba(0, 0, 0, 0.6);
   content: 'integer: int32';
@@ -359,9 +407,33 @@ fieldset[id^='root_array of objects_'] > legend::after {
   padding: 3px 6px;
 }
 
+.field.field-integer.field-uint32 label::after {
+  color: rgba(0, 0, 0, 0.6);
+  content: 'integer: uint32';
+  background: #f2f2f2;
+  border-radius: 3px;
+  font-family: 'Proxima Nova', sans-serif;
+  font-size: 11px;
+  font-weight: lighter;
+  margin-left: 10px;
+  padding: 3px 6px;
+}
+
 .field.field-integer.field-int64 label::after {
   color: rgba(0, 0, 0, 0.6);
   content: 'integer: int64';
+  background: #f2f2f2;
+  border-radius: 3px;
+  font-family: 'Proxima Nova', sans-serif;
+  font-size: 11px;
+  font-weight: lighter;
+  margin-left: 10px;
+  padding: 3px 6px;
+}
+
+.field.field-integer.field-uint64 label::after {
+  color: rgba(0, 0, 0, 0.6);
+  content: 'integer: uint64';
   background: #f2f2f2;
   border-radius: 3px;
   font-family: 'Proxima Nova', sans-serif;

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@readme/api-explorer",
-  "version": "4.4.4",
+  "version": "4.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/api-explorer/src/Params.jsx
+++ b/packages/api-explorer/src/Params.jsx
@@ -49,8 +49,14 @@ function Params({
           idPrefix={operation.operationId}
           schema={schema.schema}
           widgets={{
-            int64: UpDownWidget,
+            int8: UpDownWidget,
+            uint8: UpDownWidget,
+            int16: UpDownWidget,
+            uint16: UpDownWidget,
             int32: UpDownWidget,
+            uint32: UpDownWidget,
+            int64: UpDownWidget,
+            uint64: UpDownWidget,
             double: UpDownWidget,
             float: UpDownWidget,
             binary: FileWidget,

--- a/packages/api-explorer/src/form-components/SchemaField.jsx
+++ b/packages/api-explorer/src/form-components/SchemaField.jsx
@@ -26,7 +26,10 @@ function getCustomType(schema) {
     if (schema.format === 'binary') return 'file';
   }
 
-  if (isNumType(schema, 'integer', /int32|int64/) || isNumType(schema, 'number', /float|double/)) {
+  if (
+    isNumType(schema, 'integer', /int8|int16|int32|int64/) ||
+    isNumType(schema, 'number', /float|double/)
+  ) {
     return schema.format;
   }
 


### PR DESCRIPTION
We have a current problem in the explorer with our integer `format` support where we're misidentifying `uint64` as `int32`. This resolves that, as well as expands our support to the following integer formats:

* `int8`
* `uint8`
* `int16`
* `uint16`
* `uint32`
* `uint64`

Ideally, we wouldn't need to hardcode these kinds of things in here, but the [TSC is working through some proposals](https://github.com/OAI/OpenAPI-Specification/issues/845) on a format registry to the spec.

![Screen Shot 2019-08-02 at 11 44 13 PM](https://user-images.githubusercontent.com/33762/62408543-877b7580-b57f-11e9-8ae1-5cc887149c4a.png)