### PR TITLE
fix: Stop nesting Markdown response descriptions in a p tag

### DIFF
--- a/packages/api-explorer/__tests__/ResponseSchema.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseSchema.test.jsx
@@ -34,7 +34,7 @@ test('should display response schema description', () => {
 
   expect(
     responseSchema
-      .find('p.desc')
+      .find('div.desc')
       .first()
       .text(),
   ).toBe(props.operation.responses['200'].description);

--- a/packages/api-explorer/src/ResponseSchema.jsx
+++ b/packages/api-explorer/src/ResponseSchema.jsx
@@ -96,9 +96,9 @@ class ResponseSchema extends React.Component {
         {this.renderHeader()}
         <div className="response-schema">
           {operation.responses[this.state.selectedStatus].description && (
-            <p className="desc">
+            <div className="desc">
               {markdown(operation.responses[this.state.selectedStatus].description)}
-            </p>
+            </div>
           )}
           {schema && <ResponseSchemaBody schema={schema} oas={oas} />}
         </div>


### PR DESCRIPTION
This resolves a persistent error on every usage of the Explorer where because we render response descriptions as Markdown, we're nesting a `<p>` tag within another `<p>` tag, which is invalid DOM.

```
Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
    in p
    in p
    in div
    in div
    in ResponseSchema
    in div
    in div
    in div
    in EndpointErrorBoundary
    in div
    in Doc
    in div
    in div
    in ApiExplorer
    in ErrorBoundary
    in Unknown (created by Demo)
    in div (created by Demo)
    in Demo (created by _class)
    in _class
    in AppContainer
```