### PR TITLE
fix: creating a custom UnsupportedField for RJSF to handle errors

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1465,9 +1465,9 @@
       }
     },
     "@readme/react-jsonschema-form": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/react-jsonschema-form/-/react-jsonschema-form-1.1.1.tgz",
-      "integrity": "sha512-V0G7usTxh+J0IJ81kma5+6T8GoaD8DqONJ90cCvLisdNXif+Mp2ikqBchDQ4voMk6IRRKs56NYtJV0B6AtxaWA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@readme/react-jsonschema-form/-/react-jsonschema-form-1.1.2.tgz",
+      "integrity": "sha512-0fH2YRt0MPuX1UjA3ulsOK/yespQO9e6KiEHcctyiWJK2whQU7D5TCUczkWwIxoG9hOudByV5iVzSHLh9YIIVQ==",
       "requires": {
         "@babel/runtime-corejs2": "^7.4.5",
         "ajv": "^6.7.0",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -10,7 +10,7 @@
     "@readme/oas-extensions": "^6.0.5",
     "@readme/oas-to-har": "^6.0.5",
     "@readme/oas-tooling": "^3.1.0",
-    "@readme/react-jsonschema-form": "^1.1.1",
+    "@readme/react-jsonschema-form": "^1.1.2",
     "@readme/syntax-highlighter": "^6.0.5",
     "@readme/variable": "^6.0.5",
     "classnames": "^2.2.5",

--- a/packages/api-explorer/src/ErrorBoundary.jsx
+++ b/packages/api-explorer/src/ErrorBoundary.jsx
@@ -17,7 +17,13 @@ class ErrorBoundary extends React.Component {
       .toString(36)
       .substr(2, 7)}`;
 
-    this.props.onError(error, { supportErrorCode, componentStack: info });
+    const errorData = {
+      supportErrorCode,
+      componentStack: info,
+      ...error,
+    };
+
+    this.props.onError(error, errorData);
 
     this.setState({
       error,

--- a/packages/api-explorer/src/Params.jsx
+++ b/packages/api-explorer/src/Params.jsx
@@ -14,6 +14,7 @@ const Oas = require('@readme/oas-tooling');
 const { parametersToJsonSchema } = require('@readme/oas-tooling/utils');
 
 const DescriptionField = require('./form-components/DescriptionField');
+const UnsupportedField = require('./form-components/UnsupportedField');
 const createBaseInput = require('./form-components/BaseInput');
 const createSelectWidget = require('./form-components/SelectWidget');
 const createArrayField = require('./form-components/ArrayField');
@@ -65,6 +66,7 @@ function Params({
                 ArrayField,
                 DescriptionField,
                 SchemaField,
+                UnsupportedField,
               }}
               formContext={{
                 useNewMarkdownEngine,
@@ -88,7 +90,7 @@ function Params({
                 // 🚨 Temporarily disabling support for rendering the datetime widget as RJSF appears to be disabling it in
                 // browsers that don't fully support it.
                 /* dateTime: DateTimeWidget,
-              'date-time': DateTimeWidget, */
+                'date-time': DateTimeWidget, */
 
                 double: UpDownWidget,
                 duration: TextWidget,

--- a/packages/api-explorer/src/form-components/UnsupportedField.jsx
+++ b/packages/api-explorer/src/form-components/UnsupportedField.jsx
@@ -1,0 +1,26 @@
+const PropTypes = require('prop-types');
+
+function UnsupportedField({ schema, idSchema, reason }) {
+  let message = 'Unsupported field schema';
+  if (idSchema && idSchema.$id) {
+    message += ` for field \`${idSchema.$id}\``;
+  }
+
+  if (reason) {
+    message += `: ${reason}.`;
+  }
+
+  const error = new Error(message);
+
+  if (schema) error.schema = schema;
+
+  throw error;
+}
+
+UnsupportedField.propTypes = {
+  idSchema: PropTypes.object,
+  reason: PropTypes.string,
+  schema: PropTypes.object.isRequired,
+};
+
+module.exports = UnsupportedField;


### PR DESCRIPTION
I added support for being able to override `UnsupportedField` in https://github.com/readmeio/react-jsonschema-form/pull/10. Without this, we had no way to capture errors from RJSF.