### PR TITLE
Fix issue where responses stored as a $ref wouldn't be fully loaded

### DIFF
--- a/example/swagger-files/examples.json
+++ b/example/swagger-files/examples.json
@@ -62,17 +62,7 @@
             }
           },
           "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/xml": {
-                "examples": {
-                  "response": {
-                    "value":
-                      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
-                  }
-                }
-              }
-            }
+            "$ref": "#/components/responses/400-Response-Ref"
           }
         },
         "summary": "Update Password"
@@ -81,7 +71,21 @@
   },
   "components": {
     "schemas": {},
-    "responses": {},
+    "responses": {
+      "400-Response-Ref": {
+        "description": "Validation failed",
+        "content": {
+          "application/xml": {
+            "examples": {
+              "response": {
+                "value":
+                  "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
+              }
+            }
+          }
+        }
+      }
+    },
     "parameters": {},
     "examples": {},
     "requestBodies": {},

--- a/packages/api-explorer/__tests__/ExampleTabs.test.jsx
+++ b/packages/api-explorer/__tests__/ExampleTabs.test.jsx
@@ -8,7 +8,7 @@ const showCodeResults = require('../src/lib/show-code-results');
 
 const oas = new Oas(example);
 const props = {
-  examples: showCodeResults(oas.operation('/results', 'get')),
+  examples: showCodeResults(oas.operation('/results', 'get'), oas),
   selected: 0,
   setExampleTab: () => {},
 };

--- a/packages/api-explorer/__tests__/ResponseSchema.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseSchema.test.jsx
@@ -11,6 +11,7 @@ const oas = new Oas(petstore);
 const props = {
   operation: oas.operation('/pet/{petId}', 'get'),
   oas,
+  theme: 'light',
 };
 
 test('should display a header with a dropdown', () => {
@@ -44,13 +45,13 @@ test('should work if there are no responses', () => {
   // Need to create a new operation without any responses
   const responseSchema = shallow(
     <ResponseSchema
+      {...props}
       operation={
         new Operation({}, '/', 'get', {
           ...oas.operation('/pet/{petId}', 'get'),
           responses: undefined,
         })
       }
-      oas={oas}
     />,
   );
 
@@ -60,10 +61,10 @@ test('should work if there are no responses', () => {
 test('should work if responses is an empty object', () => {
   const responseSchema = shallow(
     <ResponseSchema
+      {...props}
       operation={
         new Operation({}, '/', 'get', { ...oas.operation('/pet/{petId}', 'get'), responses: {} })
       }
-      oas={oas}
     />,
   );
 
@@ -77,11 +78,11 @@ test('should contain ResponseSchemaBody element if $ref exist for "application/j
 
 test('should not contain ResponseSchemaBody element if $ref not exist', () => {
   const testProps = {
+    ...props,
     operation: new Operation({}, '/', 'get', {
       ...oas.operation('/pet/{petId}', 'get'),
       responses: {},
     }),
-    oas,
   };
   const responseSchema = shallow(<ResponseSchema {...testProps} />);
   expect(responseSchema.find('ResponseSchemaBody').length).toBe(0);
@@ -89,6 +90,7 @@ test('should not contain ResponseSchemaBody element if $ref not exist', () => {
 
 test('should render schema from "application/json"', () => {
   const testProps = {
+    ...props,
     operation: new Operation({}, '/', 'get', {
       ...oas.operation('/pet/findByTags', 'get'),
       responses: {
@@ -104,7 +106,6 @@ test('should render schema from "application/json"', () => {
         },
       },
     }),
-    oas,
   };
 
   const responseSchema = shallow(<ResponseSchema {...testProps} />);
@@ -113,6 +114,7 @@ test('should render schema from "application/json"', () => {
 
 test('should contain ResponseSchemaBody element if $ref exist for "application/xml"', () => {
   const testProps = {
+    ...props,
     operation: new Operation(oas, '/', 'get', {
       ...oas.operation('/pet/{petId}', 'get'),
       responses: {
@@ -128,7 +130,6 @@ test('should contain ResponseSchemaBody element if $ref exist for "application/x
         },
       },
     }),
-    oas,
   };
 
   const responseSchema = shallow(<ResponseSchema {...testProps} />);
@@ -140,6 +141,7 @@ test('should allow $ref lookup at the responses object level', () => {
     components: {
       responses: {
         Response: {
+          description: 'This is a description for a response.',
           content: {
             'application/json': {
               schema: {
@@ -170,6 +172,8 @@ test('should allow $ref lookup at the responses object level', () => {
       operation={testOas.operation('/ref-responses', 'get')}
     />,
   );
+
+  expect(responseSchema.find('.desc').length).toBe(1);
   expect(responseSchema.find('ResponseSchemaBody').length).toBe(1);
 });
 
@@ -186,6 +190,7 @@ test('should change selectedStatus in component', () => {
 
 test('should not break if schema property missing', () => {
   const testProps = {
+    ...props,
     operation: new Operation({}, '/', 'get', {
       ...oas.operation('/pet/findByTags', 'get'),
       responses: {
@@ -198,7 +203,6 @@ test('should not break if schema property missing', () => {
         },
       },
     }),
-    oas,
   };
 
   const responseSchema = shallow(<ResponseSchema {...testProps} />);

--- a/packages/api-explorer/__tests__/ResponseTabs.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseTabs.test.jsx
@@ -11,6 +11,7 @@ const Oas = require('../src/lib/Oas');
 
 const oas = new Oas(petstore);
 const props = {
+  oas,
   operation: oas.operation('/pet', 'post'),
   responseTab: 'result',
   setTab: () => {},
@@ -69,10 +70,12 @@ test('should call setTab() on click', () => {
 
 test('should call hideResults() on click', () => {
   const hideResults = jest.fn();
+  const exampleResultsOas = new Oas(exampleResults);
   const exampleTabs = shallow(
     <ResponseTabs
       {...props}
-      operation={new Oas(exampleResults).operation('/results', 'get')}
+      oas={exampleResultsOas}
+      operation={exampleResultsOas.operation('/results', 'get')}
       hideResults={hideResults}
     />,
   );

--- a/packages/api-explorer/__tests__/fixtures/example-results/oas.json
+++ b/packages/api-explorer/__tests__/fixtures/example-results/oas.json
@@ -32,7 +32,17 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/400-Response-Ref"
+            "description": "Validation failed",
+            "content": {
+              "application/xml": {
+                "examples": {
+                  "response": {
+                    "value":
+                      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Update Password"
@@ -173,6 +183,34 @@
     "/nolang": {
       "get": {
         "description": ""
+      }
+    },
+    "/ref-response-example": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "response": {
+                    "value": {
+                      "user": {
+                        "email": "test@example.com",
+                        "name": "Test user name"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400-Response-Ref"
+          }
+        },
+        "summary": "Update Password"
       }
     }
   },

--- a/packages/api-explorer/__tests__/fixtures/example-results/oas.json
+++ b/packages/api-explorer/__tests__/fixtures/example-results/oas.json
@@ -32,17 +32,7 @@
             }
           },
           "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/xml": {
-                "examples": {
-                  "response": {
-                    "value":
-                      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
-                  }
-                }
-              }
-            }
+            "$ref": "#/components/responses/400-Response-Ref"
           }
         },
         "summary": "Update Password"
@@ -188,7 +178,21 @@
   },
   "components": {
     "schemas": {},
-    "responses": {},
+    "responses": {
+      "400-Response-Ref": {
+        "description": "Validation failed",
+        "content": {
+          "application/xml": {
+            "examples": {
+              "response": {
+                "value":
+                  "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
+              }
+            }
+          }
+        }
+      }
+    },
     "parameters": {},
     "examples": {},
     "requestBodies": {},

--- a/packages/api-explorer/__tests__/lib/create-code-shower.test.js
+++ b/packages/api-explorer/__tests__/lib/create-code-shower.test.js
@@ -13,9 +13,18 @@ function encodeJsonExample(json) {
 }
 
 describe('createCodeShower', () => {
-  it('should return codes array if there are examples for the operation', () => {
-    const operation = oas.operation('/results', 'get');
-
+  test.each([
+    [
+      'should return codes array if there are examples for the operation',
+      oas.operation('/results', 'get'),
+    ],
+    [
+      // The response for this should be identical to `GET /results`, just the way they're formed in
+      // the OAS is different.
+      'should return codes array if there are examples for the operation, and one of the examples is a $ref',
+      oas.operation('/ref-response-example', 'get'),
+    ],
+  ])('%s', (testcase, operation) => {
     expect(createCodeShower(operation, oas)).toEqual([
       {
         languages: [

--- a/packages/api-explorer/__tests__/lib/create-code-shower.test.js
+++ b/packages/api-explorer/__tests__/lib/create-code-shower.test.js
@@ -16,7 +16,7 @@ describe('createCodeShower', () => {
   it('should return codes array if there are examples for the operation', () => {
     const operation = oas.operation('/results', 'get');
 
-    expect(createCodeShower(operation)).toEqual([
+    expect(createCodeShower(operation, oas)).toEqual([
       {
         languages: [
           {
@@ -49,7 +49,7 @@ describe('createCodeShower', () => {
   it('should not set `multipleExamples` if there is just a single example', () => {
     const operation = oas.operation('/single-media-type-single-example', 'get');
 
-    expect(createCodeShower(operation)).toEqual([
+    expect(createCodeShower(operation, oas)).toEqual([
       {
         languages: [
           {
@@ -83,7 +83,7 @@ describe('createCodeShower', () => {
   it('should return multiple nested examples if there are multiple response media types types for the operation', () => {
     const operation = oas.operation('/multi-media-types-multiple-examples', 'get');
 
-    expect(createCodeShower(operation)).toEqual([
+    expect(createCodeShower(operation, oas)).toEqual([
       {
         status: '200',
         languages: [
@@ -136,16 +136,16 @@ describe('createCodeShower', () => {
 
   it('should return early if there is no example', () => {
     const operation = oas2.operation('/pet/findByStatus', 'get');
-    expect(createCodeShower(operation)).toEqual([]);
+    expect(createCodeShower(operation, oas)).toEqual([]);
   });
 
   it('should return early if there is no response', () => {
     const operation = oas.operation('/nolang', 'get');
-    expect(createCodeShower(operation)).toEqual([]);
+    expect(createCodeShower(operation, oas)).toEqual([]);
   });
 
   it('should return codes if type is not `results`', () => {
     const operation = oas.operation('/results', 'get');
-    expect(createCodeShower2(operation)).toEqual([]);
+    expect(createCodeShower2(operation, oas)).toEqual([]);
   });
 });

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -27,8 +27,7 @@
     "inspect": "jsinspect",
     "lint": "eslint -f unix . --ext js --ext jsx",
     "pretest": "npm run lint && npm run inspect && npm run prettier",
-    "prettier": "prettier --list-different \"./**/**.{js,jsx}\"",
-    "prettier:write": "prettier --write \"./**/**.{js,jsx}\"",
+    "prettier": "prettier --list-different --write \"./**/**.{js,jsx}\"",
     "test": "jest --coverage --runInBand",
     "watch": "webpack -w --progress"
   },

--- a/packages/api-explorer/src/ResponseExample.jsx
+++ b/packages/api-explorer/src/ResponseExample.jsx
@@ -169,7 +169,7 @@ class ResponseExample extends React.Component {
       // legacy shape so we need to adhoc rewrite them to fit this new work.
       examples = upgradeLegacyResponses(exampleResponses);
     } else {
-      examples = showCodeResults(operation);
+      examples = showCodeResults(operation, oas);
     }
 
     const hasExamples = examples.find(e => {

--- a/packages/api-explorer/src/ResponseSchema.jsx
+++ b/packages/api-explorer/src/ResponseSchema.jsx
@@ -87,6 +87,14 @@ class ResponseSchema extends React.Component {
     const { operation, oas } = this.props;
     if (!operation.responses || Object.keys(operation.responses).length === 0) return null;
     const schema = this.getSchema(operation);
+
+    let response = operation.responses[this.state.selectedStatus];
+
+    // @todo This should really be called higher up when the OAS is processed within the Doc component.
+    if (response.$ref) {
+      response = findSchemaDefinition(response.$ref, oas);
+    }
+
     return (
       <div
         className={classNames('hub-reference-response-definitions', {
@@ -95,11 +103,7 @@ class ResponseSchema extends React.Component {
       >
         {this.renderHeader()}
         <div className="response-schema">
-          {operation.responses[this.state.selectedStatus].description && (
-            <div className="desc">
-              {markdown(operation.responses[this.state.selectedStatus].description)}
-            </div>
-          )}
+          {response.description && <div className="desc">{markdown(response.description)}</div>}
           {schema && <ResponseSchemaBody schema={schema} oas={oas} />}
         </div>
       </div>

--- a/packages/api-explorer/src/ResponseTabs.jsx
+++ b/packages/api-explorer/src/ResponseTabs.jsx
@@ -4,8 +4,9 @@ const showCodeResults = require('./lib/show-code-results');
 const IconStatus = require('./IconStatus');
 const Tab = require('./Tab');
 const { Operation } = require('./lib/Oas');
+const Oas = require('./lib/Oas');
 
-function ResponseTabs({ result, operation, responseTab, setTab, hideResults }) {
+function ResponseTabs({ result, oas, operation, responseTab, setTab, hideResults }) {
   return (
     <ul className="code-sample-tabs hub-reference-results-header">
       <Tab
@@ -28,7 +29,7 @@ function ResponseTabs({ result, operation, responseTab, setTab, hideResults }) {
         Metadata
       </Tab>
 
-      {showCodeResults(operation).length > 0 && (
+      {showCodeResults(operation, oas).length > 0 && (
         // eslint-disable-next-line jsx-a11y/anchor-is-valid
         <a
           className="hub-reference-results-back pull-right"
@@ -49,6 +50,7 @@ ResponseTabs.propTypes = {
   result: PropTypes.shape({
     status: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   }),
+  oas: PropTypes.instanceOf(Oas).isRequired,
   operation: PropTypes.instanceOf(Operation).isRequired,
   responseTab: PropTypes.string.isRequired,
   setTab: PropTypes.func.isRequired,

--- a/packages/api-explorer/src/lib/create-code-shower.js
+++ b/packages/api-explorer/src/lib/create-code-shower.js
@@ -1,3 +1,5 @@
+const findSchemaDefinition = require('./find-schema-definition');
+
 function getLanguage(response) {
   return response.content ? Object.keys(response.content)[0] : '';
 }
@@ -58,7 +60,7 @@ function constructLanguage(language, response, example) {
 }
 
 module.exports = type => {
-  return pathOperation => {
+  return (pathOperation, oas) => {
     // Only working for results
     if (type !== 'results') return [];
 
@@ -68,7 +70,12 @@ module.exports = type => {
 
     const codes = Object.keys(pathOperation.responses || {})
       .map(status => {
-        const response = pathOperation.responses[status];
+        let response = pathOperation.responses[status];
+
+        // @todo This should really be called higher up when the OAS is processed within the Doc component.
+        if (response.$ref) {
+          response = findSchemaDefinition(response.$ref, oas);
+        }
 
         // @todo We should really be calling these `mediaTypes`, not `languages`.
         const languages = [];


### PR DESCRIPTION
When a response is stored within a `$ref` component, the explorer wouldn't display it in response tab window, and the description (if present) would be missing from the response schema body box.

![Screen Shot 2019-11-05 at 4 48 12 PM](https://user-images.githubusercontent.com/33762/68258736-7f9ef780-ffec-11e9-8aa9-daa5c2bd4b35.png)

With this fix in place, `$ref` responses appear as they would if they weren't loaded as a component:

![Screen Shot 2019-11-05 at 4 50 01 PM](https://user-images.githubusercontent.com/33762/68258764-980f1200-ffec-11e9-9398-489f18e9f665.png)
