### PR TITLE
Set link tag's [target] in the editor

### DIFF
--- a/packages/markdown/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/markdown/__tests__/__snapshots__/index.test.js.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`anchor target: should allow _blank if using HTML 1`] = `"<p><a href=\\"https://example.com\\" target=\\"_blank\\">test</a></p>"`;
+
+exports[`anchor target: should default to _self 1`] = `"<p><a href=\\"https://example.com\\" target=\\"_self\\">test</a></p>"`;
+
 exports[`anchors 1`] = `
 "<p><a href=\\"http://example.com\\" target=\\"_self\\">link</a><br/>
 <a href=\\"\\" target=\\"_self\\">xss</a><br/>

--- a/packages/markdown/__tests__/index.test.js
+++ b/packages/markdown/__tests__/index.test.js
@@ -68,9 +68,7 @@ test('anchors', () => {
 });
 
 test('anchor target: should default to _self', () => {
-  expect(
-    shallow(markdown('[test](https://example.com)')).html(),
-  ).toMatchSnapshot();
+  expect(shallow(markdown('[test](https://example.com)')).html()).toMatchSnapshot();
 });
 
 test('anchor target: should allow _blank if using HTML', () => {

--- a/packages/markdown/__tests__/index.test.js
+++ b/packages/markdown/__tests__/index.test.js
@@ -67,6 +67,18 @@ test('anchors', () => {
   ).toMatchSnapshot();
 });
 
+test('anchor target: should default to _self', () => {
+  expect(
+    shallow(markdown('[test](https://example.com)')).html(),
+  ).toMatchSnapshot();
+});
+
+test('anchor target: should allow _blank if using HTML', () => {
+  expect(
+    shallow(markdown('<a href="https://example.com" target="_blank">test</a>')).html(),
+  ).toMatchSnapshot();
+});
+
 test('anchors with baseUrl', () => {
   const wrapper = mount(
     React.createElement(

--- a/packages/markdown/components/Anchor.jsx
+++ b/packages/markdown/components/Anchor.jsx
@@ -45,7 +45,7 @@ function docLink(href) {
 }
 
 function Anchor(props) {
-  const {href, target, baseUrl, children} = props
+  const { href, target, baseUrl, children } = props;
   return (
     <a target={target} href={getHref(href, baseUrl)} {...docLink(href)}>
       {children}

--- a/packages/markdown/components/Anchor.jsx
+++ b/packages/markdown/components/Anchor.jsx
@@ -45,27 +45,30 @@ function docLink(href) {
 }
 
 function Anchor(props) {
+  const {href, target, baseUrl, children} = props
   return (
-    <a href={getHref(props.href, props.baseUrl)} target="_self" {...docLink(props.href)}>
-      {props.children}
+    <a target={target} href={getHref(href, baseUrl)} {...docLink(href)}>
+      {children}
     </a>
   );
 }
 
 Anchor.propTypes = {
   href: PropTypes.string,
+  target: PropTypes.string,
   baseUrl: PropTypes.string,
   children: PropTypes.node.isRequired,
 };
 
 Anchor.defaultProps = {
   href: '',
+  target: '_self',
   baseUrl: '/',
 };
 
 module.exports = sanitizeSchema => {
   // This is for our custom link formats
-  sanitizeSchema.protocols.href.push('doc', 'ref', 'blog', 'changelog', 'page');
+  sanitizeSchema.protocols.href.push('doc', 'target', 'ref', 'blog', 'changelog', 'page');
 
   return props => (
     <BaseUrlContext.Consumer>

--- a/packages/markdown/components/Anchor.jsx
+++ b/packages/markdown/components/Anchor.jsx
@@ -47,7 +47,7 @@ function docLink(href) {
 function Anchor(props) {
   const { href, target, baseUrl, children } = props;
   return (
-    <a target={target} href={getHref(href, baseUrl)} {...docLink(href)}>
+    <a href={getHref(href, baseUrl)} target={target} {...docLink(href)}>
       {children}
     </a>
   );


### PR DESCRIPTION
Writing a link with a `[target]` attribute should render, well... a link with a `[target]` attribute, obviously... 