### PR TITLE
fix: using the appropriate markdown contexts when necessary

### DIFF
--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -4,8 +4,6 @@ const PropTypes = require('prop-types');
 const extensions = require('@readme/oas-extensions');
 const VariablesContext = require('@readme/variable/contexts/Variables');
 const OauthContext = require('@readme/variable/contexts/Oauth');
-const GlossaryTermsContext = require('@readme/markdown/contexts/GlossaryTerms');
-const BaseUrlContext = require('@readme/markdown/contexts/BaseUrl');
 const SelectedAppContext = require('@readme/variable/contexts/SelectedApp');
 
 const ErrorBoundary = require('./ErrorBoundary');
@@ -181,6 +179,18 @@ class ApiExplorer extends React.Component {
 
       return true;
     });
+
+    /* eslint-disable global-require */
+    let BaseUrlContext;
+    let GlossaryTermsContext;
+    if (this.props.useNewMarkdownEngine) {
+      BaseUrlContext = require('@readme/markdown/contexts/BaseUrl');
+      GlossaryTermsContext = require('@readme/markdown/contexts/GlossaryTerms');
+    } else {
+      BaseUrlContext = require('@readme/markdown-magic/contexts/BaseUrl');
+      GlossaryTermsContext = require('@readme/markdown-magic/contexts/GlossaryTerms');
+    }
+    /* eslint-enable global-require */
 
     return (
       <div className={`is-lang-${this.state.language}`}>


### PR DESCRIPTION
## 🧰 What's being changed?

This resolves a bug in our Markdown processing of links where we weren't prepending the supplied `baseUrl` because, when the old Markdown processor was enabled, we were loading a context consumer that was never actually set up.

What happens now is that if the new Markdown engine is enabled, we'll use the context for `BaseUrl` and `GlossaryTerms` from `@readme/markdown`, otherwise we'll use the same files but from `@readme/markdown-engine`.


## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
