### PR TITLE
Add href attribute to <a> tags used for switching code tabs

### DIFF
--- a/packages/api-explorer/src/block-types/Code.jsx
+++ b/packages/api-explorer/src/block-types/Code.jsx
@@ -28,10 +28,11 @@ class BlockCode extends React.Component {
           {(!opts.hideHeaderOnOne || codes.length > 1) && (
             <ul className="block-code-header">
               {codes.map((code, i) => (
+                /* eslint-disable jsx-a11y/href-no-hash */
                 // eslint-disable-next-line react/no-array-index-key
                 <li key={i}>
                   <a
-                    href=""
+                    href="#"
                     onClick={e => {
                       e.preventDefault();
                       this.showCode(i);


### PR DESCRIPTION
This fixes an issue when navigating to /reference on a project
and switching code tabs, which makes the page do a full refresh.

No idea why, lets see if this fixes it on a PR app.