### PR TITLE
feat: setting a custom header for all "Try It" requests

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -4516,9 +4516,9 @@
       }
     },
     "fetch-har": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fetch-har/-/fetch-har-2.1.0.tgz",
-      "integrity": "sha512-tdLjwZ/8TAEMiO2yD0t1Zj/wscXgYTPSZOBQF9WEO17uYcjIQp/PbD/+UXRpYiyrj7CfjFjwPIaK+OuAE4TpsA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-har/-/fetch-har-2.2.0.tgz",
+      "integrity": "sha512-7QXY711Vnr4nInGqn4b+26keGHkmy0dSXTCMTGH8YzVRvLI99fHzU/yNu+9cYXruu9uK4/ASVA3IAsM6qXw7xg=="
     },
     "figgy-pudding": {
       "version": "3.5.1",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -10,7 +10,7 @@
     "@readme/syntax-highlighter": "^4.16.0",
     "@readme/variable": "^4.16.0",
     "classnames": "^2.2.5",
-    "fetch-har": "^2.0.0",
+    "fetch-har": "^2.2.0",
     "httpsnippet": "^1.19.1",
     "js-cookie": "^2.1.4",
     "lodash.kebabcase": "^4.1.1",

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -70,7 +70,7 @@ class Doc extends React.Component {
       proxyUrl: true,
     });
 
-    return fetchHar(har).then(async res => {
+    return fetchHar(har, 'ReadMe API Explorer').then(async res => {
       this.props.tryItMetrics(har, res);
 
       this.setState({

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -21,6 +21,8 @@ const { Operation } = Oas;
 const parseResponse = require('./lib/parse-response');
 const Content = require('./block-types/Content');
 
+const pkg = require('../package.json');
+
 class Doc extends React.Component {
   constructor(props) {
     super(props);
@@ -70,7 +72,7 @@ class Doc extends React.Component {
       proxyUrl: true,
     });
 
-    return fetchHar(har, 'ReadMe API Explorer').then(async res => {
+    return fetchHar(har, `ReadMe API Explorer/${pkg.version}`).then(async res => {
       this.props.tryItMetrics(har, res);
 
       this.setState({


### PR DESCRIPTION
I'm iffy on the header name, but this will allow people to split apart "Try It" requests in their Developer Metrics.