### PR TITLE
feat: backporting the legacy markdown engine to run alongside the new

### DIFF
--- a/packages/api-explorer/__tests__/ResponseSchema.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseSchema.test.jsx
@@ -30,17 +30,30 @@ test('selectedStatus should change state of selectedStatus', () => {
   expect(responseSchema.state('selectedStatus')).toBe('400');
 });
 
-test('should display response schema description', () => {
-  const responseSchema = shallow(<ResponseSchema {...props} />);
-  const text = responseSchema
-    .find('div.desc')
-    .first()
-    .find('div.desc')
-    .find('p')
-    .first()
-    .text();
-  expect(text).toBe(props.operation.responses['200'].description);
-});
+test.each([[true], [false]])(
+  'should display response schema description [new markdown engine=%s]',
+  useNewMarkdownEngine => {
+    const responseSchema = shallow(<ResponseSchema {...props} useNewMarkdownEngine={useNewMarkdownEngine} />);
+    let text;
+
+    if (useNewMarkdownEngine) {
+      text = responseSchema
+        .find('div.desc')
+        .first()
+        .find('div.desc')
+        .find('p')
+        .first()
+        .text();
+    } else {
+      text = responseSchema
+        .find('div.desc')
+        .first()
+        .text();
+    }
+
+    expect(text).toBe(props.operation.responses['200'].description);
+  }
+);
 
 test('should work if there are no responses', () => {
   // Need to create a new operation without any responses

--- a/packages/api-explorer/__tests__/ResponseSchemaBody.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseSchemaBody.test.jsx
@@ -221,7 +221,10 @@ test('render top level array of objects', () => {
   ).toHaveLength(1);
 });
 
-test('should render markdown in the description', () => {
+test.each([
+  [true, '<a href="https://example.com" target="_self" title="">Description</a>'],
+  [false, '<a href="https://example.com" target="_self">Description</a>'],
+])('should render markdown in the description [new markdown engine=%s]', (useNewMarkdownEngine, expected) => {
   const schema = {
     type: 'object',
     properties: {
@@ -233,10 +236,10 @@ test('should render markdown in the description', () => {
   };
 
   expect(
-    mount(<ResponseSchemaBody oas={oas} schema={schema} />)
+    mount(<ResponseSchemaBody oas={oas} schema={schema} useNewMarkdownEngine={useNewMarkdownEngine} />)
       .find('a')
       .html()
-  ).toBe('<a href="https://example.com" target="_self" title="">Description</a>');
+  ).toBe(expected);
 });
 
 test('should show "string" response type for a simple `string` schema', () => {

--- a/packages/api-explorer/__tests__/block-types/ApiHeader.test.jsx
+++ b/packages/api-explorer/__tests__/block-types/ApiHeader.test.jsx
@@ -1,0 +1,29 @@
+const React = require('react');
+const { shallow } = require('enzyme');
+const ApiHeader = require('../../src/block-types/ApiHeader');
+
+const block = {
+  type: 'api-header',
+  data: {
+    title: 'This is header',
+    type: 'post',
+  },
+};
+
+describe('ApiHeader', () => {
+  it('Api Header will render text in table header cells', () => {
+    const apiHeader = shallow(<ApiHeader block={block} />);
+    expect(apiHeader.find('h1').text()).toBe('This is header');
+  });
+
+  it('should render with the type in a span', () => {
+    const apiHeader = shallow(<ApiHeader block={block} />);
+    expect(apiHeader.find(`span.type-${block.data.type}`)).toHaveLength(1);
+  });
+
+  it('should create an #id with the slug of the title', () => {
+    const apiHeader = shallow(<ApiHeader block={block} />);
+    expect(apiHeader.find(`span#this-is-header`)).toHaveLength(1);
+    expect(apiHeader.find(`#section-this-is-header`)).toHaveLength(1);
+  });
+});

--- a/packages/api-explorer/__tests__/block-types/CallOut.test.jsx
+++ b/packages/api-explorer/__tests__/block-types/CallOut.test.jsx
@@ -1,0 +1,92 @@
+const React = require('react');
+const { shallow, mount } = require('enzyme');
+const CallOut = require('../../src/block-types/CallOut');
+
+test('should render title', () => {
+  const block = {
+    data: {
+      type: 'info',
+      title: 'Callout',
+    },
+  };
+  const callout = mount(<CallOut block={block} />);
+  expect(callout.find('h3').text()).toBe('Callout');
+});
+
+describe('icons', () => {
+  const icons = {
+    info: 'info-circle',
+    warning: 'exclamation-circle',
+    danger: 'exclamation-triangle',
+    success: 'check-square',
+  };
+
+  it('should render with title', () => {
+    Object.keys(icons).forEach(type => {
+      const className = icons[type];
+      const block = {
+        data: {
+          type,
+          title: 'Callout',
+        },
+      };
+      expect(mount(<CallOut block={block} />).find(`.fa-${className}`)).toHaveLength(1);
+    });
+  });
+
+  it('should render without title', () => {
+    Object.keys(icons).forEach(type => {
+      const className = icons[type];
+      const block = {
+        data: {
+          type,
+        },
+      };
+      expect(mount(<CallOut block={block} />).find(`.noTitleIcon .fa-${className}`)).toHaveLength(1);
+    });
+  });
+});
+
+test('should render nothing if no title and icon', () => {
+  const block = {
+    data: {
+      type: '',
+    },
+  };
+  const callout = mount(<CallOut block={block} />);
+  expect(callout.find('span').text()).toBe('');
+});
+
+test('should render body', () => {
+  const block = {
+    data: {
+      type: 'info',
+      body: 'body',
+    },
+  };
+
+  const callout = shallow(<CallOut block={block} />);
+  expect(
+    callout
+      .render()
+      .find('.callout-body')
+      .html()
+  ).toMatchSnapshot();
+});
+
+test('should render markdown in body', () => {
+  const block = {
+    data: {
+      type: 'info',
+      body: '# heading\n`test`',
+    },
+  };
+
+  const callout = shallow(<CallOut block={block} />);
+  expect(
+    callout
+      .render()
+      .find('.callout-body')
+      .html()
+  ).toMatchSnapshot();
+});

--- a/packages/api-explorer/__tests__/block-types/Code.test.jsx
+++ b/packages/api-explorer/__tests__/block-types/Code.test.jsx
@@ -1,0 +1,143 @@
+const React = require('react');
+const { mount } = require('enzyme');
+const Code = require('../../src/block-types/Code');
+
+const block = {
+  type: 'code',
+  sidebar: undefined,
+  data: {
+    codes: [
+      {
+        code: 'whjdwhjwejhkwhjk',
+        language: 'text',
+        status: 400,
+        name: 'test',
+      },
+      {
+        code: 'var a = 1',
+        language: 'javascript',
+      },
+      {
+        code: 'whjdwhjwejhkwhjk',
+        language: 'text',
+        name: 'test',
+      },
+    ],
+  },
+};
+
+const block3 = {
+  type: 'code',
+  sidebar: undefined,
+  data: {
+    codes: [
+      {
+        code: 'whjdwhjwejhkwhjk',
+        language: 'text',
+        status: 400,
+      },
+    ],
+  },
+};
+
+const badBlock = {
+  type: 'code',
+  sidebar: undefined,
+  data: {
+    codes: {
+      code: {
+        code: 'whjdwhjwejhkwhjk',
+        language: 'text',
+        status: 400,
+      },
+    },
+  },
+};
+
+const block2 = {
+  type: 'code',
+  sidebar: undefined,
+  data: {
+    codes: [
+      {
+        code: 'var a = 1',
+        language: 'javascript',
+      },
+    ],
+  },
+};
+
+test('Code will render name if provided within em tag if codes has a status', () => {
+  const codeInput = mount(<Code block={block} />);
+  expect(codeInput.find('em').text()).toBe('test');
+});
+
+test('Code will render status code within em tag', () => {
+  const codeInput = mount(<Code block={block3} />);
+  expect(codeInput.find('em').text()).toBe('Bad Request');
+});
+
+test('If codes array is not passed as an array expect empty array', () => {
+  const codeInput = mount(<Code block={badBlock} />);
+
+  expect(codeInput.find('span').text()).toBe('');
+});
+
+test('Code will render language if name or status is not provided within a tag if codes has a status', () => {
+  const codeInput = mount(<Code block={block2} />);
+  expect(codeInput.find('a').text()).toBe('JavaScript');
+});
+
+test('Code will render label if provided within opts', () => {
+  const codeInput = mount(<Code block={block} opts={{ label: 'label' }} />);
+  expect(codeInput.find('label').text()).toBe('label');
+});
+
+test('Code should switch tabs', () => {
+  const codeInput = mount(<Code block={block} opts={{}} />);
+  const anchor = codeInput.find('li a').at(1);
+  anchor.simulate('click');
+  expect(anchor.render().hasClass('active')).toBe(true);
+});
+
+test('should uppercase known languages', () => {
+  expect(
+    mount(
+      <Code
+        block={{
+          data: {
+            codes: [
+              {
+                language: 'http',
+                code: '',
+              },
+            ],
+          },
+        }}
+      />
+    )
+      .find('li a')
+      .text()
+  ).toBe('HTTP');
+});
+
+test('should pass through unknown languages', () => {
+  expect(
+    mount(
+      <Code
+        block={{
+          data: {
+            codes: [
+              {
+                language: 'unknown-language-somehow',
+                code: '',
+              },
+            ],
+          },
+        }}
+      />
+    )
+      .find('li a')
+      .text()
+  ).toBe('unknown-language-somehow');
+});

--- a/packages/api-explorer/__tests__/block-types/Content.test.jsx
+++ b/packages/api-explorer/__tests__/block-types/Content.test.jsx
@@ -1,0 +1,84 @@
+const React = require('react');
+const fs = require('fs');
+const { mount } = require('enzyme');
+const Content = require('../../src/block-types/Content');
+
+test('should output one of each block type', () => {
+  const body = fs.readFileSync(`${__dirname}/blocks.txt`, 'utf8');
+  const content = mount(<Content body={body} isThreeColumn />);
+
+  ['textarea', 'html', 'embed', 'api-header', 'code', 'callout', 'parameters', 'image'].forEach(type => {
+    expect(content.find(`.magic-block-${type}`)).toHaveLength(1);
+  });
+});
+
+const body = `
+  [block:api-header]
+  {
+    "title": "This is cool header",
+    "sidebar": true
+  }
+  [/block]
+  [block:textarea]
+  {
+    "text": "This is text area"
+  }
+  [/block]
+`;
+
+test('should output only left content if `isThreeColumn=left`', () => {
+  const content = mount(<Content body={body} isThreeColumn="left" />);
+
+  expect(content.find('.magic-block-textarea')).toHaveLength(1);
+});
+
+test('should output only right content if `isThreeColumn=right`', () => {
+  const content = mount(<Content body={body} isThreeColumn="right" />);
+
+  expect(content.find('.magic-block-api-header')).toHaveLength(1);
+});
+
+test('should make code not-dark if it is in the left column', () => {
+  const content = mount(
+    <Content
+      body={`
+        [block:code]
+        {
+          "codes": [
+            {
+              "code": "var a = 1;",
+              "language": "javascript"
+            }
+          ]
+        }
+        [/block]
+      `}
+      isThreeColumn="left"
+    />
+  );
+
+  expect(content.html()).toContain('cm-s-neo');
+});
+
+test('should make code `dark` if it is in right column', () => {
+  const content = mount(
+    <Content
+      body={`
+        [block:code]
+        {
+          "codes": [
+            {
+              "code": "var a = 1;",
+              "language": "javascript"
+            }
+          ],
+          "sidebar": true
+        }
+        [/block]
+      `}
+      isThreeColumn="right"
+    />
+  );
+
+  expect(content.html()).toContain('cm-s-tomorrow-night');
+});

--- a/packages/api-explorer/__tests__/block-types/Embed.test.jsx
+++ b/packages/api-explorer/__tests__/block-types/Embed.test.jsx
@@ -1,0 +1,63 @@
+const React = require('react');
+const { shallow } = require('enzyme');
+const Embed = require('../../src/block-types/Embed');
+
+describe('Embed', () => {
+  it('Embed will have src property if iframe is true', () => {
+    const block = {
+      type: 'embed',
+      data: {
+        html: false,
+        url: 'http://jsbin.com/fewilipowi/edit?js,output',
+        title: 'JS Bin',
+        favicon: 'http://static.jsbin.com/images/favicon.png',
+        image: 'http://static.jsbin.com/images/logo.png',
+        iframe: true,
+      },
+      sidebar: undefined,
+    };
+    const embedInput = shallow(<Embed block={block} />);
+    expect(embedInput.find('iframe').prop('src')).toBe('http://jsbin.com/fewilipowi/edit?js,output');
+    // expect(embedInput.find('iframe').text()).toBe('');
+  });
+
+  it('Embed will have no text property if iframe is false', () => {
+    const url =
+      '<iframe class="embedly-embed" src="//cdn.embedly.com/widgets/media.html?src=https%3A%2F%2Fwww.youtube.com%2Fembed%2FjYjDqzZ4gjY%3Ffeature%3Doembed&url=http%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DjYjDqzZ4gjY&image=https%3A%2F%2Fi.ytimg.com%2Fvi%2FjYjDqzZ4gjY%2Fhqdefault.jpg&key=f2aa6fc3595946d0afc3d76cbbd25dc3&type=text%2Fhtml&schema=youtube" width="640" height="480" scrolling="no" frameborder="0" allowfullscreen></iframe>';
+    const block = {
+      type: 'embed',
+      data: {
+        favicon: 'https://s.ytimg.com/yts/img/ringo/img/favicon-vfl8qSV2F.ico',
+        html: url,
+        image: 'https://i.ytimg.com/vi/jYjDqzZ4gjY/hqdefault.jpg',
+        sidebar: true,
+        title: 'White kids Watch me whip school Chorus',
+        url: 'https://www.youtube.com/watch?v=jYjDqzZ4gjY',
+      },
+      sidebar: true,
+    };
+    const embedInput = shallow(<Embed block={block} />);
+
+    expect(embedInput.find('span').text()).toBe('');
+  });
+
+  it('Embed will have a and img tag if favicon is provided but iframe and html condition is false', () => {
+    const block = {
+      type: 'embed',
+      data: {
+        html: false,
+        url: 'http://jsbin.com/fewilipowi/edit?js,output',
+        favicon: 'http://static.jsbin.com/images/favicon.png',
+        image: 'http://static.jsbin.com/images/logo.png',
+        iframe: false,
+        width: '100%',
+        height: '300px',
+      },
+      sidebar: undefined,
+    };
+    const embedInput = shallow(<Embed block={block} />);
+    expect(embedInput.find('strong').html()).toBe(
+      '<strong><img alt="" class="favicon" src="http://static.jsbin.com/images/favicon.png"/><a href="http://jsbin.com/fewilipowi/edit?js,output" target="_new">http://jsbin.com/fewilipowi/edit?js,output</a></strong>'
+    );
+  });
+});

--- a/packages/api-explorer/__tests__/block-types/Html.test.jsx
+++ b/packages/api-explorer/__tests__/block-types/Html.test.jsx
@@ -1,0 +1,19 @@
+const React = require('react');
+const { shallow } = require('enzyme');
+const Html = require('../../src/block-types/Html');
+
+const block = {
+  type: 'html',
+  data: {
+    html: '<p>This is an html</p>',
+  },
+  sidebar: undefined,
+};
+
+describe('Html', () => {
+  it('should display innerHtml', () => {
+    const htmlInput = shallow(<Html block={block} />);
+    expect(htmlInput.find('.magic-block-html')).toHaveLength(1);
+    expect(htmlInput.html()).toBe('<div class="magic-block-html"><p>This is an html</p></div>');
+  });
+});

--- a/packages/api-explorer/__tests__/block-types/Image.test.jsx
+++ b/packages/api-explorer/__tests__/block-types/Image.test.jsx
@@ -1,0 +1,58 @@
+const React = require('react');
+const { shallow } = require('enzyme');
+const Image = require('../../src/block-types/Image');
+
+describe('Image', () => {
+  it('Image has a tag with property href set to url', () => {
+    const block = {
+      type: 'image',
+      data: {
+        images: [
+          {
+            image: [
+              'https://files.readme.io/924824e-fullsizeoutput_314.jpeg',
+              'fullsizeoutput_314.jpeg',
+              640,
+              1136,
+              '#c8b396',
+            ],
+          },
+        ],
+      },
+      sidebar: undefined,
+    };
+    const imageInput = shallow(<Image block={block} />);
+
+    expect(imageInput.find('a').prop('href')).toBe('https://files.readme.io/924824e-fullsizeoutput_314.jpeg');
+  });
+
+  it('Image will render caption if given in props', () => {
+    const block = {
+      type: 'image',
+      data: {
+        images: [
+          {
+            image: [
+              'https://files.readme.io/924824e-fullsizeoutput_314.jpeg',
+              'fullsizeoutput_314.jpeg',
+              640,
+              1136,
+              '#c8b396',
+            ],
+            caption: 'doggo',
+          },
+        ],
+      },
+      sidebar: undefined,
+    };
+
+    const imageInput = shallow(<Image block={block} />);
+
+    expect(
+      imageInput
+        .find('figcaption')
+        .render()
+        .text()
+    ).toBe('doggo');
+  });
+});

--- a/packages/api-explorer/__tests__/block-types/Parameters.test.jsx
+++ b/packages/api-explorer/__tests__/block-types/Parameters.test.jsx
@@ -1,0 +1,29 @@
+const React = require('react');
+const { shallow } = require('enzyme');
+const Parameters = require('../../src/block-types/Parameters');
+
+describe('Parameters', () => {
+  it('Parameters will render text in table', () => {
+    const block = {
+      type: 'parameters',
+      sidebar: undefined,
+      data: {
+        cols: 1,
+        rows: 1,
+        data: {
+          '0-0': 'arbitrary',
+          'h-0': 'test',
+        },
+      },
+    };
+
+    const parametersInput = shallow(<Parameters block={block} />);
+    expect(parametersInput.find('div.th').text()).toBe('test');
+    expect(
+      parametersInput
+        .find('div.td')
+        .render()
+        .text()
+    ).toBe('arbitrary');
+  });
+});

--- a/packages/api-explorer/__tests__/block-types/TextArea.test.jsx
+++ b/packages/api-explorer/__tests__/block-types/TextArea.test.jsx
@@ -1,0 +1,14 @@
+const React = require('react');
+const { shallow } = require('enzyme');
+const TextArea = require('../../src/block-types/TextArea');
+
+describe('TextArea', () => {
+  it('Text area will output text', () => {
+    const block = {
+      type: 'textarea',
+      text: 'this is text',
+    };
+    const textArea = shallow(<TextArea block={block} />);
+    expect(textArea.find('p').text()).toBe(block.text);
+  });
+});

--- a/packages/api-explorer/__tests__/block-types/__snapshots__/CallOut.test.jsx.snap
+++ b/packages/api-explorer/__tests__/block-types/__snapshots__/CallOut.test.jsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render body 1`] = `"<p>body</p>"`;
+
+exports[`should render markdown in body 1`] = `
+"<h1 class=\\"header-scroll\\"><div class=\\"anchor waypoint\\" id=\\"section-heading\\"></div>heading<a class=\\"fa fa-anchor\\" href=\\"#section-heading\\"></a></h1>
+<p><code><span class=\\"cm-s-neo\\">test</span></code></p>"
+`;

--- a/packages/api-explorer/__tests__/block-types/blocks.txt
+++ b/packages/api-explorer/__tests__/block-types/blocks.txt
@@ -1,0 +1,82 @@
+[block:textarea]
+{
+  "text": "This is text area"
+}
+[/block]
+[block:html]
+{
+  "html": "<p>This is an html</p>"
+}
+[/block]
+[block:api-header]
+{
+  "title": "This is cool header",
+  "sidebar": true
+}
+[/block]
+
+[block:callout]
+{
+  "type": "info",
+  "title": "Callout"
+}
+[/block]
+
+[block:image]
+{
+   "images": [
+    {
+      "image": [
+        "https://files.readme.io/924824e-fullsizeoutput_314.jpeg",
+        "fullsizeoutput_314.jpeg",
+        640,
+        1136,
+        "#c8b396"
+      ]
+    }
+  ]
+}
+[/block]
+
+[block:code]
+{
+  "codes": [
+     {
+        "code": "whjdwhjwejhkwhjk",
+        "language": "text",
+        "status": 400,
+        "name": "    "
+      },
+      {
+        "code": "var a = 1;",
+        "language": "javascript"
+      }
+  ]
+}
+[/block]
+
+[block:parameters]
+{
+  "data": {
+    "0-0": "arbitrary",
+    "0-1": "info",
+    "0-2": "test",
+    "h-0": "test",
+    "h-1": "1",
+    "h-2": "2"
+  },
+  "cols": 3,
+  "rows": 1
+}
+[/block]
+
+[block:embed]
+{
+	"html": "<iframe class=\"embedly-embed\" src=\"//cdn.embedly.com/widgets/media.html?src=https%3A%2F%2Fwww.youtube.com%2Fembed%2FjYjDqzZ4gjY%3Ffeature%3Doembed&url=http%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DjYjDqzZ4gjY&image=https%3A%2F%2Fi.ytimg.com%2Fvi%2FjYjDqzZ4gjY%2Fhqdefault.jpg&key=02466f963b9b4bb8845a05b53d3235d7&type=text%2Fhtml&schema=youtube\" width=\"640\" height=\"480\" scrolling=\"no\" frameborder=\"0\" allowfullscreen></iframe>",
+	"url": "https://www.youtube.com/watch?v=jYjDqzZ4gjY",
+	"title": "White kids Watch me whip school Chorus - chorus white kids singing Watch me whip",
+	"favicon": "https://s.ytimg.com/yts/img/ringo/img/favicon-vfl8qSV2F.ico",
+	"image": "https://i.ytimg.com/vi/jYjDqzZ4gjY/hqdefault.jpg",
+	"sidebar": true
+}
+[/block]

--- a/packages/api-explorer/__tests__/form-components/DescriptionField.test.jsx
+++ b/packages/api-explorer/__tests__/form-components/DescriptionField.test.jsx
@@ -1,15 +1,23 @@
 const React = require('react');
 const { shallow } = require('enzyme');
 const markdown = require('@readme/markdown');
+const markdownMagic = require('@readme/markdown-magic');
 const DescriptionField = require('../../src/form-components/DescriptionField');
 
-test('should parse description as markdown', () => {
+test.each([[true], [false]])('should parse description as markdown [new markdown engine=%s]', useNewMarkdownEngine => {
   const actual = '`all` or a comma-separated list of action [fields](ref:action-object)';
+
+  let html;
+  if (useNewMarkdownEngine) {
+    html = shallow(markdown.react(actual)).html();
+  } else {
+    html = shallow(markdownMagic(actual)).html();
+  }
 
   // I wanted to use http://airbnb.io/enzyme/docs/api/ShallowWrapper/contains.html here but it wasnt working
   expect(
-    shallow(<DescriptionField description={actual} />)
+    shallow(<DescriptionField description={actual} formContext={{ useNewMarkdownEngine }} />)
       .html()
-      .indexOf(shallow(markdown.react(actual)).html()) > 1
+      .indexOf(html) > 1
   ).toBe(true);
 });

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "@readme/markdown": "^5.0.0-alpha.4",
+    "@readme/markdown-magic": "^4.19.2",
     "@readme/oas-extensions": "^5.0.0-alpha.4",
     "@readme/oas-to-har": "^5.0.0-alpha.4",
     "@readme/oas-tooling": "^2.1.1",
@@ -28,7 +29,7 @@
     "build": "webpack --config webpack.prod.js",
     "inspect": "jsinspect",
     "lint": "eslint . --ext js --ext jsx",
-    "pretest": "npm run prettier && npm run lint && npm run inspect",
+    "pretest": "npm run lint && npm run inspect",
     "prettier": "prettier --list-different --write \"./**/**.{js,jsx}\"",
     "test": "jest --coverage --runInBand",
     "watch": "webpack -w --progress"

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -3,6 +3,7 @@ const PropTypes = require('prop-types');
 const { constructRequest } = require('fetch-har');
 const extensions = require('@readme/oas-extensions');
 const markdown = require('@readme/markdown').default;
+const markdownMagic = require('@readme/markdown-magic');
 const Waypoint = require('react-waypoint');
 const oasToHar = require('@readme/oas-to-har');
 const Oas = require('@readme/oas-tooling');
@@ -119,6 +120,8 @@ class Doc extends React.Component {
   }
 
   mainTheme(doc) {
+    const { useNewMarkdownEngine } = this.props;
+
     return (
       <React.Fragment>
         {doc.type === 'endpoint' && (
@@ -141,12 +144,14 @@ class Doc extends React.Component {
           </div>
         )}
 
-        <Content body={doc.body} flags={this.props.flags} isThreeColumn />
+        <Content body={doc.body} flags={this.props.flags} isThreeColumn useNewMarkdownEngine={useNewMarkdownEngine} />
       </React.Fragment>
     );
   }
 
   columnTheme(doc) {
+    const { useNewMarkdownEngine } = this.props;
+
     return (
       <div className="hub-api">
         <div className="hub-reference-section">
@@ -160,7 +165,12 @@ class Doc extends React.Component {
                 </React.Fragment>
               )}
 
-              <Content body={doc.body} flags={this.props.flags} isThreeColumn="left" />
+              <Content
+                body={doc.body}
+                flags={this.props.flags}
+                isThreeColumn="left"
+                useNewMarkdownEngine={useNewMarkdownEngine}
+              />
             </div>
 
             <div className="hub-reference-right">
@@ -171,7 +181,12 @@ class Doc extends React.Component {
                 </div>
               )}
               <div className="hub-reference-right switcher">{this.renderResponseSchema('dark')}</div>
-              <Content body={doc.body} flags={this.props.flags} isThreeColumn="right" />
+              <Content
+                body={doc.body}
+                flags={this.props.flags}
+                isThreeColumn="right"
+                useNewMarkdownEngine={useNewMarkdownEngine}
+              />
             </div>
           </React.Fragment>
         </div>
@@ -222,11 +237,19 @@ class Doc extends React.Component {
   }
 
   renderResponseSchema(theme = 'light') {
+    const { useNewMarkdownEngine } = this.props;
     const operation = this.getOperation();
 
     return (
       operation &&
-      operation.responses && <ResponseSchema oas={this.oas} operation={this.getOperation()} theme={theme} />
+      operation.responses && (
+        <ResponseSchema
+          oas={this.oas}
+          operation={this.getOperation()}
+          theme={theme}
+          useNewMarkdownEngine={useNewMarkdownEngine}
+        />
+      )
     );
   }
 
@@ -299,7 +322,7 @@ class Doc extends React.Component {
   }
 
   render() {
-    const { doc, lazy } = this.props;
+    const { doc, lazy, useNewMarkdownEngine } = this.props;
     const { oas } = this;
 
     const renderEndpoint = () => {
@@ -329,15 +352,22 @@ class Doc extends React.Component {
                   Suggest Edits
                 </a>
               )}
+
               <h2>{doc.title}</h2>
-              {doc.excerpt && <div className="excerpt">{markdown(doc.excerpt)}</div>}
+              {doc.excerpt && (
+                <div className="excerpt">
+                  {useNewMarkdownEngine ? markdown(doc.excerpt) : markdownMagic(doc.excerpt)}
+                </div>
+              )}
             </header>
           </div>
           <div className="hub-reference-right">&nbsp;</div>
         </div>
 
         {renderEndpoint()}
-        {!this.props.rendered && <Content body={doc.body} flags={this.props.flags} isThreeColumn />}
+        {!this.props.rendered && (
+          <Content body={doc.body} flags={this.props.flags} isThreeColumn useNewMarkdownEngine={useNewMarkdownEngine} />
+        )}
         {
           // TODO maybe we dont need to do this with a hidden input now
           // cos we can just pass it around?
@@ -402,6 +432,7 @@ Doc.propTypes = {
   setLanguage: PropTypes.func.isRequired,
   suggestedEdits: PropTypes.bool.isRequired,
   tryItMetrics: PropTypes.func.isRequired,
+  useNewMarkdownEngine: PropTypes.bool,
   user: PropTypes.shape({}),
 };
 
@@ -420,6 +451,7 @@ Doc.defaultProps = {
   Logs: undefined,
   oas: {},
   rendered: false,
+  useNewMarkdownEngine: false,
   user: {},
 };
 

--- a/packages/api-explorer/src/Params.jsx
+++ b/packages/api-explorer/src/Params.jsx
@@ -34,6 +34,7 @@ function Params({
   SelectWidget,
   TextareaWidget,
   URLWidget,
+  useNewMarkdownEngine,
 }) {
   const jsonSchema = parametersToJsonSchema(operation, oas);
 
@@ -51,6 +52,9 @@ function Params({
             DescriptionField,
             ArrayField,
             SchemaField,
+          }}
+          formContext={{
+            useNewMarkdownEngine,
           }}
           formData={formData[schema.type]}
           id={`form-${operation.operationId}`}
@@ -111,6 +115,12 @@ Params.propTypes = {
   SchemaField: PropTypes.func.isRequired,
   SelectWidget: PropTypes.func.isRequired,
   TextareaWidget: PropTypes.func.isRequired,
+  URLWidget: PropTypes.func.isRequired,
+  useNewMarkdownEngine: PropTypes.bool,
+};
+
+Params.defaultProps = {
+  useNewMarkdownEngine: false,
 };
 
 function createParams(oas) {

--- a/packages/api-explorer/src/ResponseSchema.jsx
+++ b/packages/api-explorer/src/ResponseSchema.jsx
@@ -2,6 +2,7 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const classNames = require('classnames');
 const markdown = require('@readme/markdown').default;
+const markdownMagic = require('@readme/markdown-magic');
 const Oas = require('@readme/oas-tooling');
 const { findSchemaDefinition } = require('@readme/oas-tooling/utils');
 
@@ -76,7 +77,7 @@ class ResponseSchema extends React.Component {
   }
 
   render() {
-    const { operation, oas } = this.props;
+    const { operation, oas, useNewMarkdownEngine } = this.props;
     if (!operation.responses || Object.keys(operation.responses).length === 0) return null;
     const schema = this.getSchema(operation);
 
@@ -95,8 +96,13 @@ class ResponseSchema extends React.Component {
       >
         {this.renderHeader()}
         <div className="response-schema">
-          {response.description && <div className="desc">{markdown(response.description)}</div>}
-          {schema && <ResponseSchemaBody oas={oas} schema={schema} />}
+          {response.description && (
+            <div className="desc">
+              {useNewMarkdownEngine ? markdown(response.description) : markdownMagic(response.description)}
+            </div>
+          )}
+
+          {schema && <ResponseSchemaBody oas={oas} schema={schema} useNewMarkdownEngine={useNewMarkdownEngine} />}
         </div>
       </div>
     );
@@ -107,6 +113,11 @@ ResponseSchema.propTypes = {
   oas: PropTypes.instanceOf(Oas).isRequired,
   operation: PropTypes.instanceOf(Operation).isRequired,
   theme: PropTypes.string.isRequired,
+  useNewMarkdownEngine: PropTypes.bool,
+};
+
+ResponseSchema.defaultProps = {
+  useNewMarkdownEngine: false,
 };
 
 module.exports = ResponseSchema;

--- a/packages/api-explorer/src/ResponseSchemaBody.jsx
+++ b/packages/api-explorer/src/ResponseSchemaBody.jsx
@@ -1,6 +1,7 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const markdown = require('@readme/markdown').default;
+const markdownMagic = require('@readme/markdown-magic');
 const { flattenArray, flattenSchema } = require('@readme/oas-tooling/utils');
 
 function getSchemaType(schema) {
@@ -13,7 +14,15 @@ function getSchemaType(schema) {
   return `array of ${schema.items.type}s`;
 }
 
-function ResponseSchemaBody({ schema, oas }) {
+function getDescriptionMarkdown(useNewMarkdownEngine, description) {
+  if (useNewMarkdownEngine) {
+    return markdown(description);
+  }
+
+  return markdownMagic(description);
+}
+
+function ResponseSchemaBody({ schema, oas, useNewMarkdownEngine }) {
   const rows = flattenArray(flattenSchema(schema, oas)).map(row => (
     <tr key={Math.random().toString(10)}>
       <th
@@ -35,7 +44,7 @@ function ResponseSchemaBody({ schema, oas }) {
         }}
       >
         {row.name}
-        {row.description && markdown(row.description)}
+        {row.description && getDescriptionMarkdown(useNewMarkdownEngine, row.description)}
       </td>
     </tr>
   ));
@@ -62,6 +71,11 @@ ResponseSchemaBody.propTypes = {
     properties: PropTypes.object,
     type: PropTypes.string.isRequired,
   }).isRequired,
+  useNewMarkdownEngine: PropTypes.bool,
+};
+
+ResponseSchemaBody.defaultProps = {
+  useNewMarkdownEngine: false,
 };
 
 module.exports = ResponseSchemaBody;

--- a/packages/api-explorer/src/block-types/ApiHeader.jsx
+++ b/packages/api-explorer/src/block-types/ApiHeader.jsx
@@ -1,0 +1,33 @@
+const slug = require('lodash.kebabcase');
+const React = require('react');
+const PropTypes = require('prop-types');
+
+const ApiHeader = ({ block }) => {
+  return (
+    <div className="magic-block-api-header">
+      <h1 className="header-scroll is-api-header">
+        <span id={slug(block.data.title)} />
+        <div className="anchor waypoint" id={`section-${slug(block.data.title)}`} />
+        {block.data.type && block.data.type !== 'basic' && (
+          <span className={`pg-type-big pg-type type-${slug(block.data.type)}`} />
+        )}
+        {block.data.title}
+        {
+          // eslint-disable-next-line jsx-a11y/anchor-has-content
+          <a className="fa fa-anchor" href={`#section-${slug(block.data.title)}`} />
+        }
+      </h1>
+    </div>
+  );
+};
+
+ApiHeader.propTypes = {
+  block: PropTypes.shape({
+    data: PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      type: PropTypes.string,
+    }),
+  }).isRequired,
+};
+
+module.exports = ApiHeader;

--- a/packages/api-explorer/src/block-types/CallOut.jsx
+++ b/packages/api-explorer/src/block-types/CallOut.jsx
@@ -1,0 +1,57 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+const markdown = require('@readme/markdown-magic');
+
+function Icon({ type }) {
+  switch (type) {
+    case 'info':
+      return <i className="fa fa-info-circle" title="Info" />;
+    case 'warning':
+      return <i className="fa fa-exclamation-circle" title="Warning" />;
+    case 'danger':
+      return <i className="fa fa-exclamation-triangle" title="Danger" />;
+    case 'success':
+      return <i className="fa fa-check-square" title="Success" />;
+    default:
+      return null;
+  }
+}
+
+const CallOut = ({ block, flags }) => {
+  return (
+    <div className={`magic-block-callout type-${block.data.type} ${block.data.title ? '' : 'no-title'} `}>
+      {block.data.title && (
+        <h3>
+          <Icon type={block.data.type} />
+          {block.data.title}
+        </h3>
+      )}
+
+      {!block.data.title && (
+        <span className="noTitleIcon">
+          <Icon type={block.data.type} />
+        </span>
+      )}
+      {block.data && block.data.body && <div className="callout-body">{markdown(block.data.body, flags)}</div>}
+    </div>
+  );
+};
+
+CallOut.propTypes = {
+  block: PropTypes.shape({
+    data: PropTypes.shape({
+      body: PropTypes.string,
+      title: PropTypes.string,
+      type: PropTypes.string.isRequired,
+    }),
+  }).isRequired,
+  flags: PropTypes.shape({}),
+};
+
+CallOut.defaultProps = { flags: {} };
+
+Icon.propTypes = {
+  type: PropTypes.string.isRequired,
+};
+
+module.exports = CallOut;

--- a/packages/api-explorer/src/block-types/Code.jsx
+++ b/packages/api-explorer/src/block-types/Code.jsx
@@ -1,0 +1,90 @@
+/* eslint-disable unicorn/no-nested-ternary */
+const PropTypes = require('prop-types');
+const React = require('react');
+const classNames = require('classnames');
+const syntaxHighlighter = require('@readme/syntax-highlighter');
+
+const CodeElement = require('./CodeElement');
+const statusCodes = require('../lib/statuscodes');
+
+const { uppercase } = syntaxHighlighter;
+
+class BlockCode extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { activeTab: 0 };
+  }
+
+  showCode(i) {
+    this.setState({ activeTab: i });
+  }
+
+  render() {
+    const { block, opts = {}, dark } = this.props;
+    const codes = Array.isArray(block.data.codes) ? block.data.codes : [];
+
+    return (
+      <span>
+        {opts.label && <label>{opts.label}</label>}
+        <div className="magic-block-code">
+          {(!opts.hideHeaderOnOne || codes.length > 1) && (
+            <ul className="block-code-header">
+              {codes.map((code, i) => (
+                <li key={i}>
+                  {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                  <a
+                    className={classNames({ active: i === this.state.activeTab })}
+                    href="#"
+                    onClick={e => {
+                      e.preventDefault();
+                      this.showCode(i);
+                    }}
+                  >
+                    {code.status ? (
+                      <span>
+                        <span className={`status-icon status-icon-${statusCodes(code.status)[2]}`} />
+                        {!statusCodes(code.status)[3] && statusCodes(code.status)[0]}
+                        <em>{code.name ? code.name : statusCodes(code.status)[1]}</em>
+                      </span>
+                    ) : code.name ? (
+                      code.name
+                    ) : (
+                      uppercase(code.language)
+                    )}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="block-code-code">
+            {codes.map((code, i) => {
+              return <CodeElement key={i} activeTab={i === this.state.activeTab} code={code} dark={dark} />;
+            })}
+          </div>
+        </div>
+      </span>
+    );
+  }
+}
+
+BlockCode.propTypes = {
+  block: PropTypes.shape({
+    data: PropTypes.shape({
+      codes: PropTypes.array,
+    }),
+  }),
+  dark: PropTypes.bool,
+  opts: PropTypes.shape({
+    hideHeaderOnOne: PropTypes.bool,
+    label: PropTypes.string,
+  }),
+};
+
+BlockCode.defaultProps = {
+  block: { data: {} },
+  dark: false,
+  opts: {},
+};
+
+module.exports = BlockCode;

--- a/packages/api-explorer/src/block-types/CodeElement.jsx
+++ b/packages/api-explorer/src/block-types/CodeElement.jsx
@@ -1,0 +1,64 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+const syntaxHighlighter = require('@readme/syntax-highlighter');
+
+const CopyCode = require('../CopyCode');
+
+/*
+ * This component is used internally by Code
+ * The reason why it has to be a separate component
+ * is because of the copying code functionality.
+ *
+ * The stuff that we're syntax highlighting may have
+ * JWT variables embedded inside of it, but we don't
+ * know that until it's been rendered by the syntax
+ * highlighter.
+ *
+ * Because we want the rendered value and not the template
+ * <<apiKey>>, we have to render it first, then fetch
+ * the `textContent` out of the ref.
+ *
+ * We have to call setState with the value of the ref
+ * because CopyCode is rendered before the <code> element
+ * and setting a ref on it's own does not cause a rerender.
+ */
+class CodeElement extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.el = React.createRef();
+    this.state = { el: null };
+  }
+
+  componentDidMount() {
+    this.setState({ el: this.el.current });
+  }
+
+  render() {
+    const { activeTab, code, dark } = this.props;
+
+    return (
+      <div style={{ display: activeTab ? 'block' : 'none' }}>
+        <CopyCode code={() => (this.state.el ? this.state.el.textContent : '')} />
+        <pre style={{ display: activeTab ? 'block' : 'none' }}>
+          <code ref={this.el}>
+            {syntaxHighlighter(code.code, code.language, {
+              dark,
+              tokenizeVariables: true,
+            })}
+          </code>
+        </pre>
+      </div>
+    );
+  }
+}
+
+CodeElement.propTypes = {
+  activeTab: PropTypes.bool.isRequired,
+  code: PropTypes.shape({
+    code: PropTypes.string,
+    language: PropTypes.string,
+  }).isRequired,
+  dark: PropTypes.bool.isRequired,
+};
+
+module.exports = CodeElement;

--- a/packages/api-explorer/src/block-types/Content.jsx
+++ b/packages/api-explorer/src/block-types/Content.jsx
@@ -3,36 +3,128 @@ const PropTypes = require('prop-types');
 
 const markdown = require('@readme/markdown').default;
 
+const CallOut = require('./CallOut');
+const Html = require('./Html');
+const TextArea = require('./TextArea');
+const Code = require('./Code');
+const ImageBlock = require('./Image');
+const Embed = require('./Embed');
+const Parameters = require('./Parameters');
+const ApiHeader = require('./ApiHeader');
+
+const parseBlocks = require('../lib/parse-magic-blocks');
+
+const Loop = ({ content, column, flags }) => {
+  const elements = content.map((block, key) => {
+    const props = { key, block, flags };
+    switch (block.type) {
+      case 'textarea':
+        return <TextArea {...props} />;
+      case 'html':
+        return <Html {...props} />;
+      case 'embed':
+        return <Embed {...props} />;
+      case 'api-header':
+        return <ApiHeader {...props} />;
+      case 'code':
+        return <Code {...props} dark={column === 'right'} />;
+      case 'callout':
+        return <CallOut {...props} />;
+      case 'parameters':
+        return <Parameters {...props} />;
+      case 'image':
+        return <ImageBlock {...props} />;
+      default:
+        return null;
+    }
+  });
+
+  return <div>{elements}</div>;
+};
+
 const Content = props => {
-  const { body, isThreeColumn } = props;
-  const content = markdown(body);
+  const { body, isThreeColumn, useNewMarkdownEngine } = props;
+
+  if (useNewMarkdownEngine) {
+    const content = markdown(body);
+
+    if (isThreeColumn === true) {
+      return (
+        <div className="hub-reference-section">
+          <div className="hub-reference-left">
+            <div className="markdown-body">{content}</div>
+          </div>
+          <div className="hub-reference-right">
+            <div className="markdown-body">{content}</div>
+          </div>
+        </div>
+      );
+    }
+
+    return <div className="markdown-body">{content}</div>;
+  }
+
+  const content = parseBlocks(body);
+
+  const left = [];
+  const right = [];
+  content.forEach(elem => {
+    if (elem.sidebar) {
+      right.push(elem);
+    } else {
+      left.push(elem);
+    }
+  });
 
   if (isThreeColumn === true) {
     return (
       <div className="hub-reference-section">
         <div className="hub-reference-left">
-          <div className="markdown-body">{content}</div>
+          <div className="content-body">
+            <Loop column="left" content={left} flags={props.flags} />
+          </div>
         </div>
         <div className="hub-reference-right">
-          <div className="markdown-body">{content}</div>
+          <div className="content-body">
+            <Loop column="right" content={right} flags={props.flags} />
+          </div>
         </div>
       </div>
     );
   }
 
-  return <div className="markdown-body">{content}</div>;
+  return <Loop column={isThreeColumn} content={isThreeColumn === 'left' ? left : right} flags={props.flags} />;
+};
+
+Loop.propTypes = {
+  column: PropTypes.string,
+  content: PropTypes.arrayOf(
+    PropTypes.shape({
+      type: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  flags: PropTypes.shape({
+    correctnewlines: PropTypes.bool,
+  }),
+};
+
+Loop.defaultProps = {
+  column: 'left',
+  flags: {},
 };
 
 Content.propTypes = {
   body: PropTypes.string,
   flags: PropTypes.shape({}),
   isThreeColumn: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  useNewMarkdownEngine: PropTypes.bool,
 };
 
 Content.defaultProps = {
   body: '',
   flags: {},
   isThreeColumn: true,
+  useNewMarkdownEngine: false,
 };
 
 module.exports = Content;

--- a/packages/api-explorer/src/block-types/Embed.jsx
+++ b/packages/api-explorer/src/block-types/Embed.jsx
@@ -1,0 +1,57 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+
+const Embed = ({ block }) => {
+  return (
+    <div className="magic-block-embed">
+      {(() => {
+        if (block.data.html) {
+          return <span dangerouslySetInnerHTML={{ __html: block.data.html }} />;
+        } else if (block.data.iframe) {
+          return (
+            <iframe
+              className="media-iframe"
+              height={block.data.height || '300px'}
+              src={block.data.url}
+              title={block.data.title}
+              width={block.data.width || '100%'}
+            />
+          );
+        }
+
+        return (
+          <strong>
+            {block.data.favicon && <img alt="" className="favicon" src={block.data.favicon} />}
+            <a href={block.data.url} target="_new">
+              {block.data.title || block.data.url}
+            </a>
+          </strong>
+        );
+      })()}
+    </div>
+  );
+};
+
+Embed.propTypes = {
+  block: PropTypes.shape({
+    data: PropTypes.shape({
+      favicon: PropTypes.string.isRequired,
+      height: PropTypes.string,
+      html: PropTypes.boolean,
+      iframe: PropTypes.boolean,
+      title: PropTypes.string,
+      url: PropTypes.string.isRequired,
+      width: PropTypes.string,
+    }),
+  }),
+};
+
+Embed.defaultProps = {
+  block: {
+    data: {
+      title: '',
+    },
+  },
+};
+
+module.exports = Embed;

--- a/packages/api-explorer/src/block-types/Html.jsx
+++ b/packages/api-explorer/src/block-types/Html.jsx
@@ -1,0 +1,16 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+
+const Html = ({ block }) => {
+  return <div className="magic-block-html" dangerouslySetInnerHTML={{ __html: block.data.html }} />;
+};
+
+Html.propTypes = {
+  block: PropTypes.shape({
+    data: PropTypes.shape({
+      html: PropTypes.string.isRequired,
+    }),
+  }).isRequired,
+};
+
+module.exports = Html;

--- a/packages/api-explorer/src/block-types/Image.jsx
+++ b/packages/api-explorer/src/block-types/Image.jsx
@@ -1,0 +1,45 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+const markdown = require('@readme/markdown-magic');
+
+const ImageBlock = ({ block, flags }) => {
+  const myImage = block.data.images.map((image, i) => {
+    const imageClass = image.sizing ? image.sizing : 'smart';
+    const border = image.border ? image.border : '';
+
+    return (
+      <div key={i} className="magic-block-image">
+        {image && image.image && image.image.length && (
+          <div>
+            <figure>
+              <a
+                className={`block-display-image-parent block-display-image-size-${imageClass}${border}`}
+                href={image.image[0]}
+              >
+                <img alt={image.caption} src={image.image[0]} />
+              </a>
+            </figure>
+            {image.caption && <figcaption>{markdown(image.caption, flags)}</figcaption>}
+          </div>
+        )}
+      </div>
+    );
+  });
+
+  return <div className="image">{myImage}</div>;
+};
+
+ImageBlock.propTypes = {
+  block: PropTypes.shape({
+    data: PropTypes.shape({
+      images: PropTypes.array.isRequired,
+    }),
+  }).isRequired,
+  flags: PropTypes.shape({}),
+};
+
+ImageBlock.defaultProps = {
+  flags: {},
+};
+
+module.exports = ImageBlock;

--- a/packages/api-explorer/src/block-types/Parameters.jsx
+++ b/packages/api-explorer/src/block-types/Parameters.jsx
@@ -1,0 +1,74 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+const markdown = require('@readme/markdown-magic');
+
+const Parameters = ({ block, flags }) => {
+  const columns = block.data.cols;
+  const { rows } = block.data;
+
+  function th() {
+    const thCells = [];
+    for (let c = 0; c < columns; c += 1) {
+      thCells.push(
+        <div key={c} className="th">
+          {block.data.data[`h-${c}`]}
+        </div>
+      );
+    }
+    return thCells;
+  }
+
+  function td(r) {
+    const tdCells = [];
+
+    for (let c = 0; c < columns; c += 1) {
+      tdCells.push(
+        <div key={c} className="td">
+          {markdown(block.data.data[`${r}-${c}`] || '', flags)}
+        </div>
+      );
+    }
+    return tdCells;
+  }
+
+  function tr() {
+    const trCells = [];
+
+    for (let r = 0; r < rows; r += 1) {
+      trCells.push(
+        <div key={r} className="tr">
+          {td(r)}
+        </div>
+      );
+    }
+    return trCells;
+  }
+
+  return (
+    <div className="magic-block-parameters">
+      <div className="block-parameters-table">
+        <div className="table">
+          {(block.data.data['h-0'] || block.data.data['h-1']) && <div className="tr">{th()}</div>}
+          {tr()}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+Parameters.propTypes = {
+  block: PropTypes.shape({
+    data: PropTypes.shape({
+      cols: PropTypes.number.isRequired,
+      data: PropTypes.object.isRequired,
+      rows: PropTypes.number.isRequired,
+    }),
+  }).isRequired,
+  flags: PropTypes.shape({}),
+};
+
+Parameters.defaultProps = {
+  flags: {},
+};
+
+module.exports = Parameters;

--- a/packages/api-explorer/src/block-types/TextArea.jsx
+++ b/packages/api-explorer/src/block-types/TextArea.jsx
@@ -1,0 +1,20 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+const markdown = require('@readme/markdown-magic');
+
+const Textarea = ({ block, flags }) => {
+  return <div className="magic-block-textarea">{markdown(block.text, flags)}</div>;
+};
+
+Textarea.propTypes = {
+  block: PropTypes.shape({
+    text: PropTypes.string.isRequired,
+  }).isRequired,
+  flags: PropTypes.shape({}),
+};
+
+Textarea.defaultProps = {
+  flags: {},
+};
+
+module.exports = Textarea;

--- a/packages/api-explorer/src/form-components/DescriptionField.jsx
+++ b/packages/api-explorer/src/form-components/DescriptionField.jsx
@@ -3,20 +3,36 @@ const React = require('react');
 const PropTypes = require('prop-types');
 
 const markdown = require('@readme/markdown').default;
+const markdownMagic = require('@readme/markdown-magic');
+
+function getDescriptionMarkdown(useNewMarkdownEngine, description) {
+  if (useNewMarkdownEngine) {
+    return markdown(description);
+  }
+
+  return markdownMagic(description);
+}
 
 function DescriptionField(props) {
-  const { id, description } = props;
+  const { id, description, formContext } = props;
+  let useNewMarkdownEngine = false;
+
+  if (formContext && 'useNewMarkdownEngine' in formContext) {
+    useNewMarkdownEngine = formContext.useNewMarkdownEngine;
+  }
+
   if (!description) return null;
 
   return (
     <div className="field-description" id={id}>
-      {typeof description === 'string' ? markdown(description) : description}
+      {typeof description === 'string' ? getDescriptionMarkdown(useNewMarkdownEngine, description) : description}
     </div>
   );
 }
 
 DescriptionField.propTypes = {
   description: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  formContext: PropTypes.any,
   id: PropTypes.string,
 };
 

--- a/packages/api-explorer/src/lib/parse-magic-blocks.js
+++ b/packages/api-explorer/src/lib/parse-magic-blocks.js
@@ -1,0 +1,62 @@
+module.exports = function parseMagicBlocks(str = '' /* , addTextareas */) {
+  let block = false;
+  const blocks = [];
+  // let previous = false;
+  // let sectionCount = 0;
+  str.split(/\n?(\[block:[-a-z]+\]|\[\/block\])\n?/).forEach(v => {
+    const check = v.match(/^(\[block:([-a-z]+)\]|\[\/block\])$/);
+
+    if (check) {
+      if (check[2]) {
+        block = check[2];
+      } else {
+        block = false;
+      }
+    } else if (v.trim().length) {
+      if (!block) {
+        blocks.push({
+          type: 'textarea',
+          text: v,
+        });
+        block = 'textarea';
+      } else if (block === 'textarea') {
+        const j = JSON.parse(v);
+        blocks.push({
+          type: 'textarea',
+          text: j.text,
+          sidebar: j.sidebar,
+        });
+      } else {
+        // if (addTextareas) {
+        //     // Everything should have a textarea between it!
+        //   if (previous && previous !== 'textarea' && block !== 'textarea') {
+        //     blocks.push({
+        //       type: 'textarea',
+        //       text: '',
+        //     });
+        //   }
+        // }
+
+        const j = JSON.parse(v);
+        blocks.push({
+          type: block,
+          data: j,
+          sidebar: j.sidebar,
+        });
+      }
+      // previous = block;
+      // sectionCount += 1;
+    }
+  });
+
+  // if (addTextareas) {
+  //   if ((previous && previous !== 'textarea') || !sectionCount) {
+  //     blocks.push({
+  //       type: 'textarea',
+  //       text: '',
+  //     });
+  //   }
+  // }
+
+  return blocks;
+};


### PR DESCRIPTION
We need to clear up the v5 release blockage in https://github.com/readmeio/api-explorer/pull/458 to make way for core improvements to the Explorer so for the time being, we're backporting our legacy markdown engine to be able to run alongside the new engine with the introduction of a `useNewMarkdownEngine` flag.

When this flag is enabled, all Markdown processing within the Explorer will switch over to using the new, non-magic block, Markdown engine in [@readme/markdown](https://www.npmjs.com/package/@readme/markdown-magic). When disabled, which will be the default behavior, all processing will be handled by our legacy engine in  [@readme/markdown-magic](http://npm.im/@readme/markdown-magic). 