### PR TITLE
fix: updating the oas package to pull in some fixes for handling response schemas

### DIFF
--- a/packages/api-explorer/__tests__/ResponseSchemaBody.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseSchemaBody.test.jsx
@@ -3,8 +3,6 @@ const { shallow, mount } = require('enzyme');
 const Oas = require('oas');
 
 const ResponseSchemaBody = require('../src/ResponseSchemaBody');
-const { flattenResponseSchema } = require('../src/ResponseSchemaBody');
-const { flatten } = require('../src/ResponseSchemaBody');
 const petstore = require('./fixtures/petstore/oas.json');
 
 const oas = new Oas(petstore);
@@ -40,27 +38,6 @@ test('display properties if object contains $ref type', () => {
       .map(a => a.text())
       .filter(a => a === 'category.name'),
   ).toHaveLength(1);
-});
-
-test('should flatten schema to an array', () => {
-  const responseSchema = {
-    type: 'object',
-    properties: {
-      category: {
-        type: 'array',
-        items: {
-          type: 'string',
-        },
-      },
-    },
-  };
-  expect(flattenResponseSchema(responseSchema)).toStrictEqual([
-    {
-      name: 'category',
-      type: '[String]',
-      description: undefined,
-    },
-  ]);
 });
 
 test('display object properties inside another object in the table', () => {
@@ -307,9 +284,4 @@ test('should show "array" response schema type', () => {
       .find('p')
       .text(),
   ).toBe('Response schema type: array of objects');
-});
-
-test('should flatten array', () => {
-  const array = [[1], [2, 3], [[4, 5]]];
-  expect(flatten(array)).toStrictEqual([1, 2, 3, 4, 5]);
 });

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1177,14 +1177,6 @@
         }
       }
     },
-    "@mapbox/hast-util-table-cell-style": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz",
-      "integrity": "sha512-QsEsh5YaDvHoMQ2YHdvZy2iDnU3GgKVBTcHf6cILyoWDZtPSdlG444pL/ioPYO/GpXSfODBb9sefEetfC4v9oA==",
-      "requires": {
-        "unist-util-visit": "^1.3.0"
-      }
-    },
     "@readme/eslint-config": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-1.10.0.tgz",
@@ -1203,60 +1195,6 @@
         "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-sonarjs": "^0.5.0",
         "eslint-plugin-unicorn": "^15.0.0"
-      }
-    },
-    "@readme/markdown": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@readme/markdown/-/markdown-4.15.0.tgz",
-      "integrity": "sha512-kQX62NXudqb6Ic0nkUSm0KZGtoVlj8DWTHEQvNVaBTNnTZ21wJAsBKBRW6zIQmVY3WJdY1Xf1BF0F5UKoVu8lg==",
-      "requires": {
-        "@readme/syntax-highlighter": "^4.15.0",
-        "@readme/variable": "^4.15.0",
-        "hast-util-sanitize": "^1.2.0",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2",
-        "rehype-raw": "^4.0.1",
-        "rehype-react": "^3.1.0",
-        "rehype-sanitize": "^2.0.1",
-        "remark-breaks": "^1.0.0",
-        "remark-parse": "^7.0.2",
-        "remark-rehype": "^5.0.0",
-        "unified": "^8.4.0"
-      }
-    },
-    "@readme/oas-extensions": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-4.15.0.tgz",
-      "integrity": "sha512-8G0RLB8/J/ZYriqL3k13PZtcCb6vBr9s0F7EpSh2o9IfuhXzMye0JacSPMBTGh8Q/ptY0p4NIZ3DaqcYBHc8+g=="
-    },
-    "@readme/oas-to-har": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-4.15.0.tgz",
-      "integrity": "sha512-z60XmuLNg6G3NDhHt2/En9LbnuVVONNo8uLYOsd6rcJd7Rn5rMUYtM9pguyZJ+CEDFTgpKCcBXx6PW00qOqF+A==",
-      "requires": {
-        "@readme/oas-extensions": "^4.15.0",
-        "oas": "^1.0.1",
-        "querystring": "^0.2.0"
-      }
-    },
-    "@readme/syntax-highlighter": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-4.15.0.tgz",
-      "integrity": "sha512-283zY5nB7Nl15unr1Yk3RzD2+dv7BsXOkkvfCiuPJB8PaVBLgPi2r7shzp9KyTdz1LNr4n1+we35yMMCW4df+Q==",
-      "requires": {
-        "@readme/variable": "^4.15.0",
-        "codemirror": "^5.48.2",
-        "react": "^16.4.2"
-      }
-    },
-    "@readme/variable": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-4.15.0.tgz",
-      "integrity": "sha512-jHoVrjZHrloYqa2JVMRccIik0pbkdsWmUA0N7MXRKxrckyObbAlOM4RFGFaKp9dZzTOxnBUHY0ZN1bSHxwNr+Q==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
       }
     },
     "@sinonjs/commons": {
@@ -1357,11 +1295,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
-    },
-    "@types/unist": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "@types/yargs": {
       "version": "15.0.1",
@@ -2230,11 +2163,6 @@
       "integrity": "sha1-MMWiL0gZeKnn+M399JaxHZS0BNM=",
       "dev": true
     },
-    "bail": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
-      "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww=="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2670,11 +2598,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "ccount": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
-      "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w=="
-    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -2686,21 +2609,6 @@
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
       }
-    },
-    "character-entities": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
-      "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w=="
-    },
-    "character-entities-legacy": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
-      "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww=="
-    },
-    "character-reference-invalid": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
-      "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg=="
     },
     "chardet": {
       "version": "0.7.0",
@@ -2896,16 +2804,6 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
-    "codemirror": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.50.2.tgz",
-      "integrity": "sha512-PPjUsC1oXSM86lunKrw609P1oM0Wu8z9rqzjbeyBYCcx44VL41aUpccdOf1PfAZtTONlmN3sT3p2etLNYa1OGg=="
-    },
-    "collapse-white-space": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
-      "integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ=="
-    },
     "collect-v8-coverage": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.0.tgz",
@@ -2947,11 +2845,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "comma-separated-tokens": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.7.tgz",
-      "integrity": "sha512-Jrx3xsP4pPv4AwJUDWY9wOXGtwPXARej6Xd99h4TUGotmf8APuquKMpK+dnD3UgyxK7OEWaisjZz+3b5jtL6xQ=="
     },
     "commander": {
       "version": "2.11.0",
@@ -3312,14 +3205,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "detab": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.2.tgz",
-      "integrity": "sha512-Q57yPrxScy816TTE1P/uLRXLDKjXhvYTbfxS/e6lPD+YrqghbsMlGB9nQzj/zVtSPaF0DFPSdO916EWO4sQUyQ==",
-      "requires": {
-        "repeat-string": "^1.5.4"
       }
     },
     "detect-file": {
@@ -5538,11 +5423,6 @@
         }
       }
     },
-    "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
-    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -5736,14 +5616,6 @@
         }
       }
     },
-    "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "requires": {
-        "function-bind": "^1.0.2"
-      }
-    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -5843,89 +5715,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hast-to-hyperscript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-7.0.4.tgz",
-      "integrity": "sha512-vmwriQ2H0RPS9ho4Kkbf3n3lY436QKLq6VaGA1pzBh36hBi3tm1DO9bR+kaJIbpT10UqaANDkMjxvjVfr+cnOA==",
-      "requires": {
-        "comma-separated-tokens": "^1.0.0",
-        "property-information": "^5.3.0",
-        "space-separated-tokens": "^1.0.0",
-        "style-to-object": "^0.2.1",
-        "unist-util-is": "^3.0.0",
-        "web-namespaces": "^1.1.2"
-      }
-    },
-    "hast-util-from-parse5": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.2.tgz",
-      "integrity": "sha512-YXFjoRS7ES7PEoLx6uihtSfKTO1s3z/tzGiV5cVpsUiihduogFXubNRCzTIW3yOOGO1nws9CxPq4MbwD39Uo+w==",
-      "requires": {
-        "ccount": "^1.0.3",
-        "hastscript": "^5.0.0",
-        "property-information": "^5.0.0",
-        "web-namespaces": "^1.1.2",
-        "xtend": "^4.0.1"
-      }
-    },
-    "hast-util-parse-selector": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.3.tgz",
-      "integrity": "sha512-nxbeqjQNxsvo/uYYAw9kij6td05YVUlf1qti09rVfbWSLT5H6wo3c+USIwX6nzXWk5kFZzXnEqO82856r0aM2Q=="
-    },
-    "hast-util-raw": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-5.0.1.tgz",
-      "integrity": "sha512-iHo7G6BjRc/GU1Yun5CIEXjil0wVnIbz11C6k0JdDichSDMtYi2+NNtk6YN7EOP0JfPstX30d3pRLfaJv5CkdA==",
-      "requires": {
-        "hast-util-from-parse5": "^5.0.0",
-        "hast-util-to-parse5": "^5.0.0",
-        "html-void-elements": "^1.0.1",
-        "parse5": "^5.0.0",
-        "unist-util-position": "^3.0.0",
-        "web-namespaces": "^1.0.0",
-        "xtend": "^4.0.1",
-        "zwitch": "^1.0.0"
-      },
-      "dependencies": {
-        "parse5": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
-        }
-      }
-    },
-    "hast-util-sanitize": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz",
-      "integrity": "sha512-AIeKHuHx0Wk45nSkGVa2/ujQYTksnDl8gmmKo/mwQi7ag7IBZ8cM3nJ2G86SajbjGP/HRpud6kMkPtcM2i0Tlw==",
-      "requires": {
-        "xtend": "^4.0.1"
-      }
-    },
-    "hast-util-to-parse5": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-5.1.1.tgz",
-      "integrity": "sha512-ivCeAd5FCXr7bapJIVsWMnx/EmbjkkW2TU2hd1prq+jGwiaUoK+FcpjyPNwsC5ogzCwWO669tOqIovGeLc/ntg==",
-      "requires": {
-        "hast-to-hyperscript": "^7.0.0",
-        "property-information": "^5.0.0",
-        "web-namespaces": "^1.0.0",
-        "xtend": "^4.0.1",
-        "zwitch": "^1.0.0"
-      }
-    },
-    "hastscript": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.1.tgz",
-      "integrity": "sha512-xHo1Hkcqd0LlWNuDL3/BxwhgAGp3d7uEvCMgCTrBY+zsOooPPH+8KAvW8PCgl+GB8H3H44nfSaF0A4BQ+4xlYg==",
-      "requires": {
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5966,11 +5755,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
       "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
       "dev": true
-    },
-    "html-void-elements": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.4.tgz",
-      "integrity": "sha512-yMk3naGPLrfvUV9TdDbuYXngh/TpHbA6TrOw3HL9kS8yhwx7i309BReNg7CbAJXGE+UMJ6je5OqJ7lC63o6YuQ=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -6109,11 +5893,6 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
-    "inline-style-parser": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
-      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
-    },
     "inquirer": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
@@ -6209,20 +5988,6 @@
         "kind-of": "^3.0.2"
       }
     },
-    "is-alphabetical": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
-      "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA=="
-    },
-    "is-alphanumerical": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
-      "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
-      "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -6283,11 +6048,6 @@
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
-    "is-decimal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
-      "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ=="
-    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -6339,11 +6099,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-hexadecimal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
-      "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA=="
-    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -6357,11 +6112,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-    },
-    "is-plain-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
-      "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -6441,21 +6191,11 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
-    "is-whitespace-character": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
-      "integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ=="
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
-    },
-    "is-word-character": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
-      "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A=="
     },
     "is-wsl": {
       "version": "1.1.0",
@@ -8312,6 +8052,14 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json2yaml": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/json2yaml/-/json2yaml-1.1.0.tgz",
+      "integrity": "sha1-VBTZB/mBZYa4DFE+wuOusquBmmw=",
+      "requires": {
+        "remedial": "1.x"
+      }
+    },
     "json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -8623,11 +8371,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown-escapes": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
-      "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw=="
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -8646,37 +8389,6 @@
           "dev": true
         }
       }
-    },
-    "mdast-util-definitions": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
-      "integrity": "sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==",
-      "requires": {
-        "unist-util-visit": "^1.0.0"
-      }
-    },
-    "mdast-util-to-hast": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-6.0.2.tgz",
-      "integrity": "sha512-GjcOimC9qHI0yNFAQdBesrZXzUkRdFleQlcoU8+TVNfDW6oLUazUx8MgUoTaUyCJzBOnE5AOgqhpURrSlf0QwQ==",
-      "requires": {
-        "collapse-white-space": "^1.0.0",
-        "detab": "^2.0.0",
-        "mdast-util-definitions": "^1.2.0",
-        "mdurl": "^1.0.1",
-        "trim": "0.0.1",
-        "trim-lines": "^1.0.0",
-        "unist-builder": "^1.0.1",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "mem": {
       "version": "4.3.0",
@@ -9179,9 +8891,9 @@
       "dev": true
     },
     "oas": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-1.4.0.tgz",
-      "integrity": "sha512-ZsZCtt9E8h86XBa85QE/HQ1ozZqo6samCzhUeeAq30lXRis64JH9sA6tn8ehRe8Gcyb3DWymNWUjjBZX5YQZPg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-1.5.0.tgz",
+      "integrity": "sha512-xMhXEJsuB+3usaj6w1Ij6TviW6HeV7IHkxf+gLeIgkmV8I44odSIz7nw2JTf65tvICEp0Pn6lQeoTbSnRFIcUw==",
       "requires": {
         "cardinal": "^2.1.1",
         "colors": "^1.1.2",
@@ -9203,18 +8915,19 @@
         "yamljs": "^0.2.8"
       },
       "dependencies": {
-        "json2yaml": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/json2yaml/-/json2yaml-1.1.0.tgz",
-          "integrity": "sha1-VBTZB/mBZYa4DFE+wuOusquBmmw=",
-          "requires": {
-            "remedial": "1.x"
-          }
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "yamljs": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.2.10.tgz",
+          "integrity": "sha1-SBzHwlynOvWfWR8MluPOVsdXpA8=",
+          "requires": {
+            "argparse": "^1.0.7",
+            "glob": "^7.0.5"
+          }
         }
       }
     },
@@ -9831,19 +9544,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-      "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -10168,14 +9868,6 @@
         }
       }
     },
-    "property-information": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.3.0.tgz",
-      "integrity": "sha512-IslotQn1hBCZDY7SaJ3zmCjVea219VTwmOk6Pu3z9haU9m4+T8GwaDubur+6NMHEU+Fjs/6/p66z6QULPkcL1w==",
-      "requires": {
-        "xtend": "^4.0.1"
-      }
-    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -10259,7 +9951,8 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -10514,95 +10207,6 @@
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
-    "rehype-raw": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-4.0.1.tgz",
-      "integrity": "sha512-g74dPCUWeB9EBfTfGF3lGOHSnZwFwN1ssc3Je9OwQO9f8yTkkAIrMqUVxT34h8zpi4ICU051tTLBZbOrzRWpxg==",
-      "requires": {
-        "hast-util-raw": "^5.0.0"
-      }
-    },
-    "rehype-react": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-3.1.0.tgz",
-      "integrity": "sha512-7SiLiqNudSGkvhrePkdKqdUvngZqzG+PJhdR5EeIFELz2j2ek4aO5DHbxUXYvaZfqUiBDO2Aeq1OROUmxmu+Vg==",
-      "requires": {
-        "@mapbox/hast-util-table-cell-style": "^0.1.3",
-        "has": "^1.0.1",
-        "hast-to-hyperscript": "^5.0.0"
-      },
-      "dependencies": {
-        "hast-to-hyperscript": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-5.0.0.tgz",
-          "integrity": "sha512-DLl3eYTz8uwwzEubDUdCChsR5t5b2ne+yvHrA2h58Suq/JnN3+Gsb9Tc4iZoCCsykmFUc6UUpwxTmQXs0akSeg==",
-          "requires": {
-            "comma-separated-tokens": "^1.0.0",
-            "property-information": "^4.0.0",
-            "space-separated-tokens": "^1.0.0",
-            "style-to-object": "^0.2.1",
-            "unist-util-is": "^2.0.0",
-            "web-namespaces": "^1.1.2"
-          }
-        },
-        "property-information": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/property-information/-/property-information-4.2.0.tgz",
-          "integrity": "sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==",
-          "requires": {
-            "xtend": "^4.0.1"
-          }
-        },
-        "unist-util-is": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
-        }
-      }
-    },
-    "rehype-sanitize": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-2.0.3.tgz",
-      "integrity": "sha512-RZFLBV36yOWNbV4g2WJDfilAzV1Sin/InQHXA+5h9+GkxCFnTJCC7SPrAdVHEIrQ882eAD8/51jEYHD6xrewcw==",
-      "requires": {
-        "hast-util-sanitize": "^1.1.0"
-      }
-    },
-    "remark-breaks": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-1.0.3.tgz",
-      "integrity": "sha512-ip5hvJE8vsUJCGfgHaEJbf/JfO6KTZV+NBG68AWkEMhrjHW3Qh7EorED41mCt0FFSTrUDeRiNHovKO7cqgPZmw=="
-    },
-    "remark-parse": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.2.tgz",
-      "integrity": "sha512-9+my0lQS80IQkYXsMA8Sg6m9QfXYJBnXjWYN5U+kFc5/n69t+XZVXU/ZBYr3cYH8FheEGf1v87rkFDhJ8bVgMA==",
-      "requires": {
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.1.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "remark-rehype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-5.0.0.tgz",
-      "integrity": "sha512-tgo+AeOotuh9FnGMkEPbE6C3OfdARqqSxT0H/KNGAiTwJLiDoRSm6x/ytqPZTyYSiQ/exbi/kx7k6uUvqYL1wQ==",
-      "requires": {
-        "mdast-util-to-hast": "^6.0.0"
-      }
-    },
     "remedial": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
@@ -10623,12 +10227,8 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
-    "replace-ext": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "request": {
       "version": "2.88.0",
@@ -11253,11 +10853,6 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
-    "space-separated-tokens": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.4.tgz",
-      "integrity": "sha512-UyhMSmeIqZrQn2UdjYpxEkwY9JUrn8pP+7L4f91zRzOQuI8MF1FGLfYU9DKCYeLdo7LXMxwrX5zKFy7eeeVHuA=="
-    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -11338,11 +10933,6 @@
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
-    },
-    "state-toggle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
-      "integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw=="
     },
     "static-extend": {
       "version": "0.1.2",
@@ -11599,14 +11189,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
-    },
-    "style-to-object": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.2.3.tgz",
-      "integrity": "sha512-1d/k4EY2N7jVLOqf2j04dTc37TPOv/hHxZmvpg8Pdh8UYydxeu/C1W1U4vD8alzf5V2Gt7rLsmkr4dxAlDm9ng==",
-      "requires": {
-        "inline-style-parser": "0.1.1"
-      }
     },
     "supports-color": {
       "version": "2.0.0",
@@ -12136,26 +11718,6 @@
         }
       }
     },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-    },
-    "trim-lines": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.2.tgz",
-      "integrity": "sha512-3GOuyNeTqk3FAqc3jOJtw7FTjYl94XBR5aD9QnDbK/T4CA9sW/J0l9RoaRPE9wyPP7NF331qnHnvJFBJ+IDkmQ=="
-    },
-    "trim-trailing-lines": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
-      "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q=="
-    },
-    "trough": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
-      "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q=="
-    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -12228,27 +11790,6 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.13.tgz",
       "integrity": "sha1-zZ3S+GSTs/RNvu7zeA/adMXuFL4="
     },
-    "unherit": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
-      "integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
-      }
-    },
-    "unified": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-      "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
-      "requires": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^2.0.0",
-        "trough": "^1.0.0",
-        "vfile": "^4.0.0"
-      }
-    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -12277,61 +11818,6 @@
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
-      }
-    },
-    "unist-builder": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
-      "integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
-      "requires": {
-        "object-assign": "^4.1.0"
-      }
-    },
-    "unist-util-generated": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.5.tgz",
-      "integrity": "sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw=="
-    },
-    "unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-    },
-    "unist-util-position": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.4.tgz",
-      "integrity": "sha512-tWvIbV8goayTjobxDIr4zVTyG+Q7ragMSMeKC3xnPl9xzIc0+she8mxXLM3JVNDDsfARPbCd3XdzkyLdo7fF3g=="
-    },
-    "unist-util-remove-position": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
-      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
-      "requires": {
-        "unist-util-visit": "^1.1.0"
-      }
-    },
-    "unist-util-stringify-position": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
-      "integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
-      "requires": {
-        "@types/unist": "^2.0.2"
-      }
-    },
-    "unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-      "requires": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "requires": {
-        "unist-util-is": "^3.0.0"
       }
     },
     "unorm": {
@@ -12543,39 +12029,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "vfile": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz",
-      "integrity": "sha512-yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==",
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-message": "^2.0.0"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-        }
-      }
-    },
-    "vfile-location": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
-    },
-    "vfile-message": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.2.tgz",
-      "integrity": "sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==",
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
-      }
-    },
     "vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -12621,11 +12074,6 @@
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
       }
-    },
-    "web-namespaces": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.3.tgz",
-      "integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA=="
     },
     "webidl-conversions": {
       "version": "4.0.2",
@@ -13129,7 +12577,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",
@@ -13142,15 +12591,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "yamljs": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.2.10.tgz",
-      "integrity": "sha1-SBzHwlynOvWfWR8MluPOVsdXpA8=",
-      "requires": {
-        "argparse": "^1.0.7",
-        "glob": "^7.0.5"
-      }
     },
     "yargs": {
       "version": "15.1.0",
@@ -13322,11 +12762,6 @@
         "lodash.isequal": "^4.5.0",
         "validator": "^11.0.0"
       }
-    },
-    "zwitch": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.4.tgz",
-      "integrity": "sha512-YO803/X+13GNaZB7fVopjvHH0uWQKgJkgKnU1YCjxShjKGVuN9PPHHW8g+uFDpkHpSTNi3rCMKMewIcbC1BAYg=="
     }
   }
 }

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -14,7 +14,7 @@
     "httpsnippet": "^1.19.1",
     "js-cookie": "^2.1.4",
     "lodash.kebabcase": "^4.1.1",
-    "oas": "^1.0.2",
+    "oas": "^1.5.0",
     "prop-types": "^15.7.2",
     "react": "^16.4.2",
     "react-copy-to-clipboard": "^5.0.1",

--- a/packages/api-explorer/src/ResponseSchemaBody.jsx
+++ b/packages/api-explorer/src/ResponseSchemaBody.jsx
@@ -1,16 +1,7 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const markdown = require('@readme/markdown');
-const { findSchemaDefinition } = require('oas/utils');
-
-const flatten = list => list.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []);
-const getName = (parent, prop) => {
-  if (!parent) return prop;
-  if (parent[parent.length - 1] === ' ') return `${parent}${prop}`;
-
-  return `${parent}.${prop}`;
-};
-const capitalizeFirstLetter = (string = '') => string.charAt(0).toUpperCase() + string.slice(1);
+const { flattenArray, flattenSchema } = require('oas/utils');
 
 function getSchemaType(schema) {
   if (schema.type !== 'array') {
@@ -22,74 +13,8 @@ function getSchemaType(schema) {
   return `array of ${schema.items.type}s`;
 }
 
-/* eslint-disable no-use-before-define */
-function flattenObject(obj, parent, level, oas) {
-  return flatten(
-    Object.keys(obj.properties).map(prop => {
-      let value = obj.properties[prop];
-      const array = [];
-      if (value.$ref) {
-        value = findSchemaDefinition(value.$ref, oas);
-      }
-
-      if (value.type === 'object') {
-        array.push(flattenResponseSchema(value, oas, getName(parent, prop), level + 1));
-      }
-
-      if (value.type === 'array' && value.items) {
-        let { items } = value;
-        if (items.$ref) {
-          items = findSchemaDefinition(items.$ref, oas);
-        }
-        if (items.type) {
-          array.push({
-            name: getName(parent, prop),
-            type: `[${capitalizeFirstLetter(items.type)}]`,
-            description: value.description,
-          });
-        }
-        const newParent = parent ? `${parent}.` : '';
-        if (items.type === 'object') {
-          array.push(flattenResponseSchema(items, oas, `${newParent}${prop}[]`, level + 1));
-        }
-        return array;
-      }
-
-      array.unshift({
-        name: getName(parent, prop),
-        type: capitalizeFirstLetter(value.type),
-        description: value.description,
-      });
-      return array;
-    }),
-  );
-}
-/* eslint-enable no-use-before-define */
-
-function flattenResponseSchema(obj, oas, parent = '', level = 0) {
-  if (level > 2) {
-    return [];
-  }
-  let newParent;
-  // top level array
-  if (obj.type === 'array' && obj.items) {
-    if (obj.items.$ref) {
-      const value = findSchemaDefinition(obj.items.$ref, oas);
-      return flattenResponseSchema(value, oas);
-    }
-    newParent = parent ? `${parent}.[]` : '';
-    return flattenResponseSchema(obj.items, oas, `${newParent}`, level + 1);
-  }
-
-  if (obj && !obj.properties) {
-    return [];
-  }
-
-  return flattenObject(obj, parent, level, oas);
-}
-
 function ResponseSchemaBody({ schema, oas }) {
-  const rows = flatten(flattenResponseSchema(schema, oas)).map(row => (
+  const rows = flattenArray(flattenSchema(schema, oas)).map(row => (
     <tr key={Math.random().toString(10)}>
       <th
         style={{
@@ -140,5 +65,3 @@ ResponseSchemaBody.propTypes = {
 };
 
 module.exports = ResponseSchemaBody;
-module.exports.flattenResponseSchema = flattenResponseSchema;
-module.exports.flatten = flatten;

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -872,11 +872,6 @@
         "eslint-plugin-unicorn": "^15.0.0"
       }
     },
-    "@readme/oas-extensions": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-4.15.0.tgz",
-      "integrity": "sha512-8G0RLB8/J/ZYriqL3k13PZtcCb6vBr9s0F7EpSh2o9IfuhXzMye0JacSPMBTGh8Q/ptY0p4NIZ3DaqcYBHc8+g=="
-    },
     "@sinonjs/commons": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
@@ -5696,9 +5691,9 @@
       "dev": true
     },
     "oas": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-1.4.0.tgz",
-      "integrity": "sha512-ZsZCtt9E8h86XBa85QE/HQ1ozZqo6samCzhUeeAq30lXRis64JH9sA6tn8ehRe8Gcyb3DWymNWUjjBZX5YQZPg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-1.5.0.tgz",
+      "integrity": "sha512-xMhXEJsuB+3usaj6w1Ij6TviW6HeV7IHkxf+gLeIgkmV8I44odSIz7nw2JTf65tvICEp0Pn6lQeoTbSnRFIcUw==",
       "requires": {
         "cardinal": "^2.1.1",
         "colors": "^1.1.2",

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^4.16.0",
-    "oas": "^1.0.1",
+    "oas": "^1.5.0",
     "querystring": "^0.2.0"
   },
   "scripts": {


### PR DESCRIPTION
This updates the [oas](https://www.npmjs.com/package/oas) package to do a few things:

- Move core OAS-specific work from `ResponseSchemaBody` out of that and into the `oas` package.
- Fix a bug in that code where if we encountered a response schema property, or `$ref`, that didn't have an explicit `type` property set, we wouldn't include it in the flattened output.

This PR doesn't add any unit tests because those tests have been added in the oas package instead. See https://github.com/readmeio/oas/pull/104 for the PR that has this code migration, bug fix, and unit tests.

That said, here is a screenshot of the schema bug in action:

![Screen Shot 2020-01-28 at 2 38 30 PM](https://user-images.githubusercontent.com/33762/73312185-fc510480-41dc-11ea-84d3-fa12ac3df16c.png)

And with the fix:

![Screen Shot 2020-01-28 at 2 38 10 PM](https://user-images.githubusercontent.com/33762/73312194-007d2200-41dd-11ea-943f-f9fb546c2382.png)

See https://github.com/readmeio/oas/pull/104/files#diff-50da53e033459b1db3c580ac63f65edfR73-R88 for the full test case.