### PR TITLE
fix: Backport support for multi media types to legacy Manual APIs

### DIFF
--- a/packages/api-explorer/__tests__/lib/upgrade-legacy-responses.test.js
+++ b/packages/api-explorer/__tests__/lib/upgrade-legacy-responses.test.js
@@ -1,0 +1,102 @@
+const upgradeLegacyResponses = require('../../src/lib/upgrade-legacy-responses');
+
+function encodeJsonExample(json) {
+  return JSON.stringify(json, undefined, 2);
+}
+
+describe('upgradeLegacyResponses', () => {
+  it('should return codes array for a legacy response shape', () => {
+    const encodedExample = {
+      meta: {
+        status_code: 200,
+        status: 'OK',
+      },
+      data: [],
+    };
+
+    const response = [
+      {
+        code: encodedExample,
+        language: 'json',
+        name: '',
+        status: 200,
+      },
+    ];
+
+    expect(upgradeLegacyResponses(response)).toEqual([
+      {
+        languages: [
+          {
+            code: encodedExample,
+            language: 'json',
+            multipleExamples: false,
+          },
+        ],
+        status: 200,
+      },
+    ]);
+  });
+
+  it('should return codes array for legacy response shape that has multiple examples', () => {
+    const response = [
+      {
+        code: encodeJsonExample({
+          meta: {
+            status_code: 200,
+            status: 'OK',
+          },
+          data: [],
+        }),
+        language: 'json',
+        name: 'OK',
+        status: 200,
+      },
+      {
+        code: encodeJsonExample({
+          meta: {
+            status_code: 200,
+            status: 'ALL OK',
+          },
+          data: [],
+        }),
+        language: 'json',
+        name: '',
+        status: 200,
+      },
+    ];
+
+    expect(upgradeLegacyResponses(response)).toEqual([
+      {
+        languages: [
+          {
+            code: false,
+            language: 'json',
+            multipleExamples: [
+              {
+                label: 'OK',
+                code: encodeJsonExample({
+                  meta: {
+                    status_code: 200,
+                    status: 'OK',
+                  },
+                  data: [],
+                }),
+              },
+              {
+                label: 'json',
+                code: encodeJsonExample({
+                  meta: {
+                    status_code: 200,
+                    status: 'ALL OK',
+                  },
+                  data: [],
+                }),
+              },
+            ],
+          },
+        ],
+        status: 200,
+      },
+    ]);
+  });
+});

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -30,7 +30,7 @@
     "prettier": "prettier --list-different \"./**/**.{js,jsx}\"",
     "prettier:write": "prettier --write \"./**/**.{js,jsx}\"",
     "test": "jest --coverage --runInBand",
-    "watch": "webpack -w"
+    "watch": "webpack -w --progress"
   },
   "publishConfig": {
     "registry": "http://registry.npmjs.org",

--- a/packages/api-explorer/src/EndpointErrorBoundary.jsx
+++ b/packages/api-explorer/src/EndpointErrorBoundary.jsx
@@ -18,17 +18,14 @@ class EndpointErrorBoundary extends React.Component {
 
   render() {
     if (this.state.error) {
-      const mailTo = (
-        <a href="mailto:support@readme.io?subject=API Explorer Error">support@readme.io</a>
-      );
-
       return (
         <div className="hub-reference-section">
           <div className="hub-reference-left" style={{ paddingLeft: '2%' }}>
             <h3>
               There was an error rendering this endpoint. If you are the owner of this project
-              please contact
-              {` ${mailTo} with the following error:`}
+              please contact&nbsp;
+              <a href="mailto:support@readme.io?subject=API Explorer Error">support@readme.io</a>
+              &nbsp;with the following error:
             </h3>
             <BoundaryStackTrace error={this.state.error} info={this.state.info} />
           </div>

--- a/packages/api-explorer/src/ErrorBoundary.jsx
+++ b/packages/api-explorer/src/ErrorBoundary.jsx
@@ -18,16 +18,13 @@ class ErrorBoundary extends React.Component {
 
   render() {
     if (this.state.error) {
-      const mailTo = (
-        <a href="mailto:support@readme.io?subject=API Explorer Error">support@readme.io</a>
-      );
-
       return (
         <div className="render-error" style={{ paddingLeft: '2%', width: '75%' }}>
           <h3>
             There was an error rendering the API Explorer. If you are the owner of this project
-            please contact
-            {` ${mailTo} with the following error:`}
+            please contact&nbsp;
+            <a href="mailto:support@readme.io?subject=API Explorer Error">support@readme.io</a>
+            &nbsp;with the following error:
           </h3>
           <BoundaryStackTrace error={this.state.error} info={this.state.info} />
         </div>

--- a/packages/api-explorer/src/lib/upgrade-legacy-responses.js
+++ b/packages/api-explorer/src/lib/upgrade-legacy-responses.js
@@ -1,0 +1,68 @@
+/**
+ * With https://github.com/readmeio/api-explorer/pull/312 we changed the shape of response
+ * examples, but unfortunately APIs that are manually documented in ReadMe are still in the
+ * legacy shape so we need to adhoc rewrite them to fit this new work.
+ *
+ * Once we do away with our legacy manual API documentation system and move to OAS for everything,
+ * this code can be removed.
+ *
+ * @param {array} responses
+ * @returns
+ */
+module.exports = responses => {
+  const codes = {};
+
+  responses.forEach(response => {
+    if (typeof codes[response.status] === 'undefined') {
+      codes[response.status] = {
+        languages: {},
+      };
+    }
+
+    if (typeof codes[response.status].languages[response.language] === 'undefined') {
+      codes[response.status].languages[response.language] = [];
+    }
+
+    codes[response.status].languages[response.language].push({
+      label: response.name,
+      code: response.code,
+    });
+  });
+
+  return Object.keys(codes)
+    .map(status => {
+      const data = codes[status];
+      const languages = [];
+
+      Object.keys(data.languages).map(language => {
+        if (data.languages[language].length === 1) {
+          languages.push({
+            code: data.languages[language][0].code,
+            language,
+            multipleExamples: false,
+          });
+
+          return true;
+        }
+
+        languages.push({
+          code: false,
+          language,
+          multipleExamples: data.languages[language].map(l => {
+            return {
+              label: l.label !== '' ? l.label : language,
+              code: l.code,
+            };
+          }),
+        });
+
+        return true;
+      });
+
+      return {
+        status: parseInt(status, 10),
+        languages,
+      };
+    })
+    .filter(Boolean);
+};


### PR DESCRIPTION
### Problem
When we shipped https://github.com/readmeio/api-explorer/pull/312 two weeks ago, it inadverantly broke all APIs that were manually documented through our manual editor because those APIs have their languages (media types) as a `language` property, but we're now building up (via the code shower utility) a `languages` array.

Since the explorer now expects `languages` to be present, all manually documented APIs were crashing.

### Fix
Since changing the shape of this data would require a large database migration, and we're currently in the process of redoing our manual editor to be OAS first (which will the code shower utility already handles), I've decided to write some adhoc code to upgrade these response examples on the fly to the new, expected, format.