### PR TITLE
fix: stop mutating the supplied pathOperation object in oas-to-har

### DIFF
--- a/packages/api-explorer/__tests__/fixtures/parameters/common.json
+++ b/packages/api-explorer/__tests__/fixtures/parameters/common.json
@@ -34,6 +34,11 @@
   ],
   "paths": {
     "/pet/{petId}": {
+      "servers": [
+        {
+          "url": "http://petstore.swagger.io/v3"
+        }
+      ],
       "parameters": [
         {
           "name": "petId",

--- a/packages/api-explorer/__tests__/index.test.jsx
+++ b/packages/api-explorer/__tests__/index.test.jsx
@@ -44,7 +44,8 @@ test('ApiExplorer should not render a common parameter OAS operation method', ()
 
   const explorer = shallow(<ApiExplorer {...propsCommon} />);
 
-  expect(explorer.find('Doc')).toHaveLength(docsCommon.length - 1);
+  // Doc should have neither `servers` or `parameters` from the spec because those aren't real HTTP methods.
+  expect(explorer.find('Doc')).toHaveLength(docsCommon.length - 2);
 });
 
 test('should display an error message if it fails to render (wrapped in ErrorBoundary)', () => {

--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -13,6 +13,8 @@ const Doc = require('./Doc');
 
 const getAuth = require('./lib/get-auth');
 
+const supportedHttpMethods = ['delete', 'get', 'head', 'options', 'post', 'put'];
+
 class ApiExplorer extends React.Component {
   constructor(props) {
     super(props);
@@ -156,9 +158,9 @@ class ApiExplorer extends React.Component {
 
   render() {
     const docs = this.props.docs.filter(doc => {
-      // If the HTTP method is `parameters`, then it represents common parameters and we shouldn't
-      // attempt to render it as a normal API operation.
-      if (typeof doc.api !== 'undefined' && doc.api.method === 'parameters') {
+      // If the HTTP method is something we don't support, then we shouldn't attempt to render it as a normal API
+      // operation.
+      if (typeof doc.api !== 'undefined' && !supportedHttpMethods.includes(doc.api.method)) {
         return false;
       }
 

--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -13,7 +13,17 @@ const Doc = require('./Doc');
 
 const getAuth = require('./lib/get-auth');
 
-const supportedHttpMethods = ['delete', 'get', 'head', 'options', 'post', 'put'];
+const supportedHttpMethods = [
+  'connect',
+  'delete',
+  'get',
+  'head',
+  'options',
+  'patch',
+  'post',
+  'put',
+  'trace',
+];
 
 class ApiExplorer extends React.Component {
   constructor(props) {
@@ -160,7 +170,10 @@ class ApiExplorer extends React.Component {
     const docs = this.props.docs.filter(doc => {
       // If the HTTP method is something we don't support, then we shouldn't attempt to render it as a normal API
       // operation.
-      if (typeof doc.api !== 'undefined' && !supportedHttpMethods.includes(doc.api.method)) {
+      if (
+        typeof doc.api !== 'undefined' &&
+        !supportedHttpMethods.includes(doc.api.method.toLowerCase())
+      ) {
         return false;
       }
 

--- a/packages/oas-to-har/__tests__/index.test.js
+++ b/packages/oas-to-har/__tests__/index.test.js
@@ -1135,7 +1135,7 @@ describe('common parameters', () => {
     });
   });
 
-  it.only('should not mutate the original pathOperation that was passed in', () => {
+  it('should not mutate the original pathOperation that was passed in', () => {
     const existingCount = operation.parameters.length;
 
     oasToHar(new Oas(commonParameters), operation, {

--- a/packages/oas-to-har/__tests__/index.test.js
+++ b/packages/oas-to-har/__tests__/index.test.js
@@ -1113,21 +1113,19 @@ describe('formData values', () => {
 });
 
 describe('common parameters', () => {
+  const operation = {
+    ...commonParameters.paths['/anything/{id}'].post,
+    path: '/anything/{id}',
+    method: 'post',
+  };
+
   it('should work for common parameters', () => {
     expect(
-      oasToHar(
-        new Oas(commonParameters),
-        {
-          ...commonParameters.paths['/anything/{id}'].post,
-          path: '/anything/{id}',
-          method: 'post',
-        },
-        {
-          path: { id: 1234 },
-          header: { 'x-extra-id': 'abcd' },
-          query: { limit: 10 },
-        },
-      ).log.entries[0].request,
+      oasToHar(new Oas(commonParameters), operation, {
+        path: { id: 1234 },
+        header: { 'x-extra-id': 'abcd' },
+        query: { limit: 10 },
+      }).log.entries[0].request,
     ).toStrictEqual({
       headers: [{ name: 'x-extra-id', value: 'abcd' }],
       queryString: [{ name: 'limit', value: '10' }],
@@ -1135,6 +1133,18 @@ describe('common parameters', () => {
       method: 'POST',
       url: 'http://httpbin.org/anything/1234',
     });
+  });
+
+  it.only('should not mutate the original pathOperation that was passed in', () => {
+    const existingCount = operation.parameters.length;
+
+    oasToHar(new Oas(commonParameters), operation, {
+      path: { id: 1234 },
+      header: { 'x-extra-id': 'abcd' },
+      query: { limit: 10 },
+    });
+
+    expect(operation.parameters).toHaveLength(existingCount);
   });
 });
 

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -3570,6 +3570,11 @@
         }
       }
     },
+    "is-docker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -5691,9 +5696,9 @@
       "dev": true
     },
     "oas": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-1.5.0.tgz",
-      "integrity": "sha512-xMhXEJsuB+3usaj6w1Ij6TviW6HeV7IHkxf+gLeIgkmV8I44odSIz7nw2JTf65tvICEp0Pn6lQeoTbSnRFIcUw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-1.5.1.tgz",
+      "integrity": "sha512-/B1lvJ2YMsAHACYR06shsoj8nVmqjztc86KoCnMMosjHlsxje3qPE0l/shXO6ItBrmY8VKxKBBBr0mn4egjtWA==",
       "requires": {
         "cardinal": "^2.1.1",
         "colors": "^1.1.2",
@@ -6093,11 +6098,12 @@
       "integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
     },
     "open": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.0.0.tgz",
-      "integrity": "sha512-K6EKzYqnwQzk+/dzJAQSBORub3xlBTxMz+ntpZpH/LyCa1o6KjXhuN+2npAaI9jaSmU3R1Q8NWf4KUWcyytGsQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.0.1.tgz",
+      "integrity": "sha512-/fVm742AZt6bZ3NpbmBzGpZksDiGbo+xz8RylegKSAnTCgT5u5tvJe0cre3QxICphqHhJHc0OFtFyvU7rNx8+Q==",
       "requires": {
-        "is-wsl": "^2.1.0"
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
       }
     },
     "openapi-schemas": {

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^4.16.0",
-    "oas": "^1.5.0",
+    "oas": "^1.5.1",
     "querystring": "^0.2.0"
   },
   "scripts": {


### PR DESCRIPTION
This resolves a major bug in the `oas-to-har` package with regard to how we were handling common parameters. 

When we call the the package to create a HAR object to call, we'd supply it with a `pathOperation` object that represented the current path+method we're processing in the current OAS file. The problem is that inside `oas-to-har`, when constructing parameters to add into the HAR, we were doing so on the `pathOperation` object that was supplied instead of against an instance variable to that function.

This meant that every time a user would click "Try It" to make an API call, we'd re-add the same common parameters to the instanced `operation` variable further up the stack in `Doc.jsx`. This would then cascade back down into `oas-to-har` and we'd slowly begin to exponentially double up on common parameters.

🙃 

Also in this PR was another bug I uncovered while investigating this one in that when we were parsing an operation, if a `servers` object was present at the HTTP method level in the operation, we'd interpret that as an HTTP method and build out an explorer document for that. We're now hardcoding to only rendering out API operations that implement every method listed on https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods.