### PR TITLE
fix: setting `x-readme-api-explorer` instead of a custom UA

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -4516,9 +4516,9 @@
       }
     },
     "fetch-har": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-har/-/fetch-har-2.2.0.tgz",
-      "integrity": "sha512-7QXY711Vnr4nInGqn4b+26keGHkmy0dSXTCMTGH8YzVRvLI99fHzU/yNu+9cYXruu9uK4/ASVA3IAsM6qXw7xg=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fetch-har/-/fetch-har-2.2.1.tgz",
+      "integrity": "sha512-DrujvjZu0lMhL19ZlP6vaL3pOsP5V+JITGIRNDxRAPSjiQqJv2Q0y74wtn4NWYbgZSD8VVroaOunH/2LXllGAA=="
     },
     "figgy-pudding": {
       "version": "3.5.1",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -10,7 +10,7 @@
     "@readme/syntax-highlighter": "^4.16.0",
     "@readme/variable": "^4.16.0",
     "classnames": "^2.2.5",
-    "fetch-har": "^2.2.0",
+    "fetch-har": "^2.2.1",
     "httpsnippet": "^1.19.1",
     "js-cookie": "^2.1.4",
     "lodash.kebabcase": "^4.1.1",


### PR DESCRIPTION
There's a bug in Firefox and Chrome where they don't respect setting a custom User-Agent on fetch() requests, so instead to let API metrics know that this request came from the Explorer, we're setting a vendor header instead.

https://stackoverflow.com/questions/42815087/sending-a-custom-user-agent-string-along-with-my-headers-fetch

Also updated `fetch-har` to 2.2.1 so it uses the `Headers` API instead of working with a bare object in the `Request` module.