### PR TITLE
If we encounter "mixed type" as a type, convert it to "string"

### DIFF
--- a/example/swagger-files/types.json
+++ b/example/swagger-files/types.json
@@ -75,6 +75,9 @@
                     "enum": ["available", "pending", "sold"],
                     "default": "available"
                   },
+                  "mixed type (unsupported in the OAS, but should be rendered as a string)": {
+                    "type": "mixed type"
+                  },
                   "integer": {
                     "type": "integer",
                     "format": "int64",

--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -186,6 +186,12 @@ function testNumberClass(schema) {
   });
 }
 
+test('should convert `mixed type` to string', () => {
+  const params = renderParams({ type: 'mixed type' });
+
+  expect(params.find(`.field-string`).length).toBe(1);
+});
+
 testNumberClass({ type: 'integer', format: 'int8' });
 testNumberClass({ type: 'integer', format: 'uint8' });
 testNumberClass({ type: 'integer', format: 'int16' });

--- a/packages/api-explorer/src/form-components/SchemaField.jsx
+++ b/packages/api-explorer/src/form-components/SchemaField.jsx
@@ -66,6 +66,14 @@ function SchemaField(props) {
     props.schema.enumNames = ['true', 'false'];
     return <BaseSchemaField {...props} uiSchema={{ 'ui:widget': 'select' }} />;
   }
+
+  // The current ReadMe manual API editor saves mixed types as "mixed type", which isn't a real type
+  // that's supported by the OAS. Since we don't have knowledge as to what those types are, let's
+  // just convert it to a string so the parameter will at least render out.
+  if (props.schema.type === 'mixed type') {
+    props.schema.type = 'string';
+  }
+
   return <BaseSchemaField {...props} />;
 }
 


### PR DESCRIPTION
This will resolve issues where if a customer documents a parameter as "mixed type" in our manual editor, we'll no longer error when rendering that parameter as "mixed type" isn't a valid OAS type.

See https://docs.robinpowered.com/reference#get-organization for a production example of this currently failing.