### PR TITLE
fix: downgrading datetime inputs to simple text inputs

### DIFF
--- a/example/swagger-files/types.json
+++ b/example/swagger-files/types.json
@@ -77,6 +77,7 @@
                     "format": "date"
                   },
                   "string (format: date-time)": {
+                    "description": "Temporarily disabled back to a simple string input due to a bug in RJSF",
                     "type": "string",
                     "format": "date-time"
                   },

--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -190,8 +190,8 @@ describe('schema format handling', () => {
     it.each([
       ['password', 'password', stringOas.operation('/format-password', 'get'), 'password'],
       ['date', 'text', stringOas.operation('/format-date', 'get'), 'date'],
-      ['date-time', 'datetime-local', stringOas.operation('/format-date-time', 'get'), 'date-time'],
-      ['dateTime', 'datetime-local', stringOas.operation('/format-dateTime', 'get'), 'date-time'],
+      ['date-time', 'text', stringOas.operation('/format-date-time', 'get'), 'string'],
+      ['dateTime', 'text', stringOas.operation('/format-dateTime', 'get'), 'string'],
       ['uri', 'url', stringOas.operation('/format-uri', 'get'), 'uri'],
       ['url', 'url', stringOas.operation('/format-url', 'get'), 'url'],
     ])(`%s should render as <input type="%s">`, (type, inputType, stringOperation, label) => {

--- a/packages/api-explorer/src/Params.jsx
+++ b/packages/api-explorer/src/Params.jsx
@@ -2,7 +2,7 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const Form = require('react-jsonschema-form').default;
 
-const DateTimeWidget = require('react-jsonschema-form/lib/components/widgets/DateTimeWidget').default;
+// const DateTimeWidget = require('react-jsonschema-form/lib/components/widgets/DateTimeWidget').default;
 const PasswordWidget = require('react-jsonschema-form/lib/components/widgets/PasswordWidget').default;
 const TextWidget = require('react-jsonschema-form/lib/components/widgets/TextWidget').default;
 const UpDownWidget = require('react-jsonschema-form/lib/components/widgets/UpDownWidget').default;
@@ -66,8 +66,10 @@ function Params({
             binary: FileWidget,
             byte: TextWidget,
             date: TextWidget,
-            dateTime: DateTimeWidget,
-            'date-time': DateTimeWidget,
+            // Temporarily disabling support for rendering the datetime widget as RJSF appears to be disabling it in
+            // browsers that don't fully support it.
+            /* dateTime: DateTimeWidget,
+            'date-time': DateTimeWidget, */
             double: UpDownWidget,
             duration: TextWidget,
             float: UpDownWidget,

--- a/packages/api-explorer/src/ResponseExample.jsx
+++ b/packages/api-explorer/src/ResponseExample.jsx
@@ -249,7 +249,9 @@ class ResponseExample extends React.Component {
                         <div className="example example_json">{transformExampleIntoReactJson(example)}</div>
                       ) : (
                         // json + multiple examples is already handled in `showExamples`.
-                        <>{isJson && example.multipleExamples ? null : getHighlightedExample(example)}</>
+                        <React.Fragment>
+                          {isJson && example.multipleExamples ? null : getHighlightedExample(example)}
+                        </React.Fragment>
                       )}
                     </pre>
                   </div>


### PR DESCRIPTION
There appears to be a bug in RJSF right now where it's disabling input into `<input type="datetime-local">` inputs in Firefox. As a quick hotfix, we're downgrading our format support of `datetime` and `date-time` to simple text inputs.