### PR TITLE
Put params before logs

### DIFF
--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -133,8 +133,8 @@ class Doc extends React.Component {
 
             <div className="hub-reference-section">
               <div className="hub-reference-left">
-                {this.renderLogs()}
                 {this.renderParams()}
+                {this.renderLogs()}
               </div>
               <div className="hub-reference-right switcher">{this.renderResponseSchema()}</div>
             </div>
@@ -155,8 +155,8 @@ class Doc extends React.Component {
               {doc.type === 'endpoint' && (
                 <React.Fragment>
                   {this.renderPathUrl()}
-                  {this.renderLogs()}
                   {this.renderParams()}
+                  {this.renderLogs()}
                 </React.Fragment>
               )}
 


### PR DESCRIPTION
We don't always have logs, so there's a ton of gray area just hangin' out above the parameters. We also update code snippets when you type, but you can't see it when the params are so far down!