### PR TITLE
chore(deps-dev): upgrading @readme/eslint-config to 2.0.0

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "printWidth": 120,
-  "singleQuote": true
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1290,9 +1290,9 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
-      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
+      "integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -3201,9 +3201,9 @@
       }
     },
     "@readme/eslint-config": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-1.16.0.tgz",
-      "integrity": "sha512-0/poD69LfLFWP5ZKqp+DbfVAMDmqQreSWyjzpHLH4n+juWak+dF4u+PgEmR5eaXGqrMj+tvhScGkoG7H2ski/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-2.0.0.tgz",
+      "integrity": "sha512-hKFBAmyAK+8IdQ9UBxxCSrBLOWAM6FIBrLR2LskYlyamIKbWmjSrgBpTEXo72Rgmg3VIl2Y3lCjGabgF9RL5oA==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0",
@@ -7584,9 +7584,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
     "@babel/preset-env": "^7.4.4",
     "@babel/preset-react": "^7.0.0",
-    "@readme/eslint-config": "^1.7.0",
+    "@readme/eslint-config": "^2.0.0",
     "auto-changelog": "^1.10.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.3",
@@ -64,5 +64,6 @@
     "react-hot-loader": "^4.12.16",
     "swagger2openapi": "^5.3.1",
     "whatwg-fetch": "^3.0.0"
-  }
+  },
+  "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/api-explorer/.prettierrc
+++ b/packages/api-explorer/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "printWidth": 120,
-  "singleQuote": true
-}

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -260,9 +260,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-      "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -285,9 +285,9 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
-      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
+      "integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -1342,9 +1342,9 @@
       }
     },
     "@readme/eslint-config": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-1.16.0.tgz",
-      "integrity": "sha512-0/poD69LfLFWP5ZKqp+DbfVAMDmqQreSWyjzpHLH4n+juWak+dF4u+PgEmR5eaXGqrMj+tvhScGkoG7H2ski/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-2.0.0.tgz",
+      "integrity": "sha512-hKFBAmyAK+8IdQ9UBxxCSrBLOWAM6FIBrLR2LskYlyamIKbWmjSrgBpTEXo72Rgmg3VIl2Y3lCjGabgF9RL5oA==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0",
@@ -3655,9 +3655,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -30,7 +30,7 @@
     "build": "webpack --config webpack.prod.js",
     "inspect": "jsinspect",
     "lint": "eslint . --ext js --ext jsx",
-    "pretest": "npm run lint && npm run inspect",
+    "pretest": "npm run lint && npm run prettier && npm run inspect",
     "prettier": "prettier --list-different --write \"./**/**.{js,jsx}\"",
     "test": "jest --coverage --runInBand",
     "watch": "webpack -w --progress"
@@ -43,7 +43,7 @@
   "license": "ISC",
   "repository": "https://github.com/readmeio/api-explorer/tree/master/packages/api-explorer",
   "devDependencies": {
-    "@readme/eslint-config": "^1.7.0",
+    "@readme/eslint-config": "^2.0.0",
     "@readme/oas-examples": "^3.0.0",
     "eslint": "^6.5.0",
     "jest": "^25.1.0",
@@ -54,5 +54,6 @@
     "webpack": "^4.41.0",
     "webpack-cli": "^3.3.9",
     "webpack-merge": "^4.2.2"
-  }
+  },
+  "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/api-logs/.prettierrc
+++ b/packages/api-logs/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "printWidth": 120,
-  "singleQuote": true
-}

--- a/packages/api-logs/package-lock.json
+++ b/packages/api-logs/package-lock.json
@@ -190,18 +190,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-      "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
-      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
+      "integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -993,9 +993,9 @@
       }
     },
     "@readme/eslint-config": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-1.16.0.tgz",
-      "integrity": "sha512-0/poD69LfLFWP5ZKqp+DbfVAMDmqQreSWyjzpHLH4n+juWak+dF4u+PgEmR5eaXGqrMj+tvhScGkoG7H2ski/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-2.0.0.tgz",
+      "integrity": "sha512-hKFBAmyAK+8IdQ9UBxxCSrBLOWAM6FIBrLR2LskYlyamIKbWmjSrgBpTEXo72Rgmg3VIl2Y3lCjGabgF9RL5oA==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0",
@@ -3391,9 +3391,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"

--- a/packages/api-logs/package.json
+++ b/packages/api-logs/package.json
@@ -12,7 +12,7 @@
     "build": "webpack --config webpack.prod.js",
     "inspect": "jsinspect",
     "lint": "eslint . --ext .jsx --ext .js",
-    "pretest": "npm run prettier && npm run lint && npm run inspect",
+    "pretest": "npm run lint && npm run prettier && npm run inspect",
     "prettier": "prettier --list-different --write \"./**/**.{js,jsx}\"",
     "test": "jest --coverage --runInBand",
     "watch": "webpack -w --progress"
@@ -25,7 +25,7 @@
   "license": "ISC",
   "repository": "https://github.com/readmeio/api-explorer/tree/master/packages/api-logs",
   "devDependencies": {
-    "@readme/eslint-config": "^1.7.0",
+    "@readme/eslint-config": "^2.0.0",
     "eslint": "^6.5.0",
     "isomorphic-fetch": "^2.2.1",
     "jest": "^25.1.0",
@@ -35,5 +35,6 @@
     "terser-webpack-plugin": "^2.3.1",
     "webpack": "^4.41.0",
     "webpack-merge": "^4.2.2"
-  }
+  },
+  "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/http-status-codes/.prettierrc
+++ b/packages/http-status-codes/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "printWidth": 120,
-  "singleQuote": true
-}

--- a/packages/http-status-codes/package-lock.json
+++ b/packages/http-status-codes/package-lock.json
@@ -161,18 +161,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-      "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
-      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
+      "integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -797,9 +797,9 @@
       }
     },
     "@readme/eslint-config": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-1.16.0.tgz",
-      "integrity": "sha512-0/poD69LfLFWP5ZKqp+DbfVAMDmqQreSWyjzpHLH4n+juWak+dF4u+PgEmR5eaXGqrMj+tvhScGkoG7H2ski/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-2.0.0.tgz",
+      "integrity": "sha512-hKFBAmyAK+8IdQ9UBxxCSrBLOWAM6FIBrLR2LskYlyamIKbWmjSrgBpTEXo72Rgmg3VIl2Y3lCjGabgF9RL5oA==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0",
@@ -2059,9 +2059,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"

--- a/packages/http-status-codes/package.json
+++ b/packages/http-status-codes/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "inspect": "jsinspect",
     "lint": "eslint .",
-    "pretest": "npm run prettier && npm run lint && npm run inspect",
+    "pretest": "npm run lint && npm run prettier && npm run inspect",
     "prettier": "prettier --list-different --write \"./**/**.{js,jsx}\"",
     "test": "jest --coverage --runInBand"
   },
@@ -22,10 +22,11 @@
     "directory": "packages/http-status-codes"
   },
   "devDependencies": {
-    "@readme/eslint-config": "^1.7.0",
+    "@readme/eslint-config": "^2.0.0",
     "eslint": "^6.5.0",
     "jest": "^25.1.0",
     "jsinspect": "^0.12.6",
     "prettier": "^2.0.1"
-  }
+  },
+  "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/markdown-magic/.prettierrc
+++ b/packages/markdown-magic/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "printWidth": 120,
-  "singleQuote": true
-}

--- a/packages/markdown-magic/package-lock.json
+++ b/packages/markdown-magic/package-lock.json
@@ -195,18 +195,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-      "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
-      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
+      "integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -894,9 +894,9 @@
       "integrity": "sha512-zqnvyz2FAw9ah6dHkcaiOpL85DPMj8KgaW1Z14Lhf4qECPKRsid4IBd30ljuAV1gdX1JA8HCuFIY8SRU1Lvb2g=="
     },
     "@readme/eslint-config": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-1.16.0.tgz",
-      "integrity": "sha512-0/poD69LfLFWP5ZKqp+DbfVAMDmqQreSWyjzpHLH4n+juWak+dF4u+PgEmR5eaXGqrMj+tvhScGkoG7H2ski/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-2.0.0.tgz",
+      "integrity": "sha512-hKFBAmyAK+8IdQ9UBxxCSrBLOWAM6FIBrLR2LskYlyamIKbWmjSrgBpTEXo72Rgmg3VIl2Y3lCjGabgF9RL5oA==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0",
@@ -2262,9 +2262,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"

--- a/packages/markdown-magic/package.json
+++ b/packages/markdown-magic/package.json
@@ -32,10 +32,11 @@
   "license": "ISC",
   "repository": "https://github.com/readmeio/api-explorer/tree/master/packages/markdown-magic",
   "devDependencies": {
-    "@readme/eslint-config": "^1.7.0",
+    "@readme/eslint-config": "^2.0.0",
     "eslint": "^6.5.0",
     "jest": "^25.1.0",
     "jsinspect": "^0.12.7",
     "prettier": "^2.0.1"
-  }
+  },
+  "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/markdown/.prettierrc
+++ b/packages/markdown/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "printWidth": 120,
-  "singleQuote": true
-}

--- a/packages/markdown/package-lock.json
+++ b/packages/markdown/package-lock.json
@@ -195,18 +195,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-      "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
-      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
+      "integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -904,9 +904,9 @@
       "integrity": "sha512-zqnvyz2FAw9ah6dHkcaiOpL85DPMj8KgaW1Z14Lhf4qECPKRsid4IBd30ljuAV1gdX1JA8HCuFIY8SRU1Lvb2g=="
     },
     "@readme/eslint-config": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-1.16.0.tgz",
-      "integrity": "sha512-0/poD69LfLFWP5ZKqp+DbfVAMDmqQreSWyjzpHLH4n+juWak+dF4u+PgEmR5eaXGqrMj+tvhScGkoG7H2ski/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-2.0.0.tgz",
+      "integrity": "sha512-hKFBAmyAK+8IdQ9UBxxCSrBLOWAM6FIBrLR2LskYlyamIKbWmjSrgBpTEXo72Rgmg3VIl2Y3lCjGabgF9RL5oA==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0",
@@ -3541,9 +3541,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -28,7 +28,7 @@
     "watch": "webpack -w --progress",
     "lint": "eslint . --ext .jsx --ext .js",
     "inspect": "jsinspect",
-    "pretest": "npm run prettier && npm run lint && npm run inspect",
+    "pretest": "npm run lint && npm run prettier && npm run inspect",
     "prettier": "prettier --list-different --write \"./**/**.{js,jsx}\"",
     "test": "jest --coverage --runInBand"
   },
@@ -40,7 +40,7 @@
   "license": "ISC",
   "repository": "https://github.com/readmeio/api-explorer/tree/master/packages/markdown",
   "devDependencies": {
-    "@readme/eslint-config": "^1.7.0",
+    "@readme/eslint-config": "^2.0.0",
     "css-loader": "^3.2.0",
     "eslint": "^6.5.0",
     "isomorphic-style-loader": "^5.1.0",
@@ -48,5 +48,6 @@
     "jsinspect": "^0.12.7",
     "prettier": "^2.0.1",
     "webpack": "^3.10.0"
-  }
+  },
+  "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/markdown/processor/compile/code-tabs.js
+++ b/packages/markdown/processor/compile/code-tabs.js
@@ -3,8 +3,7 @@ module.exports = function CodeTabsCompiler() {
   const { visitors } = Compiler.prototype;
 
   function compile(node) {
-    const md = this.block(node).split('```\n\n').join('```\n');
-    return md;
+    return this.block(node).split('```\n\n').join('```\n');
   }
   visitors['code-tabs'] = compile;
 };

--- a/packages/oas-to-har/.prettierrc
+++ b/packages/oas-to-har/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "printWidth": 120,
-  "singleQuote": true
-}

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -181,18 +181,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-      "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
-      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
+      "integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -853,9 +853,9 @@
       }
     },
     "@readme/eslint-config": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-1.16.0.tgz",
-      "integrity": "sha512-0/poD69LfLFWP5ZKqp+DbfVAMDmqQreSWyjzpHLH4n+juWak+dF4u+PgEmR5eaXGqrMj+tvhScGkoG7H2ski/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-2.0.0.tgz",
+      "integrity": "sha512-hKFBAmyAK+8IdQ9UBxxCSrBLOWAM6FIBrLR2LskYlyamIKbWmjSrgBpTEXo72Rgmg3VIl2Y3lCjGabgF9RL5oA==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0",
@@ -2118,9 +2118,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -5810,9 +5810,9 @@
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "react-is": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
-      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
     "read-pkg": {

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "inspect": "jsinspect",
     "lint": "eslint .",
-    "pretest": "npm run prettier && npm run lint && npm run inspect",
+    "pretest": "npm run lint && npm run prettier && npm run inspect",
     "prettier": "prettier --list-different --write \"./**/**.{js,jsx}\"",
     "test": "jest --coverage --runInBand"
   },
@@ -27,10 +27,11 @@
     "directory": "packages/oas-to-har"
   },
   "devDependencies": {
-    "@readme/eslint-config": "^1.7.0",
+    "@readme/eslint-config": "^2.0.0",
     "eslint": "^6.5.0",
     "jest": "^25.1.0",
     "jsinspect": "^0.12.6",
     "prettier": "^2.0.1"
-  }
+  },
+  "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/oas-to-har/src/index.js
+++ b/packages/oas-to-har/src/index.js
@@ -90,25 +90,21 @@ module.exports = (
 
   // Does this operation have any parameters?
   const parameters = [];
+  function addParameter(param) {
+    if (param.$ref) {
+      parameters.push(findSchemaDefinition(param.$ref, oas));
+    } else {
+      parameters.push(param);
+    }
+  }
+
   if (pathOperation.parameters) {
-    pathOperation.parameters.forEach(param => {
-      if (param.$ref) {
-        parameters.push(findSchemaDefinition(param.$ref, oas));
-      } else {
-        parameters.push(param);
-      }
-    });
+    pathOperation.parameters.forEach(addParameter);
   }
 
   // Does this operation have any common parameters?
   if (oas.paths && oas.paths[pathOperation.path] && oas.paths[pathOperation.path].parameters) {
-    oas.paths[pathOperation.path].parameters.forEach(param => {
-      if (param.$ref) {
-        parameters.push(findSchemaDefinition(param.$ref, oas));
-      } else {
-        parameters.push(param);
-      }
-    });
+    oas.paths[pathOperation.path].parameters.forEach(addParameter);
   }
 
   har.url = har.url.replace(/{([-_a-zA-Z0-9[\]]+)}/g, (full, key) => {

--- a/packages/syntax-highlighter/.prettierrc
+++ b/packages/syntax-highlighter/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "printWidth": 120,
-  "singleQuote": true
-}

--- a/packages/syntax-highlighter/package-lock.json
+++ b/packages/syntax-highlighter/package-lock.json
@@ -209,18 +209,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-      "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
-      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
+      "integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -840,9 +840,9 @@
       }
     },
     "@readme/eslint-config": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-1.16.0.tgz",
-      "integrity": "sha512-0/poD69LfLFWP5ZKqp+DbfVAMDmqQreSWyjzpHLH4n+juWak+dF4u+PgEmR5eaXGqrMj+tvhScGkoG7H2ski/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-2.0.0.tgz",
+      "integrity": "sha512-hKFBAmyAK+8IdQ9UBxxCSrBLOWAM6FIBrLR2LskYlyamIKbWmjSrgBpTEXo72Rgmg3VIl2Y3lCjGabgF9RL5oA==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0",
@@ -2108,9 +2108,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"

--- a/packages/syntax-highlighter/package.json
+++ b/packages/syntax-highlighter/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "inspect": "jsinspect",
     "lint": "eslint . --ext .jsx --ext .js",
-    "pretest": "npm run prettier && npm run lint && npm run inspect",
+    "pretest": "npm run lint && npm run prettier && npm run inspect",
     "prettier": "prettier --list-different --write \"./**/**.{js,jsx}\"",
     "test": "jest --coverage --runInBand"
   },
@@ -22,10 +22,11 @@
   "license": "ISC",
   "repository": "https://github.com/readmeio/api-explorer/tree/master/packages/syntax-highlighter",
   "devDependencies": {
-    "@readme/eslint-config": "^1.7.0",
+    "@readme/eslint-config": "^2.0.0",
     "eslint": "^6.5.0",
     "jest": "^25.1.0",
     "jsinspect": "^0.12.6",
     "prettier": "^2.0.1"
-  }
+  },
+  "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/variable/.prettierrc
+++ b/packages/variable/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "printWidth": 120,
-  "singleQuote": true
-}

--- a/packages/variable/package-lock.json
+++ b/packages/variable/package-lock.json
@@ -195,18 +195,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-      "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
-      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
+      "integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -881,9 +881,9 @@
       }
     },
     "@readme/eslint-config": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-1.16.0.tgz",
-      "integrity": "sha512-0/poD69LfLFWP5ZKqp+DbfVAMDmqQreSWyjzpHLH4n+juWak+dF4u+PgEmR5eaXGqrMj+tvhScGkoG7H2ski/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-2.0.0.tgz",
+      "integrity": "sha512-hKFBAmyAK+8IdQ9UBxxCSrBLOWAM6FIBrLR2LskYlyamIKbWmjSrgBpTEXo72Rgmg3VIl2Y3lCjGabgF9RL5oA==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0",
@@ -2187,9 +2187,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"

--- a/packages/variable/package.json
+++ b/packages/variable/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "inspect": "jsinspect",
     "lint": "eslint . --ext .jsx --ext .js",
-    "pretest": "npm run prettier && npm run lint && npm run inspect",
+    "pretest": "npm run lint && npm run prettier && npm run inspect",
     "prettier": "prettier --list-different --write \"./**/**.{js,jsx}\"",
     "test": "jest --coverage --runInBand"
   },
@@ -23,10 +23,11 @@
   "license": "ISC",
   "repository": "https://github.com/readmeio/api-explorer/tree/master/packages/variable",
   "devDependencies": {
-    "@readme/eslint-config": "^1.7.0",
+    "@readme/eslint-config": "^2.0.0",
     "eslint": "^6.5.0",
     "jest": "^25.1.0",
     "jsinspect": "^0.12.7",
     "prettier": "^2.0.1"
-  }
+  },
+  "prettier": "@readme/eslint-config/prettier"
 }


### PR DESCRIPTION
This upgrades `@readme/eslint-config` to 2.0.0 which allows us to start pulling in our shared Prettier config.