### PR TITLE
Fix API Righthand Sidebar Showing on Guides Pages

### DIFF
--- a/packages/api-explorer/style/main.scss
+++ b/packages/api-explorer/style/main.scss
@@ -994,7 +994,7 @@ form.rjsf {
     background: white;
   }
 
-  #hub-content:before {
+  body.hub-full #hub-content:before {
     content: '';
     width: 390px;
     height: 100%;


### PR DESCRIPTION
Fixes this issue by wrapping the `:before` pseudo with a `body.hub-full` to limit it to pages using the API reference layout:

<p align=center>

![image](https://user-images.githubusercontent.com/886627/69373786-756e3180-0c59-11ea-8547-a45896de8ff9.png)
