### PR TITLE
Editable server variables

### DIFF
--- a/packages/api-explorer/__tests__/PathUrl.test.jsx
+++ b/packages/api-explorer/__tests__/PathUrl.test.jsx
@@ -25,9 +25,19 @@ const props = {
 test('should display the path', () => {
   const pathUrl = shallow(<PathUrl {...props} />);
 
-  expect(pathUrl.find('span.url').text()).toBe(oas.servers[0].url);
-  expect(pathUrl.find('span.api-text').text()).toBe('/pet/');
-  expect(pathUrl.find('span.api-variable').text()).toBe('petId');
+  expect(pathUrl.find('span.url').text()).toBe(oas.url());
+  expect(pathUrl.find('span.path span.api-text').text()).toBe('/pet/');
+  expect(pathUrl.find('span.path span.api-variable').text()).toBe('petId');
+});
+
+test('should display the url with variables', () => {
+  const serverVariablesOas = new Oas({
+    servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'path' } } }],
+  });
+
+  const pathUrl = shallow(<PathUrl {...props} oas={serverVariablesOas} />);
+  expect(pathUrl.find('span.url span.api-text').text()).toBe('https://example.com/');
+  expect(pathUrl.find('span.url span.api-variable').text()).toBe('path');
 });
 
 describe('loading prop', () => {

--- a/packages/api-explorer/__tests__/lib/Oas.test.js
+++ b/packages/api-explorer/__tests__/lib/Oas.test.js
@@ -86,6 +86,16 @@ describe('server variables', () => {
     });
   });
 
+  describe('oas.untransformedUrl()', () => {
+    it('should return an unmodified server url', () => {
+      expect(
+        new Oas({
+          servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'path' } } }],
+        }).untransformedUrl(),
+      ).toBe('https://example.com/{path}');
+    });
+  });
+
   describe('oas.variables()', () => {
     it('should handle no variables', () => {
       expect(new Oas({ servers: [{ url: 'https://example.com/{path}' }] }).variables()).toEqual({})

--- a/packages/api-explorer/__tests__/lib/Oas.test.js
+++ b/packages/api-explorer/__tests__/lib/Oas.test.js
@@ -43,59 +43,94 @@ test('should add https:// if url does not start with a protocol', () => {
 });
 
 describe('server variables', () => {
-  it('should use defaults', () => {
-    expect(
-      new Oas({
-        servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'path' } } }],
-      }).url(),
-    ).toBe('https://example.com/path');
+  describe('oas.url()', () => {
+    it('should use defaults', () => {
+      expect(
+        new Oas({
+          servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'path' } } }],
+        }).url(),
+      ).toBe('https://example.com/path');
+    });
+
+    it('should use provided values over defaults', () => {
+      expect(
+        new Oas(
+          {
+            servers: [
+              { url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } },
+            ],
+          },
+        ).url({ username: 'domh' }),
+      ).toBe('https://domh.example.com');
+    });
+
+    it.skip('should fetch user variables from selected app', () => {
+      expect(
+        new Oas(
+          {
+            servers: [
+              { url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } },
+            ],
+          },
+          { keys: [{ name: 1, username: 'domh' }, { name: 2, username: 'readme' }] },
+          2,
+        ).url(),
+      ).toBe('https://readme.example.com');
+    });
+
+    // Test encodeURI
+    it('should pass through if no default set', () => {
+      expect(new Oas({ servers: [{ url: 'https://example.com/{path}' }] }).url()).toBe(
+        'https://example.com/{path}',
+      );
+    });
   });
 
-  it('should use user variables over defaults', () => {
-    expect(
-      new Oas(
-        {
-          servers: [
-            { url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } },
-          ],
-        },
-        { username: 'domh' },
-      ).url(),
-    ).toBe('https://domh.example.com');
-  });
+  describe('oas.variables()', () => {
+    it('should handle no variables', () => {
+      expect(new Oas({ servers: [{ url: 'https://example.com/{path}' }] }).variables()).toEqual({})
+    });
 
-  it('should fetch user variables from keys array', () => {
-    expect(
-      new Oas(
-        {
-          servers: [
-            { url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } },
-          ],
-        },
-        { keys: [{ name: 1, username: 'domh' }] },
-      ).url(),
-    ).toBe('https://domh.example.com');
-  });
+    it('should set default from spec file', () => {
+      expect(
+        new Oas(
+          {
+            servers: [
+              {
+                url: 'https://{username}.example.com',
+                variables: { username: { default: 'demo' } },
+              },
+            ],
+          },
+        ).variables(),
+      ).toEqual({ username: { default: 'demo', type: 'string' }});
+    });
 
-  it.skip('should fetch user variables from selected app', () => {
-    expect(
-      new Oas(
-        {
-          servers: [
-            { url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } },
-          ],
-        },
-        { keys: [{ name: 1, username: 'domh' }, { name: 2, username: 'readme' }] },
-        2,
-      ).url(),
-    ).toBe('https://readme.example.com');
-  });
+    it('should set default to user variable', () => {
+      expect(
+        new Oas(
+          {
+            servers: [
+              { url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } },
+            ],
+          },
+          { username: 'domh' }
+        ).variables(),
+      ).toEqual({ username: { default: 'domh', type: 'string' }});
+    });
 
-  // Test encodeURI
-  it('should pass through if no default set', () => {
-    expect(new Oas({ servers: [{ url: 'https://example.com/{path}' }] }).url()).toBe(
-      'https://example.com/{path}',
-    );
+    it('should set default to user with keys', () => {
+      expect(
+        new Oas(
+          {
+            servers: [
+              { url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } },
+            ],
+          },
+          { keys: [{ name: 1, username: 'domh' }] },
+        ).variables(),
+      ).toEqual({ username: { default: 'domh', type: 'string' } });
+    });
   });
 });
 

--- a/packages/api-explorer/__tests__/lib/Oas.test.js
+++ b/packages/api-explorer/__tests__/lib/Oas.test.js
@@ -47,20 +47,20 @@ describe('server variables', () => {
     it('should use defaults', () => {
       expect(
         new Oas({
-          servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'path' } } }],
+          servers: [
+            { url: 'https://example.com/{path}', variables: { path: { default: 'path' } } },
+          ],
         }).url(),
       ).toBe('https://example.com/path');
     });
 
     it('should use provided values over defaults', () => {
       expect(
-        new Oas(
-          {
-            servers: [
-              { url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } },
-            ],
-          },
-        ).url({ username: 'domh' }),
+        new Oas({
+          servers: [
+            { url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } },
+          ],
+        }).url({ username: 'domh' }),
       ).toBe('https://domh.example.com');
     });
 
@@ -69,7 +69,10 @@ describe('server variables', () => {
         new Oas(
           {
             servers: [
-              { url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } },
+              {
+                url: 'https://{username}.example.com',
+                variables: { username: { default: 'demo' } },
+              },
             ],
           },
           { keys: [{ name: 1, username: 'domh' }, { name: 2, username: 'readme' }] },
@@ -90,7 +93,9 @@ describe('server variables', () => {
     it('should return an unmodified server url', () => {
       expect(
         new Oas({
-          servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'path' } } }],
+          servers: [
+            { url: 'https://example.com/{path}', variables: { path: { default: 'path' } } },
+          ],
         }).untransformedUrl(),
       ).toBe('https://example.com/{path}');
     });
@@ -98,10 +103,23 @@ describe('server variables', () => {
 
   describe('oas.variables()', () => {
     it('should handle no variables', () => {
-      expect(new Oas({ servers: [{ url: 'https://example.com/{path}' }] }).variables()).toEqual({})
+      expect(new Oas({ servers: [{ url: 'https://example.com/{path}' }] }).variables()).toEqual({});
     });
 
     it('should set default from spec file', () => {
+      expect(
+        new Oas({
+          servers: [
+            {
+              url: 'https://{username}.example.com',
+              variables: { username: { default: 'demo' } },
+            },
+          ],
+        }).variables(),
+      ).toEqual({ username: { default: 'demo', type: 'string' } });
+    });
+
+    it('should set default to user variable', () => {
       expect(
         new Oas(
           {
@@ -112,21 +130,9 @@ describe('server variables', () => {
               },
             ],
           },
+          { username: 'domh' },
         ).variables(),
-      ).toEqual({ username: { default: 'demo', type: 'string' }});
-    });
-
-    it('should set default to user variable', () => {
-      expect(
-        new Oas(
-          {
-            servers: [
-              { url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } },
-            ],
-          },
-          { username: 'domh' }
-        ).variables(),
-      ).toEqual({ username: { default: 'domh', type: 'string' }});
+      ).toEqual({ username: { default: 'domh', type: 'string' } });
     });
 
     it('should set default to user with keys', () => {
@@ -134,7 +140,10 @@ describe('server variables', () => {
         new Oas(
           {
             servers: [
-              { url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } },
+              {
+                url: 'https://{username}.example.com',
+                variables: { username: { default: 'demo' } },
+              },
             ],
           },
           { keys: [{ name: 1, username: 'domh' }] },

--- a/packages/api-explorer/__tests__/lib/oas-to-har.test.js
+++ b/packages/api-explorer/__tests__/lib/oas-to-har.test.js
@@ -35,15 +35,20 @@ describe('url', () => {
   });
 
   test('should pass server variables through to oas.url()', () => {
-    expect(oasToHar(new Oas(
-      {
-        servers: [
-          {
-            url: 'https://{username}.example.com',
-            variables: { username: { default: 'demo' } },
-          },
-        ],
-      }), { path: '', method: '' }, { server: { username: 'domh' } }).log.entries[0].request.url).toBe('https://domh.example.com');
+    expect(
+      oasToHar(
+        new Oas({
+          servers: [
+            {
+              url: 'https://{username}.example.com',
+              variables: { username: { default: 'demo' } },
+            },
+          ],
+        }),
+        { path: '', method: '' },
+        { server: { username: 'domh' } },
+      ).log.entries[0].request.url,
+    ).toBe('https://domh.example.com');
   });
 
   // TODO this should probably happen within the Operation class

--- a/packages/api-explorer/__tests__/lib/oas-to-har.test.js
+++ b/packages/api-explorer/__tests__/lib/oas-to-har.test.js
@@ -34,6 +34,18 @@ describe('url', () => {
     expect(oasToHar(oas, { path: '', method: 'get' }).log.entries[0].request.url).toBe(oas.url());
   });
 
+  test('should pass server variables through to oas.url()', () => {
+    expect(oasToHar(new Oas(
+      {
+        servers: [
+          {
+            url: 'https://{username}.example.com',
+            variables: { username: { default: 'demo' } },
+          },
+        ],
+      }), { path: '', method: '' }, { server: { username: 'domh' } }).log.entries[0].request.url).toBe('https://domh.example.com');
+  });
+
   // TODO this should probably happen within the Operation class
   test('should replace whitespace with %20', () => {
     expect(

--- a/packages/api-explorer/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/api-explorer/__tests__/lib/parameters-to-json-schema.test.js
@@ -8,16 +8,14 @@ test('it should return with null if there are no parameters', async () => {
 
 test('it should return with a json schema for each parameter type', () => {
   expect(
-    parametersToJsonSchema(
-      {
-        parameters: [
-          { in: 'path', name: 'path parameter' },
-          { in: 'query', name: 'query parameter' },
-          { in: 'header', name: 'header parameter' },
-          { in: 'cookie', name: 'cookie parameter' },
-        ],
-      },
-    ),
+    parametersToJsonSchema({
+      parameters: [
+        { in: 'path', name: 'path parameter' },
+        { in: 'query', name: 'query parameter' },
+        { in: 'header', name: 'header parameter' },
+        { in: 'cookie', name: 'cookie parameter' },
+      ],
+    }),
   ).toEqual([
     {
       label: 'Path Params',
@@ -76,21 +74,19 @@ test('it should return with a json schema for each parameter type', () => {
 
 test('it should work for request body inline (json)', () => {
   expect(
-    parametersToJsonSchema(
-      {
-        requestBody: {
-          description: 'Body description',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: { a: { type: 'string' } },
-              },
+    parametersToJsonSchema({
+      requestBody: {
+        description: 'Body description',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: { a: { type: 'string' } },
             },
           },
         },
       },
-    ),
+    }),
   ).toEqual([
     {
       label: 'Body Params',
@@ -107,21 +103,19 @@ test('it should work for request body inline (json)', () => {
 
 test('it should work for request body inline (formData)', () => {
   expect(
-    parametersToJsonSchema(
-      {
-        requestBody: {
-          description: 'Form data description',
-          content: {
-            'application/x-www-form-urlencoded': {
-              schema: {
-                type: 'object',
-                properties: { a: { type: 'string' } },
-              },
+    parametersToJsonSchema({
+      requestBody: {
+        description: 'Form data description',
+        content: {
+          'application/x-www-form-urlencoded': {
+            schema: {
+              type: 'object',
+              properties: { a: { type: 'string' } },
             },
           },
         },
       },
-    ),
+    }),
   ).toEqual([
     {
       label: 'Form Data',
@@ -138,16 +132,17 @@ test('it should work for request body inline (formData)', () => {
 
 test('should work for server variables', () => {
   expect(
-    parametersToJsonSchema({}, new Oas(
-      {
+    parametersToJsonSchema(
+      {},
+      new Oas({
         servers: [
           {
             url: 'https://{username}.example.com',
             variables: { username: { default: 'demo' } },
           },
         ],
-      },
-    )),
+      }),
+    ),
   ).toEqual([
     {
       label: 'Server Variables',
@@ -155,14 +150,14 @@ test('should work for server variables', () => {
       schema: {
         type: 'object',
         properties: {
-          'username': {
+          username: {
             default: 'demo',
             type: 'string',
           },
         },
       },
-    }
-  ])
+    },
+  ]);
 });
 
 test('should pass through enum', () => {

--- a/packages/api-explorer/src/PathUrl.jsx
+++ b/packages/api-explorer/src/PathUrl.jsx
@@ -77,12 +77,20 @@ function PathUrl({
 
           {oas.servers && oas.servers.length > 0 && (
             <span className="definition-url">
-              <span className="url">{oas.url()}</span>
-              {splitPath(operation.path).map(part => (
-                <span key={part.key} className={`api-${part.type}`}>
-                  {part.value}
-                </span>
-              ))}
+              <span className="url">
+                {splitPath(oas.untransformedUrl()).map(part => (
+                  <span key={part.key} className={`api-${part.type}`}>
+                    {part.value}
+                  </span>
+                ))}
+              </span>
+              <span className="path">
+                {splitPath(operation.path).map(part => (
+                  <span key={part.key} className={`api-${part.type}`}>
+                    {part.value}
+                  </span>
+                ))}
+              </span>
             </span>
           )}
         </div>

--- a/packages/api-explorer/src/lib/Oas.js
+++ b/packages/api-explorer/src/lib/Oas.js
@@ -112,13 +112,7 @@ class Oas {
   url(values = {}) {
     const url = normalizedUrl(this);
 
-    let variables;
-    try {
-      variables = this.servers[0].variables;
-      if (!variables) throw Error('no variables');
-    } catch (e) {
-      variables = {};
-    }
+    const variables = this.variables();
 
     return url.replace(/{([-_a-zA-Z0-9[\]]+)}/g, (original, key) => {
       if (values[key]) return values[key];

--- a/packages/api-explorer/src/lib/Oas.js
+++ b/packages/api-explorer/src/lib/Oas.js
@@ -105,6 +105,10 @@ class Oas {
     this.user = user || {};
   }
 
+  untransformedUrl() {
+    return normalizedUrl(this);
+  }
+
   url(values = {}) {
     const url = normalizedUrl(this);
 

--- a/packages/api-explorer/src/lib/Oas.js
+++ b/packages/api-explorer/src/lib/Oas.js
@@ -139,8 +139,11 @@ class Oas {
     return Object.keys(variables)
       .map(k => {
         return {
-          [k]: Object.assign({ type: 'string' }, variables[k], { default: getUserVariable(this.user, k) || variables[k].default
-          })
+          [k]: {
+            ...variables[k],
+            type: 'string',
+            default: getUserVariable(this.user, k) || variables[k].default,
+          },
         }
       })
       .reduce((prev, next) => Object.assign(prev, next), {})

--- a/packages/api-explorer/src/lib/Oas.js
+++ b/packages/api-explorer/src/lib/Oas.js
@@ -148,9 +148,9 @@ class Oas {
             type: 'string',
             default: getUserVariable(this.user, k) || variables[k].default,
           },
-        }
+        };
       })
-      .reduce((prev, next) => Object.assign(prev, next), {})
+      .reduce((prev, next) => Object.assign(prev, next), {});
   }
 }
 

--- a/packages/api-explorer/src/lib/oas-to-har.js
+++ b/packages/api-explorer/src/lib/oas-to-har.js
@@ -90,7 +90,7 @@ module.exports = (
     queryString: [],
     postData: {},
     method: pathOperation.method.toUpperCase(),
-    url: `${oas.url()}${pathOperation.path}`.replace(/\s/g, '%20'),
+    url: `${oas.url(formData.server)}${pathOperation.path}`.replace(/\s/g, '%20'),
   };
 
   // TODO look to move this to Oas class as well

--- a/packages/api-explorer/src/lib/parameters-to-json-schema.js
+++ b/packages/api-explorer/src/lib/parameters-to-json-schema.js
@@ -111,8 +111,8 @@ function getServerVariables(properties) {
     schema: {
       type: 'object',
       properties,
-    }
-  }
+    },
+  };
 }
 
 module.exports = (pathOperation, oas = { variables: () => ({}) }) => {
@@ -121,7 +121,13 @@ module.exports = (pathOperation, oas = { variables: () => ({}) }) => {
   const serverVariables = oas.variables();
   const hasServerVariables = Object.keys(serverVariables).length > 0;
 
-  if (!hasParameters && !hasRequestBody && !hasCommonParameters(pathOperation) && !hasServerVariables) return null;
+  if (
+    !hasParameters &&
+    !hasRequestBody &&
+    !hasCommonParameters(pathOperation) &&
+    !hasServerVariables
+  )
+    return null;
 
   return [getServerVariables(serverVariables), getBodyParam(pathOperation, oas)]
     .concat(...getOtherParams(pathOperation, oas))

--- a/packages/api-explorer/src/lib/parameters-to-json-schema.js
+++ b/packages/api-explorer/src/lib/parameters-to-json-schema.js
@@ -103,28 +103,27 @@ function getOtherParams(pathOperation, oas) {
   });
 }
 
-function getServerVariables(variables) {
-  if (Object.keys(variables).length === 0) return null;
+function getServerVariables(properties) {
+  if (Object.keys(properties).length === 0) return null;
   return {
     type: 'server',
     label: types.server,
     schema: {
       type: 'object',
-      properties: Object.keys(variables)
-        .map(k => { return { [k]: Object.assign({ type: 'string'}, variables[k]) } })
-        .reduce((prev, next) => Object.assign(prev, next), {}),
+      properties,
     }
   }
 }
-// TODO make sure server variables are returned when there's no body
-module.exports = (pathOperation, oas) => {
+
+module.exports = (pathOperation, oas = { variables: () => ({}) }) => {
   const hasRequestBody = !!pathOperation.requestBody;
   const hasParameters = !!(pathOperation.parameters && pathOperation.parameters.length !== 0);
-  const hasServerVariables = Object.keys(oas.variables()).length > 0;
+  const serverVariables = oas.variables();
+  const hasServerVariables = Object.keys(serverVariables).length > 0;
 
   if (!hasParameters && !hasRequestBody && !hasCommonParameters(pathOperation) && !hasServerVariables) return null;
 
-  return [getServerVariables(oas.variables()), getBodyParam(pathOperation, oas)]
+  return [getServerVariables(serverVariables), getBodyParam(pathOperation, oas)]
     .concat(...getOtherParams(pathOperation, oas))
     .filter(Boolean);
 };


### PR DESCRIPTION
I decided to have a go at making server variables editable in the same manner as other properties.

<img width="1065" alt="image" src="https://user-images.githubusercontent.com/848223/65647945-2d15f880-dfb5-11e9-9df5-d1e958bf3786.png">

You can see this in action here: http://localhost:9966/?selected=swagger-files%2Fserver-variables.json.

At a high level, I had to modify two main parts of the code to add support for this:

- parameters-to-json-schema - to make it aware of server variables so the form module constructs a form for it
- oas-to-har - pass the values from the form into here so we can construct a URL with the server variables the user has typed in

This isn't quite as well supported as auth, which shares the state across endpoints when it's modified in one, but maybe this is good enough for now. Eventually we'll be able to move server variables state one level up and share them, like we do currently for auth.