### PR TITLE
fix/default-header

### DIFF
--- a/packages/api-explorer/__tests__/lib/get-auth.test.js
+++ b/packages/api-explorer/__tests__/lib/get-auth.test.js
@@ -56,6 +56,10 @@ it('should return apiKey property for apiKey', () => {
   expect(getSingle(topLevelUser, { type: 'oauth2' })).toBe('123456');
 });
 
+it('should return a default value if scheme is sec0 and default auth provided', () => {
+  expect(getSingle({}, { type: 'apiKey', _key: 'sec0', 'x-default': 'default' })).toBe('default');
+});
+
 it('should return apiKey property for bearer', () => {
   expect(getSingle(topLevelUser, { type: 'http', scheme: 'bearer' })).toBe('123456');
 });

--- a/packages/api-explorer/src/lib/get-auth.js
+++ b/packages/api-explorer/src/lib/get-auth.js
@@ -2,7 +2,7 @@ function getKey(user, scheme) {
   switch (scheme.type) {
     case 'oauth2':
     case 'apiKey':
-      return user[scheme._key] || user.apiKey || '';
+      return user[scheme._key] || user.apiKey || scheme['x-default'] || '';
     case 'http':
       if (scheme.scheme === 'basic') {
         return user[scheme._key] || { user: user.user || '', pass: user.pass || '' };


### PR DESCRIPTION
Link to Asana: https://app.asana.com/0/1123275137064497/1125820476777265

Fixes a bug where default query/header params for manual APIs not reflecting in the explorer properly.