### PR TITLE
Fix Multi-Example Display Logic

### DIFF
--- a/packages/api-explorer/src/ResponseExample.jsx
+++ b/packages/api-explorer/src/ResponseExample.jsx
@@ -173,10 +173,9 @@ class ResponseExample extends React.Component {
     }
 
     const hasExamples = examples.find(e => {
-      return e.languages.find(ee => ee.code && ee.code !== '{}' || 'multipleExamples' in ee);
+      return e.languages.find(ee => (ee.code && ee.code !== '{}') || 'multipleExamples' in ee);
     });
 
-    
     return (
       <div className="hub-reference-results-examples code-sample">
         {examples && examples.length > 0 && hasExamples && (

--- a/packages/api-explorer/src/ResponseExample.jsx
+++ b/packages/api-explorer/src/ResponseExample.jsx
@@ -173,9 +173,10 @@ class ResponseExample extends React.Component {
     }
 
     const hasExamples = examples.find(e => {
-      return e.languages.find(ee => ee.code && ee.code !== '{}');
+      return e.languages.find(ee => ee.code && ee.code !== '{}' || 'multipleExamples' in ee);
     });
 
+    
     return (
       <div className="hub-reference-results-examples code-sample">
         {examples && examples.length > 0 && hasExamples && (


### PR DESCRIPTION
|🎟 [Asana](https://app.asana.com/0/681252538274980/1147390971548626/f)|
|:--:|

Endpoints with duplicate examples of the same response code _and_ language type would not  show in the explorer. I fixed this by adding a check for `multipleExamples` entry in the `hasExamples` logic:

https://github.com/readmeio/api-explorer/blob/087219de968bd1e8487411af8510d59fd1d8e12b/packages/api-explorer/src/ResponseExample.jsx#L175-L177