### PR TITLE
fix: oas-to-har now supports common parameters

### DIFF
--- a/packages/oas-to-har/__tests__/fixtures/common-parameters.json
+++ b/packages/oas-to-har/__tests__/fixtures/common-parameters.json
@@ -5,10 +5,6 @@
       "url": "http://httpbin.org"
     }
   ],
-  "info": {
-    "version": "1.0.0",
-    "title": "An example of how we render $ref usage on resource parameters"
-  },
   "paths": {
     "/anything/{id}": {
       "parameters": [
@@ -27,11 +23,6 @@
           }
         }
       ],
-      "get": {
-        "summary": "Get anything",
-        "description": "",
-        "responses": {}
-      },
       "post": {
         "summary": "Post anything",
         "description": "",

--- a/packages/oas-to-har/__tests__/index.test.js
+++ b/packages/oas-to-har/__tests__/index.test.js
@@ -3,6 +3,7 @@ const extensions = require('@readme/oas-extensions');
 const Oas = require('oas');
 
 const oasToHar = require('../src/index');
+const commonParameters = require('./fixtures/common-parameters');
 
 const oas = new Oas();
 
@@ -1108,6 +1109,32 @@ describe('formData values', () => {
         { formData: { a: 'test', b: [1, 2, 3] } },
       ).log.entries[0].request.postData.text,
     ).toBe(querystring.stringify({ a: 'test', b: [1, 2, 3] }));
+  });
+});
+
+describe('common parameters', () => {
+  it('should work for common parameters', () => {
+    expect(
+      oasToHar(
+        new Oas(commonParameters),
+        {
+          ...commonParameters.paths['/anything/{id}'].post,
+          path: '/anything/{id}',
+          method: 'post',
+        },
+        {
+          path: { id: 1234 },
+          header: { 'x-extra-id': 'abcd' },
+          query: { limit: 10 },
+        },
+      ).log.entries[0].request,
+    ).toStrictEqual({
+      headers: [{ name: 'x-extra-id', value: 'abcd' }],
+      queryString: [{ name: 'limit', value: '10' }],
+      postData: {},
+      method: 'POST',
+      url: 'http://httpbin.org/anything/1234',
+    });
   });
 });
 

--- a/packages/oas-to-har/src/index.js
+++ b/packages/oas-to-har/src/index.js
@@ -88,6 +88,18 @@ module.exports = (
     har.url = `https://try.readme.io/${har.url}`;
   }
 
+  if (!pathOperation.parameters) {
+    // eslint-disable-next-line no-param-reassign
+    pathOperation.parameters = [];
+  }
+
+  // Does this operation have any common parameters?
+  if (oas.paths && oas.paths[pathOperation.path] && oas.paths[pathOperation.path].parameters) {
+    oas.paths[pathOperation.path].parameters.forEach(param => {
+      pathOperation.parameters.push(param);
+    });
+  }
+
   if (pathOperation.parameters) {
     pathOperation.parameters.forEach((param, i, params) => {
       if (param.$ref) {


### PR DESCRIPTION
This resolves a bug in the `oas-to-har` package where because it didn't support common parameters, any form input that belonged to one would be ignored and not added to code samples in the explorer.