### PR TITLE
Fix/syntax highlighter

### DIFF
--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@readme/api-explorer",
   "description": "UI components for the API explorer",
-  "version": "4.10.2",
+  "version": "4.10.3",
   "main": "dist/index.js",
   "dependencies": {
     "@readme/markdown": "^4.10.0",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@readme/markdown": "^4.10.0",
     "@readme/oas-extensions": "^4.10.0",
-    "@readme/syntax-highlighter": "^4.10.0",
+    "@readme/syntax-highlighter": "^4.10.1",
     "@readme/variable": "^4.10.0",
     "classnames": "^2.2.5",
     "fetch-har": "^2.0.0",

--- a/packages/api-explorer/src/CodeSample.jsx
+++ b/packages/api-explorer/src/CodeSample.jsx
@@ -72,7 +72,7 @@ class CodeSample extends React.Component {
                   key={key} // eslint-disable-line react/no-array-index-key
                   style={{ display: selected ? 'block' : '' }}
                 >
-                  {syntaxHighlighter(example.code || '', example.language, { dark: true })}
+                  {syntaxHighlighter(example.code, example.language, { dark: true })}
                 </pre>
               </div>
             );

--- a/packages/syntax-highlighter/index.js
+++ b/packages/syntax-highlighter/index.js
@@ -7,7 +7,7 @@ module.exports = (code, lang, opts = { dark: false, tokenizeVariables: false }) 
     {
       className: opts.dark ? 'cm-s-tomorrow-night' : 'cm-s-neo',
     },
-    codemirror(code || '', lang, opts),
+    codemirror(typeof code === 'string' ? code : '', lang, opts),
   );
 
 module.exports.uppercase = require('./uppercase');

--- a/packages/syntax-highlighter/index.js
+++ b/packages/syntax-highlighter/index.js
@@ -7,7 +7,7 @@ module.exports = (code, lang, opts = { dark: false, tokenizeVariables: false }) 
     {
       className: opts.dark ? 'cm-s-tomorrow-night' : 'cm-s-neo',
     },
-    codemirror(code, lang, opts),
+    codemirror(code || '', lang, opts),
   );
 
 module.exports.uppercase = require('./uppercase');

--- a/packages/syntax-highlighter/package.json
+++ b/packages/syntax-highlighter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@readme/syntax-highlighter",
   "description": "Syntax highlighter used on ReadMe.io",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "dependencies": {
     "@readme/variable": "^4.10.0",
     "codemirror": "^5.48.2",

--- a/packages/syntax-highlighter/test/index.test.js
+++ b/packages/syntax-highlighter/test/index.test.js
@@ -10,6 +10,10 @@ test('should highlight a block of code', () => {
   );
 });
 
+test('should work when passed a non-string value', () => {
+  expect(() => syntaxHighlighter(false, 'text')).not.toThrow();
+});
+
 test('should sanitize plain text language', () => {
   expect(shallow(syntaxHighlighter('& < > " \' /', 'text')).html()).toContain(
     '&amp; &lt; &gt; &quot; &#x27; /',


### PR DESCRIPTION
A value of `false` is being passed down into the API explorer via code-examples. We need to make sure that CodeMirror never is passed down anything other than a string.