### PR TITLE
Moving non-HTTP code filtering down into create-docs.

### DIFF
--- a/example/swagger-files/common-parameters.json
+++ b/example/swagger-files/common-parameters.json
@@ -1,0 +1,67 @@
+{
+    "openapi": "3.0.0",
+    "servers": [
+      {
+        "url": "http://httpbin.org"
+      }
+    ],
+    "info": {
+      "version": "1.0.0",
+      "title": "An example of how we render $ref usage on resource parameters"
+    },
+    "paths": {
+      "/anything/{id}": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "get": {
+          "summary": "Get anything",
+          "description": "",
+          "responses": {}
+        },
+        "post": {
+          "summary": "Post anything",
+          "description": "",
+          "parameters": [
+            {
+              "$ref": "#/components/parameters/limitParam"
+            }
+          ],
+          "responses": {}
+        }
+      }
+    },
+    "components": {
+      "parameters": {
+        "limitParam": {
+          "in": "query",
+          "name": "limit",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "default": 20
+          },
+          "description": "The numbers of items to return."
+        }
+      },
+      "schemas": {
+        "string_enum": {
+          "name": "string",
+          "enum": [
+            "available",
+            "pending",
+            "sold"
+          ],
+          "type": "string"
+        }
+      }
+    }
+  }

--- a/packages/api-explorer/__tests__/fixtures/parameters/common.json
+++ b/packages/api-explorer/__tests__/fixtures/parameters/common.json
@@ -1,0 +1,229 @@
+{
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v2"
+    }
+  ],
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/pet/{petId}": {
+      "parameters": [
+        {
+          "name": "petId",
+          "in": "path",
+          "description": "ID of the pet",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      ],
+      "get": {
+        "tags": ["pet"],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "Updated name of the pet",
+                    "type": "string"
+                  },
+                  "status": {
+                    "description": "Updated status of the pet",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["pet"],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Pet": {
+        "type": "object",
+        "required": ["name", "photoUrls"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "name": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "photoUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": ["available", "pending", "sold"]
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    }
+  },
+  "x-explorer-enabled": true,
+  "x-samples-enabled": true,
+  "x-samples-languages": ["curl", "node", "ruby", "javascript", "python"]
+}

--- a/packages/api-explorer/__tests__/lib/create-docs.test.js
+++ b/packages/api-explorer/__tests__/lib/create-docs.test.js
@@ -1,0 +1,8 @@
+const commonParamsOas = require('./../fixtures/parameters/common');
+const createDocs = require('../../lib/create-docs');
+
+test('should not create a doc object for unrecognized http methods', () => {
+  const docs = createDocs(commonParamsOas, 'api-setting');
+
+  expect(docs.length).toBe(3);
+});

--- a/packages/api-explorer/lib/create-docs.js
+++ b/packages/api-explorer/lib/create-docs.js
@@ -41,6 +41,13 @@ module.exports = (oas, apiSetting) => {
 
       const tag = operation.tags && operation.tags.length ? operation.tags[0] : path;
       if (!docs.find(category => category.slug === tag && category.type === 'basic')) {
+        // If the method present isn't an HTTP method that we're aware of, ignore it. This can
+        // happen in the case of an API definition using something like common parameters.
+        // https://swagger.io/docs/specification/describing-parameters
+        if (!['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'].includes(method)) {
+          return;
+        }
+
         docs.push({
           _id: Math.random().toString(16),
           title: operation.summary || path || tag,

--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -11,8 +11,6 @@ const SelectedAppContext = require('@readme/variable/contexts/SelectedApp');
 const ErrorBoundary = require('./ErrorBoundary');
 const Doc = require('./Doc');
 
-const methods = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'];
-
 const getAuth = require('./lib/get-auth');
 
 class ApiExplorer extends React.Component {
@@ -119,15 +117,13 @@ class ApiExplorer extends React.Component {
   }
 
   render() {
-    const docs = this.props.docs.filter(doc => methods.includes(((doc || {}).api || {}).method));
-
     return (
       <div className={`is-lang-${this.state.language}`}>
         <div
           id="hub-reference"
           className={`content-body hub-reference-sticky hub-reference-theme-${this.props.appearance.referenceLayout}`}
         >
-          {docs.map((doc, index) => (
+          {this.props.docs.map((doc, index) => (
             <VariablesContext.Provider value={this.props.variables}>
               <OauthContext.Provider value={this.props.oauth}>
                 <GlossaryTermsContext.Provider value={this.props.glossaryTerms}>


### PR DESCRIPTION
This resolves a regression that was introduced in https://github.com/readmeio/api-explorer/pull/211 where in certain cases, non-endpoint docs on ReadMe would be filtered out from being shown because they didn't have an HTTP method we recognized.

Instead, we're now doing this filtering within `create-docs` where we're parsing the OAS and know that we have an endpoint at hand.

Also added a new unit test for `create-docs` to make sure that we don't regress on the common parameter functionality introduced in #211 and begin showing stateless `parameters` endpoints within the explorer.