### PR TITLE
fix: edge case where Content-Type could sometimes be doubled up

### DIFF
--- a/packages/oas-to-har/__tests__/index.test.js
+++ b/packages/oas-to-har/__tests__/index.test.js
@@ -1435,6 +1435,38 @@ describe('content-type & accept header', () => {
       ).log.entries[0].request.headers
     ).toStrictEqual([{ name: 'Content-Type', value: 'application/json' }]);
   });
+
+  it("should only add a content-type if one isn't already present", () => {
+    const har = oasToHar(
+      new Oas({
+        'x-headers': [{ key: 'Content-Type', value: 'multipart/form-data' }],
+      }),
+      {
+        path: '/',
+        method: 'put',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['a'],
+                properties: {
+                  a: {
+                    type: 'string',
+                  },
+                },
+              },
+              example: { a: 'value' },
+            },
+          },
+        },
+      }
+    );
+
+    // `Content-Type: application/json` would normally appear here if there were no `x-headers`, but since there is
+    // we should default to that so as to we don't double up on Content-Type headers.
+    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'multipart/form-data' }]);
+  });
 });
 
 describe('x-headers', () => {


### PR DESCRIPTION
This resolves an edge case where if an `x-headers` array, or as a parameter, with a `Content-Type` is present on an OAS, we'd double up `Content-Type` when building a HAR with the mime type defined on the `requestBody`.

Content types defined in `x-headers`, or parameters, should always take precedence.