### PR TITLE
chore(deps): upgrading @readme/oas-tooling to 2.1.1

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1180,9 +1180,9 @@
       }
     },
     "@readme/oas-tooling": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-2.1.0.tgz",
-      "integrity": "sha512-g/5piQNBa/IyNzpDvlrTCtf3/CNMHEDYMigC71aGSaqJwTxafhi/tyYOkZCYeq4yHXyGRLhcFAWL8NA3EUnwVQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-2.1.1.tgz",
+      "integrity": "sha512-gIzonSW5P7mSYn0IFLlbMxqWSa/geDce5Vsz5O7XT231K2aQWnmOW8H1cadYQAzdBJJbjzZTNJSrKr5QJDl7yQ==",
       "requires": {
         "path-to-regexp": "^6.1.0"
       }

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -7,7 +7,7 @@
     "@readme/markdown": "^4.18.2",
     "@readme/oas-extensions": "^4.18.2",
     "@readme/oas-to-har": "^4.19.0",
-    "@readme/oas-tooling": "^2.1.0",
+    "@readme/oas-tooling": "^2.1.1",
     "@readme/syntax-highlighter": "^4.18.2",
     "@readme/variable": "^4.18.2",
     "classnames": "^2.2.5",

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -863,9 +863,9 @@
       }
     },
     "@readme/oas-tooling": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-2.1.0.tgz",
-      "integrity": "sha512-g/5piQNBa/IyNzpDvlrTCtf3/CNMHEDYMigC71aGSaqJwTxafhi/tyYOkZCYeq4yHXyGRLhcFAWL8NA3EUnwVQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-2.1.1.tgz",
+      "integrity": "sha512-gIzonSW5P7mSYn0IFLlbMxqWSa/geDce5Vsz5O7XT231K2aQWnmOW8H1cadYQAzdBJJbjzZTNJSrKr5QJDl7yQ==",
       "requires": {
         "path-to-regexp": "^6.1.0"
       }

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^4.18.2",
-    "@readme/oas-tooling": "^2.1.0",
+    "@readme/oas-tooling": "^2.1.1",
     "querystring": "^0.2.0"
   },
   "scripts": {


### PR DESCRIPTION
This updates @readme/oas-tooling to 2.1.1 to resolve an issue with the `parameters-to-json-schema` library we're using where it would error on parsing OpenAPI schemas with a `null` property.

See https://github.com/readmeio/oas/pull/114 for the full details.