### PR TITLE
If we fail to render JSON, fallback to string rendering.

### DIFF
--- a/example/swagger-files/response-schemas.json
+++ b/example/swagger-files/response-schemas.json
@@ -86,6 +86,30 @@
           }
         }
       }
+    },
+    "/anything/returns-as-json-but-is-actually-string": {
+      "get": {
+        "summary": "Returns as JSON, but is actually a simple string",
+        "description": "This example is to ensure that we don't hard fail out on attempting to parse a non-JSON string as JSON, and instead fallback to the standard syntax highlighter.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "examples": {
+                  "response": {
+                    "value": "96fab4bb-ff68-43e2-94d8-7046f3173d9c"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/packages/api-explorer/__tests__/Example.test.jsx
+++ b/packages/api-explorer/__tests__/Example.test.jsx
@@ -1,6 +1,7 @@
 const React = require('react');
 const { shallow } = require('enzyme');
 const petstore = require('./fixtures/petstore/oas');
+const string = require('./fixtures/string/oas.json');
 const exampleResults = require('./fixtures/example-results/oas');
 const extensions = require('@readme/oas-extensions');
 
@@ -57,6 +58,23 @@ test('should display json viewer', () => {
       .render()
       .find('.react-json-view').length,
   ).toBe(1);
+});
+
+test('should not fail to parse invalid json and instead show the standard syntax highlighter', () => {
+  const exampleOas = new Oas(string);
+  const example = shallow(
+    <Example {...props} oas={exampleOas} operation={exampleOas.operation('/format-uuid', 'get')} />,
+  );
+
+  // Asserting that instead of failing with the invalid JSON we attempted to render, we fallback
+  // to just rendering the string in our standard syntax highlighter.
+  expect(
+    example
+      .find('pre')
+      .at(0)
+      .render()
+      .find('.cm-number').length,
+  ).toBe(4);
 });
 
 test('should correctly highlight XML syntax', () => {

--- a/packages/api-explorer/__tests__/fixtures/string/oas.json
+++ b/packages/api-explorer/__tests__/fixtures/string/oas.json
@@ -33,7 +33,29 @@
                 "properties": {
                   "string": {
                     "type": "string",
-                    "format": "some-unknown-format"                    
+                    "format": "some-unknown-format"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/format-uuid": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "examples": {
+                  "response": {
+                    "value": "96fab4bb-ff68-43e2-94d8-7046f3173d9c"
                   }
                 }
               }

--- a/packages/api-explorer/src/Example.jsx
+++ b/packages/api-explorer/src/Example.jsx
@@ -4,7 +4,6 @@ const ReactJson = require('react-json-view').default;
 const showCodeResults = require('./lib/show-code-results');
 const contentTypeIsJson = require('./lib/content-type-is-json');
 
-// const { replaceVars } = require('./lib/replace-vars');
 const syntaxHighlighter = require('@readme/syntax-highlighter');
 const extensions = require('@readme/oas-extensions');
 
@@ -88,6 +87,21 @@ function Example({
           <div className="code-sample-body">
             {examples.map((example, index) => {
               const isJson = example.language && contentTypeIsJson(example.language);
+
+              const getHighlightedExample = ex => {
+                return syntaxHighlighter(ex.code, ex.language, {
+                  dark: true,
+                });
+              };
+
+              const transformExampleIntoReactJson = ex => {
+                try {
+                  return getReactJson(ex);
+                } catch (e) {
+                  return getHighlightedExample(ex);
+                }
+              };
+
               return (
                 <pre
                   className={`tomorrow-night tabber-body tabber-body-${index}`}
@@ -97,13 +111,9 @@ function Example({
                   {example.multipleExamples &&
                     showExamples(example.multipleExamples, setResponseType, responseType)}
                   {isJson && !example.multipleExamples ? (
-                    getReactJson(example)
+                    transformExampleIntoReactJson(example)
                   ) : (
-                    <div>
-                      {syntaxHighlighter(example.code, example.language, {
-                        dark: true,
-                      })}
-                    </div>
+                    <div>{getHighlightedExample(example)}</div>
                   )}
                 </pre>
               );


### PR DESCRIPTION
| [🎟 Asana](https://app.asana.com/0/681252538274980/1130342849794131/f) |
| :--- |

This adds in some protections on our JSON rendering in response examples to prevent us from failing out on "Unexpected token" errors if we're attempt to render a string as JSON that isn't actually JSON. This kind of thing can happen if a response is documented as returning JSON, but instead has a simple string documented as an example.