### PR TITLE
✨ implement isomorphic markdown parser package

### DIFF
--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -8,7 +8,6 @@
     "@readme/syntax-highlighter": "^6.0.3",
     "@readme/variable": "^6.0.3",
     "hast-util-sanitize": "^1.2.0",
-    "isomorphic-style-loader": "^5.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.4.2",
     "rehype-raw": "^4.0.1",
@@ -45,6 +44,7 @@
     "eslint": "^6.5.0",
     "jest": "^25.1.0",
     "jsinspect": "^0.12.7",
+    "isomorphic-style-loader": "^5.1.0",
     "prettier": "^1.18.2",
     "webpack": "^3.10.0"
   }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -8,6 +8,7 @@
     "@readme/syntax-highlighter": "^6.0.3",
     "@readme/variable": "^6.0.3",
     "hast-util-sanitize": "^1.2.0",
+    "isomorphic-style-loader": "^5.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.4.2",
     "rehype-raw": "^4.0.1",

--- a/packages/markdown/webpack.config.js
+++ b/packages/markdown/webpack.config.js
@@ -21,11 +21,11 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loader: ['style-loader', 'css-loader'],
+        loader: ['isomorphic-style-loader', 'css-loader'],
       },
       {
         test: /\.scss$/,
-        loaders: ['style-loader', 'css-loader', 'sass-loader'],
+        loaders: ['isomorphic-style-loader', 'css-loader', 'sass-loader'],
       },
       {
         // eslint-disable-next-line unicorn/no-unsafe-regex

--- a/packages/syntax-highlighter/codemirror.jsx
+++ b/packages/syntax-highlighter/codemirror.jsx
@@ -1,4 +1,4 @@
-const CodeMirror = require('codemirror');
+const CodeMirror = require('codemirror/addon/runmode/runmode.node.js');
 const React = require('react');
 const Variable = require('@readme/variable');
 const modes = require('./modes');

--- a/packages/syntax-highlighter/codemirror.jsx
+++ b/packages/syntax-highlighter/codemirror.jsx
@@ -1,4 +1,5 @@
-const CodeMirror = require('codemirror/addon/runmode/runmode.node.js');
+const CodeMirror =
+  typeof window === 'undefined' ? require('codemirror/addon/runmode/runmode.node.js') : require('codemirror');
 const React = require('react');
 const Variable = require('@readme/variable');
 const modes = require('./modes');


### PR DESCRIPTION
We needed to be able to pull in the @readme/markdown package into the core application from the server-side code. These changes allow us to do this.

To see the current behavior: https://npm.runkit.com/%40readme%2Fmarkdown