### PR TITLE
chore: instituting new code standards on prop ordering

### DIFF
--- a/packages/api-explorer/.eslintrc
+++ b/packages/api-explorer/.eslintrc
@@ -33,6 +33,9 @@
         "Params",
         "TextArea"
       ]
-    }]
+    }],
+    "react/jsx-sort-default-props": 2,
+    "react/jsx-sort-props": 2,
+    "react/sort-prop-types": 2
   }
 }

--- a/packages/api-explorer/__tests__/AuthBox.test.jsx
+++ b/packages/api-explorer/__tests__/AuthBox.test.jsx
@@ -8,13 +8,13 @@ const multipleSecurities = require('./fixtures/multiple-securities/oas');
 const oas = new Oas(multipleSecurities);
 
 const props = {
+  auth: {},
+  oauth: false,
+  open: false,
   operation: oas.operation('/or-security', 'post'),
   onChange: () => {},
   onSubmit: () => {},
   toggle: () => {},
-  open: false,
-  oauth: false,
-  auth: {},
 };
 
 test('should not display if no auth', () => {

--- a/packages/api-explorer/__tests__/CodeSample.test.jsx
+++ b/packages/api-explorer/__tests__/CodeSample.test.jsx
@@ -7,10 +7,10 @@ const Oas = require('../src/lib/Oas');
 
 const { Operation } = Oas;
 const props = {
-  setLanguage: () => {},
-  operation: new Operation({}, '/pet/{id}', 'get'),
   formData: {},
   language: 'node',
+  setLanguage: () => {},
+  operation: new Operation({}, '/pet/{id}', 'get'),
 };
 
 describe('tabs', () => {

--- a/packages/api-explorer/__tests__/Doc.test.jsx
+++ b/packages/api-explorer/__tests__/Doc.test.jsx
@@ -10,22 +10,22 @@ const oas = require('./fixtures/petstore/circular-oas');
 const multipleSecurities = require('./fixtures/multiple-securities/oas');
 
 const props = {
+  auth: {},
   doc: {
-    title: 'Title',
-    slug: 'slug',
-    type: 'endpoint',
-    swagger: { path: '/pet/{petId}' },
     api: { method: 'get' },
     formData: { path: { petId: '1' }, auth: { api_key: '' } },
     onSubmit: () => {},
+    slug: 'slug',
+    swagger: { path: '/pet/{petId}' },
+    title: 'Title',
+    type: 'endpoint',
   },
-  oas,
-  setLanguage: () => {},
   language: 'node',
-  suggestedEdits: false,
+  oas,
   oauth: false,
   onAuthChange: () => {},
-  auth: {},
+  setLanguage: () => {},
+  suggestedEdits: false,
   tryItMetrics: () => {},
 };
 
@@ -100,14 +100,14 @@ test('should work without a doc.swagger/doc.path/oas', () => {
   const doc = { title: 'title', slug: 'slug', type: 'basic' };
   const docComponent = shallow(
     <Doc
-      doc={doc}
-      setLanguage={() => {}}
-      language="node"
-      suggestedEdits
-      oauth={false}
-      tryItMetrics={() => {}}
-      onAuthChange={() => {}}
       auth={{}}
+      doc={doc}
+      language="node"
+      oauth={false}
+      onAuthChange={() => {}}
+      setLanguage={() => {}}
+      suggestedEdits
+      tryItMetrics={() => {}}
     />,
   );
   expect(docComponent.find('Waypoint').length).toBe(1);
@@ -122,15 +122,15 @@ test('should still display `Content` with column-style layout', () => {
   const doc = { title: 'title', slug: 'slug', type: 'basic' };
   const docComponent = shallow(
     <Doc
-      doc={doc}
-      setLanguage={() => {}}
-      language="node"
-      suggestedEdits
       appearance={{ referenceLayout: 'column' }}
-      oauth={false}
-      tryItMetrics={() => {}}
-      onAuthChange={() => {}}
       auth={{}}
+      doc={doc}
+      language="node"
+      oauth={false}
+      onAuthChange={() => {}}
+      setLanguage={() => {}}
+      suggestedEdits
+      tryItMetrics={() => {}}
     />,
   );
   docComponent.setState({ showEndpoint: true });
@@ -171,6 +171,7 @@ describe('onSubmit', () => {
 
   test('should make request on Submit', () => {
     const props2 = {
+      auth: { petstore_auth: 'api-key' },
       doc: {
         title: 'Title',
         slug: 'slug',
@@ -185,11 +186,10 @@ describe('onSubmit', () => {
         },
         onSubmit: () => {},
       },
-      oas,
-      setLanguage: () => {},
       language: 'node',
+      oas,
       oauth: false,
-      auth: { petstore_auth: 'api-key' },
+      setLanguage: () => {},
     };
 
     const { fetch } = window;
@@ -253,10 +253,10 @@ describe('onSubmit', () => {
     const doc = mount(
       <Doc
         {...props}
+        auth={{ api_key: 'api-key' }}
         tryItMetrics={() => {
           called = true;
         }}
-        auth={{ api_key: 'api-key' }}
       />,
     );
 
@@ -374,7 +374,6 @@ test('should output with an error message if the endpoint fails to load', () => 
   const doc = mount(
     <Doc
       {...props}
-      oas={brokenOas}
       doc={{
         title: 'title',
         slug: 'slug',
@@ -382,6 +381,7 @@ test('should output with an error message if the endpoint fails to load', () => 
         swagger: { path: '/path' },
         api: { method: 'post' },
       }}
+      oas={brokenOas}
     />,
   );
 

--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -19,11 +19,11 @@ const booleanOas = new Oas(boolean);
 const stringOas = new Oas(string);
 
 const props = {
-  oas,
-  operation,
   formData: {},
+  oas,
   onChange: () => {},
   onSubmit: () => {},
+  operation,
 };
 
 const Params = createParams(oas);
@@ -177,31 +177,30 @@ function renderParams(schema, customProps) {
   );
 }
 
-function testNumberClass(schema) {
-  const clonedSchema = JSON.parse(JSON.stringify(schema));
-  test(`${JSON.stringify(schema)} should have correct class`, () => {
-    const params = renderParams(schema);
-
-    expect(params.find(`.field-${clonedSchema.type}.field-${clonedSchema.format}`).length).toBe(1);
-  });
-}
-
 test('should convert `mixed type` to string', () => {
   const params = renderParams({ type: 'mixed type' });
 
   expect(params.find(`.field-string`).length).toBe(1);
 });
 
-testNumberClass({ type: 'integer', format: 'int8' });
-testNumberClass({ type: 'integer', format: 'uint8' });
-testNumberClass({ type: 'integer', format: 'int16' });
-testNumberClass({ type: 'integer', format: 'uint16' });
-testNumberClass({ type: 'integer', format: 'int32' });
-testNumberClass({ type: 'integer', format: 'uint32' });
-testNumberClass({ type: 'integer', format: 'int64' });
-testNumberClass({ type: 'integer', format: 'uint64' });
-testNumberClass({ type: 'number', format: 'float' });
-testNumberClass({ type: 'number', format: 'double' });
+test.each([
+  ['integer', 'int8'],
+  ['integer', 'uint8'],
+  ['integer', 'int16'],
+  ['integer', 'uint16'],
+  ['integer', 'int32'],
+  ['integer', 'uint32'],
+  ['integer', 'int64'],
+  ['integer', 'uint64'],
+  ['number', 'float'],
+  ['number', 'double'],
+])('{ type: %s, format: %s } should have correct class', (type, format) => {
+  const schema = { type, format };
+  const clonedSchema = JSON.parse(JSON.stringify(schema));
+  const params = renderParams(schema);
+
+  expect(params.find(`.field-${clonedSchema.type}.field-${clonedSchema.format}`).length).toBe(1);
+});
 
 test('should not error if `integer|number` are missing `format`', () => {
   expect(() => {

--- a/packages/api-explorer/__tests__/PathUrl.test.jsx
+++ b/packages/api-explorer/__tests__/PathUrl.test.jsx
@@ -11,15 +11,15 @@ const petstore = require('./fixtures/petstore/oas');
 const oas = new Oas(petstore);
 
 const props = {
-  oas,
-  operation: oas.operation('/pet/{petId}', 'get'),
+  apiKey: '',
   dirty: false,
   loading: false,
-  onChange: () => {},
-  toggleAuth: () => {},
-  onSubmit: () => {},
+  oas,
   oauth: false,
-  apiKey: '',
+  onChange: () => {},
+  onSubmit: () => {},
+  operation: oas.operation('/pet/{petId}', 'get'),
+  toggleAuth: () => {},
 };
 
 test('should display the path', () => {
@@ -69,8 +69,8 @@ test('button click should call onSubmit', () => {
   shallow(
     <PathUrl
       {...props}
-      operation={new Operation({}, '/path', 'get', { operationId: '123' })}
       onSubmit={onSubmit}
+      operation={new Operation({}, '/path', 'get', { operationId: '123' })}
     />,
   )
     .find('button[type="submit"]')

--- a/packages/api-explorer/__tests__/Response.test.jsx
+++ b/packages/api-explorer/__tests__/Response.test.jsx
@@ -9,12 +9,12 @@ const { Operation } = Oas;
 const oas = new Oas(petstore);
 
 const props = {
-  result: null,
-  operation: new Operation({}, '/pet', 'post'),
   hideResults: () => {},
+  result: null,
   oas,
   oauth: false,
   onChange: () => {},
+  operation: new Operation({}, '/pet', 'post'),
 };
 
 describe('no result', () => {

--- a/packages/api-explorer/__tests__/ResponseBody.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseBody.test.jsx
@@ -11,8 +11,8 @@ const Oas = require('../src/lib/Oas');
 const { Operation } = Oas;
 const oas = new Oas(petstore);
 const props = {
-  operation: new Operation({}, '/pet', 'post'),
   oauth: false,
+  operation: new Operation({}, '/pet', 'post'),
 };
 
 beforeEach(async () => {

--- a/packages/api-explorer/__tests__/ResponseExample.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseExample.test.jsx
@@ -11,10 +11,10 @@ const Oas = require('../src/lib/Oas');
 const oas = new Oas(petstore);
 
 const props = {
-  result: null,
   oas,
-  operation: oas.operation('/pet', 'post'),
   onChange: () => {},
+  operation: oas.operation('/pet', 'post'),
+  result: null,
 };
 
 test('should show no examples if endpoint does not any', () => {

--- a/packages/api-explorer/__tests__/ResponseSchema.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseSchema.test.jsx
@@ -9,8 +9,8 @@ const { Operation } = Oas;
 const oas = new Oas(petstore);
 
 const props = {
-  operation: oas.operation('/pet/{petId}', 'get'),
   oas,
+  operation: oas.operation('/pet/{petId}', 'get'),
   theme: 'light',
 };
 

--- a/packages/api-explorer/__tests__/ResponseTabs.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseTabs.test.jsx
@@ -11,11 +11,11 @@ const Oas = require('../src/lib/Oas');
 
 const oas = new Oas(petstore);
 const props = {
+  hideResults: () => {},
   oas,
   operation: oas.operation('/pet', 'post'),
   responseTab: 'result',
   setTab: () => {},
-  hideResults: () => {},
 };
 
 beforeEach(async () => {
@@ -74,9 +74,9 @@ test('should call hideResults() on click', () => {
   const exampleTabs = shallow(
     <ResponseTabs
       {...props}
+      hideResults={hideResults}
       oas={exampleResultsOas}
       operation={exampleResultsOas.operation('/results', 'get')}
-      hideResults={hideResults}
     />,
   );
 

--- a/packages/api-explorer/__tests__/SecurityInput.test.jsx
+++ b/packages/api-explorer/__tests__/SecurityInput.test.jsx
@@ -3,9 +3,9 @@ const { mount, shallow } = require('enzyme');
 const SecurityInput = require('../src/SecurityInput');
 
 const baseProps = {
-  onChange: () => {},
-  oauth: false,
   auth: {},
+  oauth: false,
+  onChange: () => {},
 };
 
 test('should render an Oauth2 component if type is oauth2', () => {
@@ -48,7 +48,7 @@ describe('oauth2', () => {
 
   test('should disable the input if `oauth=true`', () => {
     const securityInput = mount(
-      <SecurityInput {...props} {...baseProps} oauth auth={{ 'test-auth': 'test' }} />,
+      <SecurityInput {...props} {...baseProps} auth={{ 'test-auth': 'test' }} oauth />,
     );
     expect(securityInput.find('input').prop('disabled')).toBe(true);
   });
@@ -63,7 +63,7 @@ describe('oauth2', () => {
   test('should display api key if set', () => {
     const apiKey = '123456';
     const securityInput = mount(
-      <SecurityInput {...props} {...baseProps} oauth auth={{ 'test-auth': apiKey }} />,
+      <SecurityInput {...props} {...baseProps} auth={{ 'test-auth': apiKey }} oauth />,
     );
 
     expect(securityInput.find('input').prop('value')).toBe(apiKey);
@@ -151,7 +151,7 @@ describe('basic', () => {
     const user = 'user';
     const pass = 'pass';
     const securityInput = mount(
-      <SecurityInput {...props} {...baseProps} oauth auth={{ 'test-basic': { user, pass } }} />,
+      <SecurityInput {...props} {...baseProps} auth={{ 'test-basic': { user, pass } }} oauth />,
     );
 
     expect(securityInput.find('input[name="user"]').prop('value')).toBe(user);

--- a/packages/api-explorer/__tests__/block-types/Embed.test.jsx
+++ b/packages/api-explorer/__tests__/block-types/Embed.test.jsx
@@ -59,7 +59,7 @@ describe('Embed', () => {
     };
     const embedInput = shallow(<Embed block={block} />);
     expect(embedInput.find('strong').html()).toBe(
-      '<strong><img src="http://static.jsbin.com/images/favicon.png" class="favicon" alt=""/><a href="http://jsbin.com/fewilipowi/edit?js,output" target="_new">http://jsbin.com/fewilipowi/edit?js,output</a></strong>',
+      '<strong><img alt="" class="favicon" src="http://static.jsbin.com/images/favicon.png"/><a href="http://jsbin.com/fewilipowi/edit?js,output" target="_new">http://jsbin.com/fewilipowi/edit?js,output</a></strong>',
     );
   });
 });

--- a/packages/api-explorer/__tests__/index.test.jsx
+++ b/packages/api-explorer/__tests__/index.test.jsx
@@ -15,15 +15,15 @@ const docs = createDocs(oas, 'api-setting');
 
 const languages = ['node', 'curl'];
 const props = {
+  appearance: {},
   docs,
+  flags: {},
+  glossaryTerms: [],
   oasFiles: {
     'api-setting': { ...oas, [extensions.SAMPLES_LANGUAGES]: languages },
   },
-  flags: {},
-  appearance: {},
   suggestedEdits: false,
   variables: { user: {}, defaults: [] },
-  glossaryTerms: [],
 };
 
 test('ApiExplorer renders a doc for each', () => {
@@ -132,10 +132,10 @@ describe('oas', () => {
     const explorer = shallow(
       <ApiExplorer
         {...props}
+        docs={[{ ...baseDoc, category: { apiSetting: 'api-setting' } }]}
         oasFiles={{
           'api-setting': oas,
         }}
-        docs={[{ ...baseDoc, category: { apiSetting: 'api-setting' } }]}
       />,
     );
 
@@ -147,10 +147,10 @@ describe('oas', () => {
     const explorer = shallow(
       <ApiExplorer
         {...props}
+        docs={[{ ...baseDoc, api: { method: 'get', apiSetting: { _id: 'api-setting' } } }]}
         oasFiles={{
           'api-setting': oas,
         }}
-        docs={[{ ...baseDoc, api: { method: 'get', apiSetting: { _id: 'api-setting' } } }]}
       />,
     );
 
@@ -161,10 +161,10 @@ describe('oas', () => {
     const explorer = shallow(
       <ApiExplorer
         {...props}
+        docs={[{ ...baseDoc, api: { method: 'get', apiSetting: 'api-setting' } }]}
         oasFiles={{
           'api-setting': oas,
         }}
-        docs={[{ ...baseDoc, api: { method: 'get', apiSetting: 'api-setting' } }]}
       />,
     );
 

--- a/packages/api-explorer/src/AuthBox.jsx
+++ b/packages/api-explorer/src/AuthBox.jsx
@@ -27,11 +27,11 @@ function Securities({ authInputRef, operation, onChange, oauth, auth, onSubmit }
             }
             {securities.map(security => (
               <SecurityInput
+                key={security._key}
                 auth={auth}
-                onChange={onChange}
                 authInputRef={authInputRef}
                 oauth={oauth}
-                key={security._key}
+                onChange={onChange}
                 scheme={security}
               />
             ))}
@@ -58,21 +58,21 @@ function AuthBox({
   return (
     <div className={classNames('hub-auth-dropdown', 'simple-dropdown', { open })}>
       {/* eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label, jsx-a11y/anchor-is-valid */}
-      <a href="#" className="icon icon-user-lock" onClick={toggle} />
+      <a className="icon icon-user-lock" href="#" onClick={toggle} />
 
       <div className="nopad">
         <div className="triangle" />
         <div>
           <Securities
-            authInputRef={authInputRef}
-            operation={operation}
-            oauth={oauth}
             auth={auth}
+            authInputRef={authInputRef}
+            oauth={oauth}
             onChange={onChange}
             onSubmit={e => {
               e.preventDefault();
               onSubmit();
             }}
+            operation={operation}
           />
         </div>
         <div className={classNames('hub-authrequired', { active: needsAuth })}>
@@ -87,22 +87,22 @@ function AuthBox({
 }
 
 AuthBox.propTypes = {
-  operation: PropTypes.instanceOf(Operation).isRequired,
+  auth: PropTypes.shape({}),
   authInputRef: PropTypes.func,
+  needsAuth: PropTypes.bool,
+  oauth: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  toggle: PropTypes.func.isRequired,
-  needsAuth: PropTypes.bool,
   open: PropTypes.bool,
-  oauth: PropTypes.bool.isRequired,
-  auth: PropTypes.shape({}),
+  operation: PropTypes.instanceOf(Operation).isRequired,
+  toggle: PropTypes.func.isRequired,
 };
 
 AuthBox.defaultProps = {
+  auth: {},
+  authInputRef: () => {},
   needsAuth: false,
   open: false,
-  authInputRef: () => {},
-  auth: {},
 };
 
 module.exports = AuthBox;

--- a/packages/api-explorer/src/CodeSample.jsx
+++ b/packages/api-explorer/src/CodeSample.jsx
@@ -47,8 +47,8 @@ class CodeSample extends React.Component {
               <li key={key}>
                 {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                 <a
-                  href="#"
                   className={selectedClass}
+                  href="#"
                   onClick={e => {
                     e.preventDefault();
                     setLanguage(example.language);
@@ -68,8 +68,8 @@ class CodeSample extends React.Component {
               <div style={{ display: selected ? 'block' : 'none' }}>
                 <CopyCode key={`copy-${key}`} code={example.code} />
                 <pre
-                  className="tomorrow-night tabber-body"
                   key={key} // eslint-disable-line react/no-array-index-key
+                  className="tomorrow-night tabber-body"
                   style={{ display: selected ? 'block' : '' }}
                 >
                   {syntaxHighlighter(example.code, example.language, { dark: true })}
@@ -101,8 +101,8 @@ class CodeSample extends React.Component {
                   <li key={lang}>
                     {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                     <a
-                      href="#"
                       className={`hub-lang-switch-${lang}`}
+                      href="#"
                       onClick={e => {
                         e.preventDefault();
                         setLanguage(lang);
@@ -128,18 +128,18 @@ class CodeSample extends React.Component {
 }
 
 CodeSample.propTypes = {
-  oas: PropTypes.instanceOf(Oas).isRequired,
-  setLanguage: PropTypes.func.isRequired,
-  operation: PropTypes.instanceOf(Operation).isRequired,
-  formData: PropTypes.shape({}).isRequired,
   auth: PropTypes.shape({}).isRequired,
   examples: PropTypes.arrayOf(
     PropTypes.shape({
-      language: PropTypes.string.isRequired,
       code: PropTypes.string.isRequired,
+      language: PropTypes.string.isRequired,
     }),
   ),
+  formData: PropTypes.shape({}).isRequired,
   language: PropTypes.string.isRequired,
+  oas: PropTypes.instanceOf(Oas).isRequired,
+  operation: PropTypes.instanceOf(Operation).isRequired,
+  setLanguage: PropTypes.func.isRequired,
 };
 
 CodeSample.defaultProps = {

--- a/packages/api-explorer/src/CopyCode.jsx
+++ b/packages/api-explorer/src/CopyCode.jsx
@@ -31,8 +31,8 @@ class CopyCode extends React.Component {
 
   render() {
     return (
-      <CopyToClipboard text={this.state.code} onCopy={this.onCopy}>
-        <button type="button" className="copy-code-button">
+      <CopyToClipboard onCopy={this.onCopy} text={this.state.code}>
+        <button className="copy-code-button" type="button">
           {this.state.copied ? (
             <span className="fa fa-check" />
           ) : (
@@ -44,8 +44,8 @@ class CopyCode extends React.Component {
   }
 }
 
-module.exports = CopyCode;
-
 CopyCode.propTypes = {
   code: PropTypes.string.isRequired,
 };
+
+module.exports = CopyCode;

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -181,13 +181,13 @@ class Doc extends React.Component {
 
     return (
       <CodeSample
-        oas={this.oas}
-        setLanguage={this.props.setLanguage}
-        operation={this.getOperation()}
-        formData={this.state.formData}
         auth={this.props.auth}
-        language={this.props.language}
         examples={examples}
+        formData={this.state.formData}
+        language={this.props.language}
+        oas={this.oas}
+        operation={this.getOperation()}
+        setLanguage={this.props.setLanguage}
       />
     );
   }
@@ -202,13 +202,13 @@ class Doc extends React.Component {
 
     return (
       <Response
-        result={this.state.result}
-        oas={this.oas}
-        operation={this.getOperation()}
-        oauth={this.props.oauth}
-        hideResults={this.hideResults}
         exampleResponses={exampleResponses}
+        hideResults={this.hideResults}
+        oas={this.oas}
+        oauth={this.props.oauth}
         onChange={this.onChange}
+        operation={this.getOperation()}
+        result={this.state.result}
       />
     );
   }
@@ -219,7 +219,7 @@ class Doc extends React.Component {
     return (
       operation &&
       operation.responses && (
-        <ResponseSchema theme={theme} operation={this.getOperation()} oas={this.oas} />
+        <ResponseSchema oas={this.oas} operation={this.getOperation()} theme={theme} />
       )
     );
   }
@@ -245,16 +245,16 @@ class Doc extends React.Component {
 
     return (
       <Logs
-        user={this.props.user}
         baseUrl={this.props.baseUrl}
+        changeGroup={this.props.changeGroup}
+        group={this.props.group}
+        groups={this.props.groups}
         query={{
           url,
           method,
         }}
         result={this.state.result}
-        group={this.props.group}
-        groups={this.props.groups}
-        changeGroup={this.props.changeGroup}
+        user={this.props.user}
       />
     );
   }
@@ -262,11 +262,11 @@ class Doc extends React.Component {
   renderParams() {
     return (
       <this.Params
-        oas={this.oas}
-        operation={this.getOperation()}
         formData={this.state.formData}
+        oas={this.oas}
         onChange={this.onChange}
         onSubmit={this.onSubmit}
+        operation={this.getOperation()}
       />
     );
   }
@@ -275,18 +275,18 @@ class Doc extends React.Component {
     /* eslint-disable no-return-assign */
     return (
       <PathUrl
-        oas={this.oas}
-        operation={this.getOperation()}
+        auth={this.props.auth}
+        authInputRef={el => (this.authInput = el)}
         dirty={this.state.dirty}
         loading={this.state.loading}
-        onChange={this.props.onAuthChange}
-        showAuthBox={this.state.showAuthBox}
         needsAuth={this.state.needsAuth}
+        oas={this.oas}
         oauth={this.props.oauth}
-        toggleAuth={this.toggleAuth}
+        onChange={this.props.onAuthChange}
         onSubmit={this.onSubmit}
-        authInputRef={el => (this.authInput = el)}
-        auth={this.props.auth}
+        operation={this.getOperation()}
+        showAuthBox={this.state.showAuthBox}
+        toggleAuth={this.toggleAuth}
       />
     );
   }
@@ -299,7 +299,7 @@ class Doc extends React.Component {
       if (this.props.appearance.splitReferenceDocs) return this.renderEndpoint();
       if (lazy) {
         return (
-          <Waypoint onEnter={this.waypointEntered} fireOnRapidScroll={false} bottomOffset="-1%">
+          <Waypoint bottomOffset="-1%" fireOnRapidScroll={false} onEnter={this.waypointEntered}>
             {this.state.showEndpoint && this.renderEndpoint()}
           </Waypoint>
         );
@@ -339,8 +339,8 @@ class Doc extends React.Component {
           // cos we can just pass it around?
         }
         <input
-          type="hidden"
           id={`swagger-${extensions.SEND_DEFAULTS}`}
+          type="hidden"
           value={oas[extensions.SEND_DEFAULTS]}
         />
       </div>
@@ -349,51 +349,40 @@ class Doc extends React.Component {
 }
 
 Doc.propTypes = {
-  doc: PropTypes.shape({
-    title: PropTypes.string.isRequired,
-    excerpt: PropTypes.string,
-    slug: PropTypes.string.isRequired,
-    type: PropTypes.string.isRequired,
-    api: PropTypes.shape({
-      method: PropTypes.string.isRequired,
-      params: PropTypes.object,
-      examples: PropTypes.shape({
-        codes: PropTypes.arrayOf(
-          PropTypes.shape({
-            language: PropTypes.string.isRequired,
-            code: PropTypes.string.isRequired,
-          }),
-        ),
-      }),
-      results: PropTypes.shape({
-        codes: PropTypes.arrayOf(
-          PropTypes.shape({}), // TODO: Jsinspect threw an error because this was too similar to L330
-        ),
-      }),
-    }),
-    swagger: PropTypes.shape({
-      path: PropTypes.string.isRequired,
-    }),
-  }).isRequired,
-  user: PropTypes.shape({}),
-  auth: PropTypes.shape({}).isRequired,
-  Logs: PropTypes.func,
-  oas: PropTypes.shape({}),
-  setLanguage: PropTypes.func.isRequired,
-  flags: PropTypes.shape({
-    correctnewlines: PropTypes.bool,
-  }),
   appearance: PropTypes.shape({
     referenceLayout: PropTypes.string,
     splitReferenceDocs: PropTypes.bool,
   }),
-  language: PropTypes.string.isRequired,
+  auth: PropTypes.shape({}).isRequired,
   baseUrl: PropTypes.string,
-  oauth: PropTypes.bool.isRequired,
-  suggestedEdits: PropTypes.bool.isRequired,
-  tryItMetrics: PropTypes.func.isRequired,
-  onAuthChange: PropTypes.func.isRequired,
-  lazy: PropTypes.bool,
+  changeGroup: PropTypes.func.isRequired,
+  doc: PropTypes.shape({
+    api: PropTypes.shape({
+      examples: PropTypes.shape({
+        codes: PropTypes.arrayOf(
+          PropTypes.shape({
+            code: PropTypes.string.isRequired,
+            language: PropTypes.string.isRequired,
+          }),
+        ),
+      }),
+      method: PropTypes.string.isRequired,
+      params: PropTypes.object,
+      results: PropTypes.shape({
+        codes: PropTypes.arrayOf(PropTypes.shape({})),
+      }),
+    }),
+    excerpt: PropTypes.string,
+    slug: PropTypes.string.isRequired,
+    swagger: PropTypes.shape({
+      path: PropTypes.string.isRequired,
+    }),
+    title: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+  }).isRequired,
+  flags: PropTypes.shape({
+    correctnewlines: PropTypes.bool,
+  }),
   group: PropTypes.string,
   groups: PropTypes.arrayOf(
     PropTypes.shape({
@@ -401,24 +390,33 @@ Doc.propTypes = {
       name: PropTypes.string,
     }),
   ),
-  changeGroup: PropTypes.func.isRequired,
+  language: PropTypes.string.isRequired,
+  lazy: PropTypes.bool,
+  Logs: PropTypes.func,
+  oas: PropTypes.shape({}),
+  oauth: PropTypes.bool.isRequired,
+  onAuthChange: PropTypes.func.isRequired,
+  setLanguage: PropTypes.func.isRequired,
+  suggestedEdits: PropTypes.bool.isRequired,
+  tryItMetrics: PropTypes.func.isRequired,
+  user: PropTypes.shape({}),
 };
 
 Doc.defaultProps = {
-  oas: {},
-  flags: {
-    correctnewlines: false,
-  },
-  lazy: true,
   appearance: {
     referenceLayout: 'row',
     splitReferenceDocs: false,
   },
-  Logs: undefined,
-  user: {},
   baseUrl: '/',
+  flags: {
+    correctnewlines: false,
+  },
   group: '',
   groups: [],
+  lazy: true,
+  Logs: undefined,
+  oas: {},
+  user: {},
 };
 
 module.exports = Doc;

--- a/packages/api-explorer/src/ExampleTabs.jsx
+++ b/packages/api-explorer/src/ExampleTabs.jsx
@@ -9,14 +9,14 @@ function ExampleTabs({ examples, selected, setExampleTab }) {
       {examples.map((example, index) => {
         return (
           <Tab
-            selected={index === selected}
+            key={index} // eslint-disable-line react/no-array-index-key
             onClick={e => {
               e.preventDefault();
               setExampleTab(index);
             }}
-            key={index} // eslint-disable-line react/no-array-index-key
+            selected={index === selected}
           >
-            <IconStatus status={example.status} name={example.name} />
+            <IconStatus name={example.name} status={example.status} />
           </Tab>
         );
       })}

--- a/packages/api-explorer/src/IconStatus.jsx
+++ b/packages/api-explorer/src/IconStatus.jsx
@@ -26,13 +26,13 @@ function IconStatus({ status, name }) {
 }
 
 IconStatus.propTypes = {
-  status: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   name: PropTypes.string,
+  status: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 IconStatus.defaultProps = {
-  status: 200, // TODO: For some reason this wasn't getting passed sometimes
   name: '',
+  status: 200, // TODO: For some reason this wasn't getting passed sometimes
 };
 
 module.exports = IconStatus;

--- a/packages/api-explorer/src/Params.jsx
+++ b/packages/api-explorer/src/Params.jsx
@@ -39,14 +39,24 @@ function Params({
     jsonSchema &&
     jsonSchema.map(schema => {
       return [
-        <div className="param-type-header" key={`${schema.type}-header`}>
+        <div key={`${schema.type}-header`} className="param-type-header">
           <h3>{schema.label}</h3>
           <div className="param-header-border" />
         </div>,
         <Form
           key={`${schema.type}-form`}
+          fields={{
+            DescriptionField,
+            ArrayField,
+            SchemaField,
+          }}
+          formData={formData[schema.type]}
           id={`form-${operation.operationId}`}
           idPrefix={operation.operationId}
+          onChange={form => {
+            return onChange({ [schema.type]: form.formData });
+          }}
+          onSubmit={onSubmit}
           schema={schema.schema}
           widgets={{
             int8: UpDownWidget,
@@ -71,19 +81,9 @@ function Params({
             BaseInput,
             SelectWidget,
           }}
-          onSubmit={onSubmit}
-          formData={formData[schema.type]}
-          onChange={form => {
-            return onChange({ [schema.type]: form.formData });
-          }}
-          fields={{
-            DescriptionField,
-            ArrayField,
-            SchemaField,
-          }}
         >
           {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
-          <button type="submit" style={{ display: 'none' }} />
+          <button style={{ display: 'none' }} type="submit" />
         </Form>,
       ];
     })
@@ -91,17 +91,17 @@ function Params({
 }
 
 Params.propTypes = {
-  oas: PropTypes.instanceOf(Oas).isRequired,
-  operation: PropTypes.instanceOf(Operation).isRequired,
+  ArrayField: PropTypes.func.isRequired,
+  BaseInput: PropTypes.func.isRequired,
+  FileWidget: PropTypes.func.isRequired,
   formData: PropTypes.shape({}).isRequired,
+  oas: PropTypes.instanceOf(Oas).isRequired,
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  BaseInput: PropTypes.func.isRequired,
-  SelectWidget: PropTypes.func.isRequired,
-  ArrayField: PropTypes.func.isRequired,
+  operation: PropTypes.instanceOf(Operation).isRequired,
   SchemaField: PropTypes.func.isRequired,
+  SelectWidget: PropTypes.func.isRequired,
   TextareaWidget: PropTypes.func.isRequired,
-  FileWidget: PropTypes.func.isRequired,
 };
 
 function createParams(oas) {
@@ -117,12 +117,12 @@ function createParams(oas) {
     return (
       <Params
         {...props}
-        BaseInput={BaseInput}
-        SelectWidget={SelectWidget}
         ArrayField={ArrayField}
-        SchemaField={SchemaField}
-        TextareaWidget={TextareaWidget}
+        BaseInput={BaseInput}
         FileWidget={FileWidget}
+        SchemaField={SchemaField}
+        SelectWidget={SelectWidget}
+        TextareaWidget={TextareaWidget}
         URLWidget={URLWidget}
       />
     );

--- a/packages/api-explorer/src/PathUrl.jsx
+++ b/packages/api-explorer/src/PathUrl.jsx
@@ -43,22 +43,22 @@ function PathUrl({
           {oas[extensions.EXPLORER_ENABLED] && (
             <div className="api-definition-actions">
               <AuthBox
-                operation={operation}
+                auth={auth}
+                authInputRef={authInputRef}
+                needsAuth={needsAuth}
+                oauth={oauth}
                 onChange={onChange}
                 onSubmit={onSubmit}
                 open={showAuthBox}
-                needsAuth={needsAuth}
+                operation={operation}
                 toggle={toggleAuth}
-                authInputRef={authInputRef}
-                oauth={oauth}
-                auth={auth}
               />
 
               <button
                 className={classNames('api-try-it-out', { active: dirty })}
-                type="submit"
                 disabled={loading}
                 onClick={onSubmit}
+                type="submit"
               >
                 {!loading && (
                   <span className="try-it-now-btn">
@@ -92,25 +92,25 @@ function PathUrl({
 }
 
 PathUrl.propTypes = {
-  oas: PropTypes.instanceOf(Oas).isRequired,
-  operation: PropTypes.instanceOf(Operation).isRequired,
+  auth: PropTypes.shape({}),
   authInputRef: PropTypes.func,
   dirty: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
-  onChange: PropTypes.func.isRequired,
-  toggleAuth: PropTypes.func.isRequired,
-  onSubmit: PropTypes.func.isRequired,
-  showAuthBox: PropTypes.bool,
   needsAuth: PropTypes.bool,
+  oas: PropTypes.instanceOf(Oas).isRequired,
   oauth: PropTypes.bool.isRequired,
-  auth: PropTypes.shape({}),
+  onChange: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  operation: PropTypes.instanceOf(Operation).isRequired,
+  showAuthBox: PropTypes.bool,
+  toggleAuth: PropTypes.func.isRequired,
 };
 
 PathUrl.defaultProps = {
-  showAuthBox: false,
-  needsAuth: false,
-  authInputRef: () => {},
   auth: {},
+  authInputRef: () => {},
+  needsAuth: false,
+  showAuthBox: false,
 };
 
 module.exports = PathUrl;

--- a/packages/api-explorer/src/Response.jsx
+++ b/packages/api-explorer/src/Response.jsx
@@ -41,16 +41,16 @@ class Response extends React.Component {
             {result !== null && (
               <span>
                 <ResponseTabs
-                  result={result}
+                  hideResults={hideResults}
                   oas={oas}
                   operation={operation}
                   responseTab={responseTab}
+                  result={result}
                   setTab={this.setTab}
-                  hideResults={hideResults}
                 />
 
                 {responseTab === 'result' && (
-                  <ResponseBody result={result} oauth={oauth} isOauth={!!securities.OAuth2} />
+                  <ResponseBody isOauth={!!securities.OAuth2} oauth={oauth} result={result} />
                 )}
                 {responseTab === 'metadata' && <ResponseMetadata result={result} />}
               </span>
@@ -58,11 +58,11 @@ class Response extends React.Component {
           </div>
 
           <ResponseExample
+            exampleResponses={exampleResponses}
+            oas={oas}
+            onChange={this.props.onChange}
             operation={operation}
             result={result}
-            oas={oas}
-            exampleResponses={exampleResponses}
-            onChange={this.props.onChange}
           />
         </div>
       </div>
@@ -71,18 +71,18 @@ class Response extends React.Component {
 }
 
 Response.propTypes = {
-  result: PropTypes.shape({}),
-  oas: PropTypes.instanceOf(Oas).isRequired,
-  operation: PropTypes.instanceOf(Operation).isRequired,
-  oauth: PropTypes.bool.isRequired,
-  hideResults: PropTypes.func.isRequired,
   exampleResponses: PropTypes.arrayOf(PropTypes.shape({})),
+  hideResults: PropTypes.func.isRequired,
+  oas: PropTypes.instanceOf(Oas).isRequired,
+  oauth: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
+  operation: PropTypes.instanceOf(Operation).isRequired,
+  result: PropTypes.shape({}),
 };
 
 Response.defaultProps = {
-  result: {},
   exampleResponses: [],
+  result: {},
 };
 
 module.exports = Response;

--- a/packages/api-explorer/src/ResponseBody.jsx
+++ b/packages/api-explorer/src/ResponseBody.jsx
@@ -13,19 +13,19 @@ function Authorized({ result }) {
       {result.isBinary && <div>A binary file was returned</div>}
       {!result.isBinary && isJson && (
         <ReactJson
-          src={result.responseBody}
           collapsed={1}
           collapseStringsAfterLength={100}
-          enableClipboard={false}
-          theme="tomorrow"
-          name={null}
           displayDataTypes={false}
           displayObjectSize={false}
+          enableClipboard={false}
+          name={null}
+          src={result.responseBody}
           style={{
             padding: '20px 10px',
             backgroundColor: 'transparent',
             fontSize: '12px',
           }}
+          theme="tomorrow"
         />
       )}
       {!result.isBinary && !isJson && (
@@ -87,8 +87,8 @@ function ResponseBody({ result, isOauth, oauth }) {
   );
 }
 
-module.exports = ResponseBody;
-
 ResponseBody.propTypes = { ...Unauthorized.propTypes, ...Authorized.propTypes };
 
 ResponseBody.defaultProps = Unauthorized.defaultProps;
+
+module.exports = ResponseBody;

--- a/packages/api-explorer/src/ResponseExample.jsx
+++ b/packages/api-explorer/src/ResponseExample.jsx
@@ -23,21 +23,21 @@ function isDisplayable(example, responseExampleCopy) {
 function getReactJson(example, responseExampleCopy) {
   return (
     <ReactJson
-      src={JSON.parse(example.code)}
+      key={example.code}
       collapsed={2}
       collapseStringsAfterLength={100}
-      enableClipboard={false}
-      theme="tomorrow"
-      name={null}
       displayDataTypes={false}
       displayObjectSize={false}
-      key={example.code}
+      enableClipboard={false}
+      name={null}
+      src={JSON.parse(example.code)}
       style={{
         padding: '20px 10px',
         backgroundColor: 'transparent',
         display: isDisplayable(example, responseExampleCopy) ? 'block' : 'none',
         fontSize: '12px',
       }}
+      theme="tomorrow"
     />
   );
 }
@@ -111,7 +111,7 @@ class ResponseExample extends React.Component {
               value={responseMediaTypeCopy}
             >
               {mediaTypes.map((l, idx) => (
-                <option value={idx} key={l.language}>
+                <option key={l.language} value={idx}>
                   {l.language}
                 </option>
               ))}
@@ -141,7 +141,7 @@ class ResponseExample extends React.Component {
                 value={responseExampleCopy}
               >
                 {examples.map(example => (
-                  <option value={example.label} key={example.label}>
+                  <option key={example.label} value={example.label}>
                     {example.label}
                   </option>
                 ))}
@@ -265,16 +265,16 @@ class ResponseExample extends React.Component {
 }
 
 ResponseExample.propTypes = {
-  result: PropTypes.shape({}),
-  oas: PropTypes.instanceOf(Oas).isRequired,
-  operation: PropTypes.instanceOf(Operation).isRequired,
   exampleResponses: PropTypes.arrayOf(PropTypes.shape({})),
+  oas: PropTypes.instanceOf(Oas).isRequired,
   onChange: PropTypes.func.isRequired,
+  operation: PropTypes.instanceOf(Operation).isRequired,
+  result: PropTypes.shape({}),
 };
 
 ResponseExample.defaultProps = {
-  result: {},
   exampleResponses: [],
+  result: {},
 };
 
 module.exports = ResponseExample;

--- a/packages/api-explorer/src/ResponseMetadata.jsx
+++ b/packages/api-explorer/src/ResponseMetadata.jsx
@@ -15,8 +15,8 @@ function Meta({ label, children }) {
 }
 
 Meta.propTypes = {
-  label: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
+  label: PropTypes.string.isRequired,
 };
 
 function ResponseMetadata({ result }) {

--- a/packages/api-explorer/src/ResponseSchema.jsx
+++ b/packages/api-explorer/src/ResponseSchema.jsx
@@ -68,11 +68,11 @@ class ResponseSchema extends React.Component {
         <div className="pull-right">
           <select
             className="switcher-switch"
-            value={this.state.selectedStatus}
             onChange={this.changeHandler}
+            value={this.state.selectedStatus}
           >
             {keys.map(status => (
-              <option value={status} key={status}>
+              <option key={status} value={status}>
                 {status}
               </option>
             ))}
@@ -104,7 +104,7 @@ class ResponseSchema extends React.Component {
         {this.renderHeader()}
         <div className="response-schema">
           {response.description && <div className="desc">{markdown(response.description)}</div>}
-          {schema && <ResponseSchemaBody schema={schema} oas={oas} />}
+          {schema && <ResponseSchemaBody oas={oas} schema={schema} />}
         </div>
       </div>
     );
@@ -112,8 +112,8 @@ class ResponseSchema extends React.Component {
 }
 
 ResponseSchema.propTypes = {
-  operation: PropTypes.instanceOf(Operation).isRequired,
   oas: PropTypes.instanceOf(Oas).isRequired,
+  operation: PropTypes.instanceOf(Operation).isRequired,
   theme: PropTypes.string.isRequired,
 };
 

--- a/packages/api-explorer/src/ResponseSchemaBody.jsx
+++ b/packages/api-explorer/src/ResponseSchemaBody.jsx
@@ -133,12 +133,12 @@ function ResponseSchemaBody({ schema, oas }) {
 }
 
 ResponseSchemaBody.propTypes = {
+  oas: PropTypes.shape({}).isRequired,
   schema: PropTypes.shape({
-    type: PropTypes.string.isRequired,
     items: PropTypes.object,
     properties: PropTypes.object,
+    type: PropTypes.string.isRequired,
   }).isRequired,
-  oas: PropTypes.shape({}).isRequired,
 };
 
 module.exports = ResponseSchemaBody;

--- a/packages/api-explorer/src/ResponseTabs.jsx
+++ b/packages/api-explorer/src/ResponseTabs.jsx
@@ -10,21 +10,21 @@ function ResponseTabs({ result, oas, operation, responseTab, setTab, hideResults
   return (
     <ul className="code-sample-tabs hub-reference-results-header">
       <Tab
-        selected={responseTab === 'result'}
         onClick={e => {
           e.preventDefault();
           setTab('result');
         }}
+        selected={responseTab === 'result'}
       >
         <IconStatus status={result.status} />
       </Tab>
 
       <Tab
-        selected={responseTab === 'metadata'}
         onClick={e => {
           e.preventDefault();
           setTab('metadata');
         }}
+        selected={responseTab === 'metadata'}
       >
         Metadata
       </Tab>
@@ -47,14 +47,14 @@ function ResponseTabs({ result, oas, operation, responseTab, setTab, hideResults
 }
 
 ResponseTabs.propTypes = {
-  result: PropTypes.shape({
-    status: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  }),
+  hideResults: PropTypes.func.isRequired,
   oas: PropTypes.instanceOf(Oas).isRequired,
   operation: PropTypes.instanceOf(Operation).isRequired,
   responseTab: PropTypes.string.isRequired,
+  result: PropTypes.shape({
+    status: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  }),
   setTab: PropTypes.func.isRequired,
-  hideResults: PropTypes.func.isRequired,
 };
 
 ResponseTabs.defaultProps = {

--- a/packages/api-explorer/src/SecurityInput.jsx
+++ b/packages/api-explorer/src/SecurityInput.jsx
@@ -17,8 +17,8 @@ class Input extends React.Component {
     return (
       <DebounceInput
         {...this.props}
-        minLength={0}
         debounceTimeout={process.env.NODE_ENV === 'test' ? 0 : 300}
+        minLength={0}
       />
     );
   }
@@ -50,9 +50,9 @@ function SecurityInput(props) {
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
             change={change}
-            user={props.auth[props.scheme._key].user}
-            pass={props.auth[props.scheme._key].pass}
             Input={Input}
+            pass={props.auth[props.scheme._key].pass}
+            user={props.auth[props.scheme._key].user}
           />
         );
       }
@@ -69,13 +69,13 @@ function SecurityInput(props) {
 }
 
 SecurityInput.propTypes = {
-  scheme: PropTypes.shape({
-    type: PropTypes.string.isRequired,
-    scheme: PropTypes.string,
-    _key: PropTypes.string.isRequired,
-  }).isRequired,
-  onChange: PropTypes.func.isRequired,
   auth: PropTypes.shape({}),
+  onChange: PropTypes.func.isRequired,
+  scheme: PropTypes.shape({
+    _key: PropTypes.string.isRequired,
+    scheme: PropTypes.string,
+    type: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 SecurityInput.defaultProps = {

--- a/packages/api-explorer/src/Tab.jsx
+++ b/packages/api-explorer/src/Tab.jsx
@@ -6,10 +6,10 @@ function Tab({ children, onClick, selected }) {
   return (
     // eslint-disable-next-line jsx-a11y/anchor-is-valid
     <a
-      href="#"
       className={classNames('hub-reference-results-header-item tabber-tab invalidclass', {
         selected,
       })}
+      href="#"
       onClick={onClick}
     >
       {children}
@@ -17,10 +17,10 @@ function Tab({ children, onClick, selected }) {
   );
 }
 
-module.exports = Tab;
-
 Tab.propTypes = {
   children: PropTypes.node.isRequired,
   onClick: PropTypes.func.isRequired,
   selected: PropTypes.bool.isRequired,
 };
+
+module.exports = Tab;

--- a/packages/api-explorer/src/block-types/ApiHeader.jsx
+++ b/packages/api-explorer/src/block-types/ApiHeader.jsx
@@ -24,8 +24,8 @@ const ApiHeader = ({ block }) => {
 ApiHeader.propTypes = {
   block: PropTypes.shape({
     data: PropTypes.shape({
-      type: PropTypes.string,
       title: PropTypes.string.isRequired,
+      type: PropTypes.string,
     }),
   }).isRequired,
 };

--- a/packages/api-explorer/src/block-types/CallOut.jsx
+++ b/packages/api-explorer/src/block-types/CallOut.jsx
@@ -46,9 +46,9 @@ const CallOut = ({ block, flags }) => {
 CallOut.propTypes = {
   block: PropTypes.shape({
     data: PropTypes.shape({
-      type: PropTypes.string.isRequired,
-      title: PropTypes.string,
       body: PropTypes.string,
+      title: PropTypes.string,
+      type: PropTypes.string.isRequired,
     }),
   }).isRequired,
   flags: PropTypes.shape({}),

--- a/packages/api-explorer/src/block-types/Code.jsx
+++ b/packages/api-explorer/src/block-types/Code.jsx
@@ -33,12 +33,12 @@ class BlockCode extends React.Component {
                 <li key={i}>
                   {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                   <a
+                    className={classNames({ active: i === this.state.activeTab })}
                     href="#"
                     onClick={e => {
                       e.preventDefault();
                       this.showCode(i);
                     }}
-                    className={classNames({ active: i === this.state.activeTab })}
                   >
                     {/* eslint-disable-next-line no-nested-ternary */}
                     {code.status ? (
@@ -62,7 +62,7 @@ class BlockCode extends React.Component {
 
           <div className="block-code-code">
             {codes.map((code, i) => {
-              return <CodeElement code={code} activeTab={i === this.state.activeTab} dark={dark} />;
+              return <CodeElement activeTab={i === this.state.activeTab} code={code} dark={dark} />;
             })}
           </div>
         </div>
@@ -77,17 +77,17 @@ BlockCode.propTypes = {
       codes: PropTypes.array,
     }),
   }),
+  dark: PropTypes.bool,
   opts: PropTypes.shape({
     hideHeaderOnOne: PropTypes.bool,
     label: PropTypes.string,
   }),
-  dark: PropTypes.bool,
 };
 
 BlockCode.defaultProps = {
   block: { data: {} },
-  opts: {},
   dark: false,
+  opts: {},
 };
 
 module.exports = BlockCode;

--- a/packages/api-explorer/src/block-types/Content.jsx
+++ b/packages/api-explorer/src/block-types/Content.jsx
@@ -59,12 +59,12 @@ const Content = props => {
       <div className="hub-reference-section">
         <div className="hub-reference-left">
           <div className="content-body">
-            <Loop content={left} column="left" flags={props.flags} />
+            <Loop column="left" content={left} flags={props.flags} />
           </div>
         </div>
         <div className="hub-reference-right">
           <div className="content-body">
-            <Loop content={right} column="right" flags={props.flags} />
+            <Loop column="right" content={right} flags={props.flags} />
           </div>
         </div>
       </div>
@@ -73,20 +73,20 @@ const Content = props => {
 
   return (
     <Loop
+      column={isThreeColumn}
       content={isThreeColumn === 'left' ? left : right}
       flags={props.flags}
-      column={isThreeColumn}
     />
   );
 };
 
 Loop.propTypes = {
+  column: PropTypes.string,
   content: PropTypes.arrayOf(
     PropTypes.shape({
       type: PropTypes.string.isRequired,
     }),
   ).isRequired,
-  column: PropTypes.string,
   flags: PropTypes.shape({
     correctnewlines: PropTypes.bool,
   }),
@@ -98,15 +98,15 @@ Loop.defaultProps = {
 };
 
 Content.propTypes = {
-  isThreeColumn: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   body: PropTypes.string,
   flags: PropTypes.shape({}),
+  isThreeColumn: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 };
 
 Content.defaultProps = {
-  isThreeColumn: true,
   body: '',
   flags: {},
+  isThreeColumn: true,
 };
 
 module.exports = Content;

--- a/packages/api-explorer/src/block-types/Embed.jsx
+++ b/packages/api-explorer/src/block-types/Embed.jsx
@@ -12,17 +12,17 @@ const Embed = ({ block }) => {
           return (
             <iframe
               className="media-iframe"
-              title={block.data.title}
-              src={block.data.url}
-              width={block.data.width || '100%'}
               height={block.data.height || '300px'}
+              src={block.data.url}
+              title={block.data.title}
+              width={block.data.width || '100%'}
             />
           );
         }
 
         return (
           <strong>
-            {block.data.favicon && <img src={block.data.favicon} className="favicon" alt="" />}
+            {block.data.favicon && <img alt="" className="favicon" src={block.data.favicon} />}
             <a href={block.data.url} target="_new">
               {block.data.title || block.data.url}
             </a>
@@ -36,13 +36,13 @@ const Embed = ({ block }) => {
 Embed.propTypes = {
   block: PropTypes.shape({
     data: PropTypes.shape({
+      favicon: PropTypes.string.isRequired,
+      height: PropTypes.string,
       html: PropTypes.boolean,
       iframe: PropTypes.boolean,
-      url: PropTypes.string.isRequired,
-      favicon: PropTypes.string.isRequired,
-      width: PropTypes.string,
-      height: PropTypes.string,
       title: PropTypes.string,
+      url: PropTypes.string.isRequired,
+      width: PropTypes.string,
     }),
   }),
 };

--- a/packages/api-explorer/src/block-types/Image.jsx
+++ b/packages/api-explorer/src/block-types/Image.jsx
@@ -9,7 +9,7 @@ const ImageBlock = ({ block, flags }) => {
 
     return (
       // eslint-disable-next-line react/no-array-index-key
-      <div className="magic-block-image" key={i}>
+      <div key={i} className="magic-block-image">
         {image && image.image && image.image.length && (
           <div>
             <figure>
@@ -17,7 +17,7 @@ const ImageBlock = ({ block, flags }) => {
                 className={`block-display-image-parent block-display-image-size-${imageClass}${border}`}
                 href={image.image[0]}
               >
-                <img src={image.image[0]} alt={image.caption} />
+                <img alt={image.caption} src={image.image[0]} />
               </a>
             </figure>
             {image.caption && <figcaption>{markdown(image.caption, flags)}</figcaption>}

--- a/packages/api-explorer/src/block-types/Parameters.jsx
+++ b/packages/api-explorer/src/block-types/Parameters.jsx
@@ -10,7 +10,7 @@ const Parameters = ({ block, flags }) => {
     const thCells = [];
     for (let c = 0; c < columns; c += 1) {
       thCells.push(
-        <div className="th" key={c}>
+        <div key={c} className="th">
           {block.data.data[`h-${c}`]}
         </div>,
       );
@@ -23,7 +23,7 @@ const Parameters = ({ block, flags }) => {
 
     for (let c = 0; c < columns; c += 1) {
       tdCells.push(
-        <div className="td" key={c}>
+        <div key={c} className="td">
           {markdown(block.data.data[`${r}-${c}`] || '', flags)}
         </div>,
       );
@@ -36,7 +36,7 @@ const Parameters = ({ block, flags }) => {
 
     for (let r = 0; r < rows; r += 1) {
       trCells.push(
-        <div className="tr" key={r}>
+        <div key={r} className="tr">
           {td(r)}
         </div>,
       );
@@ -60,8 +60,8 @@ Parameters.propTypes = {
   block: PropTypes.shape({
     data: PropTypes.shape({
       cols: PropTypes.number.isRequired,
-      rows: PropTypes.number.isRequired,
       data: PropTypes.object.isRequired,
+      rows: PropTypes.number.isRequired,
     }),
   }).isRequired,
   flags: PropTypes.shape({}),

--- a/packages/api-explorer/src/form-components/DescriptionField.jsx
+++ b/packages/api-explorer/src/form-components/DescriptionField.jsx
@@ -9,20 +9,20 @@ function DescriptionField(props) {
   if (!description) return null;
 
   return (
-    <div id={id} className="field-description">
+    <div className="field-description" id={id}>
       {typeof description === 'string' ? markdown(description) : description}
     </div>
   );
 }
 
 DescriptionField.propTypes = {
-  id: PropTypes.string,
   description: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  id: PropTypes.string,
 };
 
 DescriptionField.defaultProps = {
-  id: '',
   description: '',
+  id: '',
 };
 
 module.exports = DescriptionField;

--- a/packages/api-explorer/src/form-components/SchemaField.jsx
+++ b/packages/api-explorer/src/form-components/SchemaField.jsx
@@ -110,27 +110,27 @@ function SchemaField(props) {
 }
 
 CustomTemplate.propTypes = {
-  id: PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
   classNames: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  help: PropTypes.node.isRequired,
-  required: PropTypes.node.isRequired,
   description: PropTypes.node.isRequired,
   errors: PropTypes.node.isRequired,
-  children: PropTypes.node.isRequired,
+  help: PropTypes.node.isRequired,
+  id: PropTypes.node.isRequired,
+  label: PropTypes.string.isRequired,
+  required: PropTypes.node.isRequired,
   schema: PropTypes.shape({}).isRequired,
 };
 
 SchemaField.propTypes = {
-  schema: PropTypes.shape({
-    type: PropTypes.string,
-    format: PropTypes.string,
-    enumNames: PropTypes.array,
-    readOnly: PropTypes.bool,
-  }).isRequired,
   registry: PropTypes.shape({
-    widgets: PropTypes.object,
     FieldTemplate: PropTypes.func,
+    widgets: PropTypes.object,
+  }).isRequired,
+  schema: PropTypes.shape({
+    enumNames: PropTypes.array,
+    format: PropTypes.string,
+    readOnly: PropTypes.bool,
+    type: PropTypes.string,
   }).isRequired,
   uiSchema: PropTypes.shape({}),
 };

--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -152,8 +152,8 @@ class ApiExplorer extends React.Component {
     return (
       <div className={`is-lang-${this.state.language}`}>
         <div
-          id="hub-reference"
           className={`content-body hub-reference-sticky hub-reference-theme-${this.props.appearance.referenceLayout}`}
+          id="hub-reference"
         >
           {docs.map((doc, index) => (
             <VariablesContext.Provider value={this.props.variables}>
@@ -163,24 +163,24 @@ class ApiExplorer extends React.Component {
                     <SelectedAppContext.Provider value={this.state.selectedApp}>
                       <Doc
                         key={doc._id}
+                        appearance={this.props.appearance}
+                        auth={this.state.auth}
+                        baseUrl={this.props.baseUrl.replace(/\/$/, '')}
+                        changeGroup={this.changeGroup}
                         doc={doc}
-                        lazy={this.isLazy(index)}
-                        oas={this.getOas(doc)}
-                        setLanguage={this.setLanguage}
                         flags={this.props.flags}
-                        user={this.props.variables.user}
                         group={this.state.group}
                         groups={this.groups}
-                        changeGroup={this.changeGroup}
-                        Logs={this.props.Logs}
-                        baseUrl={this.props.baseUrl.replace(/\/$/, '')}
-                        appearance={this.props.appearance}
                         language={this.state.language}
+                        lazy={this.isLazy(index)}
+                        Logs={this.props.Logs}
+                        oas={this.getOas(doc)}
                         oauth={this.props.oauth}
+                        onAuthChange={this.onAuthChange}
+                        setLanguage={this.setLanguage}
                         suggestedEdits={this.props.suggestedEdits}
                         tryItMetrics={this.props.tryItMetrics}
-                        auth={this.state.auth}
-                        onAuthChange={this.onAuthChange}
+                        user={this.props.variables.user}
                       />
                     </SelectedAppContext.Provider>
                   </BaseUrlContext.Provider>
@@ -195,44 +195,50 @@ class ApiExplorer extends React.Component {
 }
 
 ApiExplorer.propTypes = {
-  docs: PropTypes.arrayOf(PropTypes.object).isRequired,
-  oasFiles: PropTypes.shape({}).isRequired,
-  dontLazyLoad: PropTypes.bool,
   appearance: PropTypes.shape({
     referenceLayout: PropTypes.string,
     splitReferenceDocs: PropTypes.bool,
   }).isRequired,
+  baseUrl: PropTypes.string,
+  docs: PropTypes.arrayOf(PropTypes.object).isRequired,
+  dontLazyLoad: PropTypes.bool,
   flags: PropTypes.shape({
     correctnewlines: PropTypes.bool,
   }),
-  oauth: PropTypes.bool,
-  baseUrl: PropTypes.string,
+  glossaryTerms: PropTypes.arrayOf(
+    PropTypes.shape({
+      definition: PropTypes.string.isRequired,
+      term: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
   Logs: PropTypes.func,
+  oasFiles: PropTypes.shape({}).isRequired,
+  oauth: PropTypes.bool,
   suggestedEdits: PropTypes.bool.isRequired,
   tryItMetrics: PropTypes.func,
   variables: PropTypes.shape({
-    user: PropTypes.shape({
-      keys: PropTypes.array,
-      id: PropTypes.string,
-    }).isRequired,
     defaults: PropTypes.arrayOf(
-      PropTypes.shape({ name: PropTypes.string.isRequired, default: PropTypes.string.isRequired }),
+      PropTypes.shape({
+        default: PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
+      }),
     ).isRequired,
+    user: PropTypes.shape({
+      id: PropTypes.string,
+      keys: PropTypes.array,
+    }).isRequired,
   }).isRequired,
-  glossaryTerms: PropTypes.arrayOf(
-    PropTypes.shape({ term: PropTypes.string.isRequired, definition: PropTypes.string.isRequired }),
-  ).isRequired,
 };
 
 ApiExplorer.defaultProps = {
-  oauth: false,
+  baseUrl: '/',
+  dontLazyLoad: false,
   flags: {
     correctnewlines: false,
   },
-  tryItMetrics: () => {},
   Logs: undefined,
-  baseUrl: '/',
-  dontLazyLoad: false,
+  oauth: false,
+  tryItMetrics: () => {},
 };
 
 module.exports = props => (

--- a/packages/api-explorer/src/security-input-types/ApiKey.jsx
+++ b/packages/api-explorer/src/security-input-types/ApiKey.jsx
@@ -10,8 +10,8 @@ function ApiKey({ apiKey, scheme, authInputRef, change, Input }) {
       <div className="col-xs-7">
         <Input
           inputRef={authInputRef}
-          type="text"
           onChange={e => change(e.target.value)}
+          type="text"
           value={apiKey}
         />
       </div>
@@ -21,12 +21,12 @@ function ApiKey({ apiKey, scheme, authInputRef, change, Input }) {
 
 ApiKey.propTypes = {
   apiKey: PropTypes.string,
-  scheme: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-  }).isRequired,
   authInputRef: PropTypes.func,
   change: PropTypes.func.isRequired,
   Input: PropTypes.func.isRequired,
+  scheme: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 ApiKey.defaultProps = {

--- a/packages/api-explorer/src/security-input-types/Basic.jsx
+++ b/packages/api-explorer/src/security-input-types/Basic.jsx
@@ -12,18 +12,18 @@ function Basic({ user, pass, change, authInputRef, Input }) {
         <label htmlFor="user">username</label>
         <Input
           inputRef={authInputRef}
-          type="text"
-          onChange={e => inputChange(e.target.name, e.target.value)}
           name="user"
+          onChange={e => inputChange(e.target.name, e.target.value)}
+          type="text"
           value={user}
         />
       </div>
       <div className="col-xs-6">
         <label htmlFor="password">password</label>
         <Input
-          type="text"
-          onChange={e => inputChange(e.target.name, e.target.value)}
           name="pass"
+          onChange={e => inputChange(e.target.name, e.target.value)}
+          type="text"
           value={pass}
         />
       </div>
@@ -32,17 +32,17 @@ function Basic({ user, pass, change, authInputRef, Input }) {
 }
 
 Basic.propTypes = {
-  change: PropTypes.func.isRequired,
   authInputRef: PropTypes.func,
-  user: PropTypes.string,
-  pass: PropTypes.string,
+  change: PropTypes.func.isRequired,
   Input: PropTypes.func.isRequired,
+  pass: PropTypes.string,
+  user: PropTypes.string,
 };
 
 Basic.defaultProps = {
-  user: '',
-  pass: '',
   authInputRef: () => {},
+  pass: '',
+  user: '',
 };
 
 module.exports = Basic;

--- a/packages/api-explorer/src/security-input-types/Oauth2.jsx
+++ b/packages/api-explorer/src/security-input-types/Oauth2.jsx
@@ -41,11 +41,11 @@ function Oauth2({ apiKey, authInputRef, oauth, change, Input }) {
         </div>
         <div className="col-xs-6">
           <Input
-            inputRef={authInputRef}
             disabled={oauth}
-            type="text"
-            onChange={e => change(e.target.value)}
+            inputRef={authInputRef}
             name="apiKey"
+            onChange={e => change(e.target.value)}
+            type="text"
             value={apiKey}
           />
         </div>
@@ -56,10 +56,10 @@ function Oauth2({ apiKey, authInputRef, oauth, change, Input }) {
 
 Oauth2.propTypes = {
   apiKey: PropTypes.string,
-  oauth: PropTypes.bool.isRequired,
-  change: PropTypes.func.isRequired,
   authInputRef: PropTypes.func,
+  change: PropTypes.func.isRequired,
   Input: PropTypes.func.isRequired,
+  oauth: PropTypes.bool.isRequired,
 };
 
 Oauth2.defaultProps = {


### PR DESCRIPTION
While working on resolving the dozens and dozens of React warnings (missing props, invalid props, etc) that fill up the output from Jest, it became increasingly difficult to discern what props tests aren't supplying because nothing is alphabetized.

This institutes a couple new code standard rules within the explorer:

* `propTypes` must be alphabetized
* `defaultProps` must be alphabetized
* The order in which props are supplied to a DOM or React element must be alphabetized.