### PR TITLE
🐛 fix broken api log url

### DIFF
--- a/packages/api-logs/index.jsx
+++ b/packages/api-logs/index.jsx
@@ -145,7 +145,7 @@ class Logs extends React.Component {
 
   visitLogItem(log) {
     const { baseUrl } = this.props;
-    window.open(`${baseUrl}logs/${log._id}`);
+    window.open(`${baseUrl}/logs/${log._id}`);
   }
 
   renderLogs() {


### PR DESCRIPTION
From this thread: https://readmeio.slack.com/archives/CRE57G3J7/p1579654198009000

Fixes the logs URL. See here for another reference: https://github.com/readmeio/api-explorer/blob/master/packages/api-logs/index.jsx#L228

We currently have a temporary fix via redirects in the parent project settings

