### PR TITLE
fix: updating @readme/oas-tooling to 3.1.3

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1368,9 +1368,9 @@
       "dev": true
     },
     "@readme/oas-tooling": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.2.tgz",
-      "integrity": "sha512-Kew3UkimXz1PW06SqtTiR1iRBRxzHn8b8fePH4ofW5BLm0wDh97kRqFgctI7NdU9Y+6POpnEugWXxgUKW265lA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.3.tgz",
+      "integrity": "sha512-oCcMmSWLF1PtU774knEHYsKUNShyhTKNtxZ6NsetpYgJIKPku3BLxWRgrqiccxIZGYLVdRmQ1SzL/DbsGi06uA==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -873,9 +873,9 @@
       }
     },
     "@readme/oas-tooling": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.2.tgz",
-      "integrity": "sha512-Kew3UkimXz1PW06SqtTiR1iRBRxzHn8b8fePH4ofW5BLm0wDh97kRqFgctI7NdU9Y+6POpnEugWXxgUKW265lA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.3.tgz",
+      "integrity": "sha512-oCcMmSWLF1PtU774knEHYsKUNShyhTKNtxZ6NsetpYgJIKPku3BLxWRgrqiccxIZGYLVdRmQ1SzL/DbsGi06uA==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^6.0.5",
-    "@readme/oas-tooling": "^3.1.2",
+    "@readme/oas-tooling": "^3.1.3",
     "querystring": "^0.2.0"
   },
   "scripts": {


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes two issues with how we render JSON Schema:

* [x] When we encounter an OAS that has `type` typod to `array` when they intended it to be `object` as `properties` and no `items` is present, we now reshape that as a proper object.
* [x] If we encounter a `requestBody` that has a content schema of just `{}`, we now ignore it as there's no information to render.

## 📖 Release Notes
### 3.1.3
- fix: magically resolving objects that are typod as arrays [`#132`](https://github.com/readmeio/oas/pull/132)
- fix: don't prepare a parameter/body schema if it's empty [`#131`](https://github.com/readmeio/oas/pull/131)
