### PR TITLE
Fixing a regression of additionalProperties keys not being editable

### DIFF
--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -2,6 +2,7 @@ const React = require('react');
 const { mount } = require('enzyme');
 const extensions = require('@readme/oas-extensions');
 const Oas = require('oas');
+const { ADDITIONAL_PROPERTY_FLAG } = require('react-jsonschema-form/lib/utils');
 
 const Description = require('../src/form-components/DescriptionField');
 const createParams = require('../src/Params');
@@ -147,6 +148,18 @@ test('should convert `mixed type` to string', () => {
   const params = renderParams({ type: 'mixed type' });
 
   expect(params.find(`.field-string`)).toHaveLength(1);
+});
+
+test('additionalProperties object labels (keys) should be editable', () => {
+  const params = renderParams({
+    type: 'object',
+    additionalProperties: true,
+    // RJSF adds this property if you go through the `Form` object, but we aren't here so we're
+    // faking it.
+    [ADDITIONAL_PROPERTY_FLAG]: true,
+  });
+
+  expect(params.find('input#root_a-key')).toHaveLength(1);
 });
 
 describe('schema format handling', () => {

--- a/packages/api-explorer/src/form-components/SchemaField.jsx
+++ b/packages/api-explorer/src/form-components/SchemaField.jsx
@@ -11,6 +11,7 @@ const React = require('react');
 const PropTypes = require('prop-types');
 
 const BaseSchemaField = require('react-jsonschema-form/lib/components/fields/SchemaField').default;
+const { ADDITIONAL_PROPERTY_FLAG } = require('react-jsonschema-form/lib/utils');
 
 function getDefaultNumFormat(type) {
   if (type === 'integer') return 'int32';
@@ -70,13 +71,36 @@ function getTypeLabel(schema) {
 }
 
 function CustomTemplate(props) {
-  const { id, classNames, label, help, required, description, errors, children, schema } = props;
+  const {
+    id,
+    classNames,
+    label,
+    help,
+    required,
+    description,
+    errors,
+    children,
+    schema,
+    onKeyChange,
+  } = props;
+
+  let editableLabel = label;
+  if (ADDITIONAL_PROPERTY_FLAG in schema) {
+    editableLabel = (
+      <input
+        defaultValue={label}
+        id={`${id}-key`}
+        onBlur={event => onKeyChange(event.target.value)}
+        type="text"
+      />
+    );
+  }
 
   return (
     <div className={`${classNames} param`}>
       <span className="label">
         <label className="label-name" htmlFor={id}>
-          {label}
+          {editableLabel}
           {required && <span className="label-required">*</span>}
         </label>
         <span className="label-type">{getTypeLabel(schema)}</span>
@@ -141,9 +165,14 @@ CustomTemplate.propTypes = {
   errors: PropTypes.node.isRequired,
   help: PropTypes.node.isRequired,
   id: PropTypes.node.isRequired,
-  label: PropTypes.string.isRequired,
-  required: PropTypes.node.isRequired,
+  label: PropTypes.string,
+  onKeyChange: PropTypes.func,
+  required: PropTypes.bool,
   schema: PropTypes.shape({}).isRequired,
+};
+
+CustomTemplate.defaultProps = {
+  onKeyChange: () => {},
 };
 
 SchemaField.propTypes = {

--- a/packages/api-explorer/src/form-components/SchemaField.jsx
+++ b/packages/api-explorer/src/form-components/SchemaField.jsx
@@ -84,23 +84,20 @@ function CustomTemplate(props) {
     onKeyChange,
   } = props;
 
-  let editableLabel = label;
-  if (ADDITIONAL_PROPERTY_FLAG in schema) {
-    editableLabel = (
-      <input
-        defaultValue={label}
-        id={`${id}-key`}
-        onBlur={event => onKeyChange(event.target.value)}
-        type="text"
-      />
-    );
-  }
+  const EditLabel = (
+    <input
+      defaultValue={label}
+      id={`${id}-key`}
+      onBlur={event => onKeyChange(event.target.value)}
+      type="text"
+    />
+  );
 
   return (
     <div className={`${classNames} param`}>
       <span className="label">
         <label className="label-name" htmlFor={id}>
-          {editableLabel}
+          {ADDITIONAL_PROPERTY_FLAG in schema ? EditLabel : label}
           {required && <span className="label-required">*</span>}
         </label>
         <span className="label-type">{getTypeLabel(schema)}</span>


### PR DESCRIPTION
This resolves a regression of functional on schemas with `additionalProperties` no longer having editable labels/keys.
 
### Broken
![Screen Shot 2019-12-12 at 3 19 51 PM](https://user-images.githubusercontent.com/33762/70757046-10a37580-1cf3-11ea-8002-2ff3382930ee.png)

### Resolved
![Screen Shot 2019-12-12 at 3 19 47 PM](https://user-images.githubusercontent.com/33762/70757056-1731ed00-1cf3-11ea-98c9-65d04105c689.png)

*Note:* Keys don't update until you focus out of the input, but this is the same behavior that RJSF has currently https://rjsf-team.github.io/react-jsonschema-form/