### PR TITLE
fix: support for repairing malformed array schemas

### DIFF
--- a/example/swagger-files/types.json
+++ b/example/swagger-files/types.json
@@ -195,6 +195,14 @@
                   "boolean without description": {
                     "type": "boolean"
                   },
+                  "array (of mixed content)": {
+                    "type": "array",
+                    "items": {}
+                  },
+                  "array (of mixed content, no `items` property)": {
+                    "type": "array",
+                    "description": "Techncally this is a malformed schema, but we support it and repair it to have `items: {}`"
+                  },
                   "array (of strings)": {
                     "type": "array",
                     "items": {

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -269,9 +269,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.8.7.tgz",
-      "integrity": "sha512-R8zbPiv25S0pGfMqAr55dRRxWB8vUeo3wicI4g9PFVBKmsy/9wmQUV1AaYW/kxRHUhx42TTh6F0+QO+4pwfYWg==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.9.2.tgz",
+      "integrity": "sha512-ayjSOxuK2GaSDJFCtLgHnYjuMyIpViNujWrZo8GUpN60/n7juzJKK5yOo6RFVb0zdU9ACJFK+MsZrUnj3OmXMw==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1377,9 +1377,9 @@
       }
     },
     "@readme/react-jsonschema-form": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@readme/react-jsonschema-form/-/react-jsonschema-form-1.1.2.tgz",
-      "integrity": "sha512-0fH2YRt0MPuX1UjA3ulsOK/yespQO9e6KiEHcctyiWJK2whQU7D5TCUczkWwIxoG9hOudByV5iVzSHLh9YIIVQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@readme/react-jsonschema-form/-/react-jsonschema-form-1.1.3.tgz",
+      "integrity": "sha512-eJMRNG7H7svsfK1W9Ho93FKnnRLpJ6yScYqgvH2ISj366SkjaFLkrUKc1BYXZP8aqFUq316Y0HOiP4WuprLPwA==",
       "requires": {
         "@babel/runtime-corejs2": "^7.4.5",
         "ajv": "^6.7.0",
@@ -1399,9 +1399,9 @@
           "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
         },
         "react-is": {
-          "version": "16.13.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
-          "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1341,29 +1341,6 @@
         }
       }
     },
-    "@mapbox/hast-util-table-cell-style": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz",
-      "integrity": "sha512-QsEsh5YaDvHoMQ2YHdvZy2iDnU3GgKVBTcHf6cILyoWDZtPSdlG444pL/ioPYO/GpXSfODBb9sefEetfC4v9oA==",
-      "requires": {
-        "unist-util-visit": "^1.3.0"
-      },
-      "dependencies": {
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        }
-      }
-    },
-    "@readme/emojis": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/emojis/-/emojis-1.0.0.tgz",
-      "integrity": "sha512-zqnvyz2FAw9ah6dHkcaiOpL85DPMj8KgaW1Z14Lhf4qECPKRsid4IBd30ljuAV1gdX1JA8HCuFIY8SRU1Lvb2g=="
-    },
     "@readme/eslint-config": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-2.0.0.tgz",
@@ -1384,127 +1361,16 @@
         "eslint-plugin-unicorn": "^17.0.1"
       }
     },
-    "@readme/http-status-codes": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/http-status-codes/-/http-status-codes-6.0.5.tgz",
-      "integrity": "sha512-Te4svMJZITiIAp186VOTsazFDEV4bTyexeItz4ysElMK5YHTE3kynSBhZAS8D6SX9WQxCZ1Q6MpxsNGmki+o9w=="
-    },
-    "@readme/markdown": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@readme/markdown/-/markdown-6.0.6.tgz",
-      "integrity": "sha512-zJEDa+Pt1WYWWmsYFnJB3Y2grpIz3uI4HV7PlbzM6WHMYtK/a+R9l+yGEWUjCosFCVfxfeBwGeTfh+WnoH8l0w==",
-      "requires": {
-        "@readme/emojis": "^1.0.0",
-        "@readme/syntax-highlighter": "^6.0.5",
-        "@readme/variable": "^6.0.5",
-        "hast-util-sanitize": "^1.2.0",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2",
-        "rehype-raw": "^4.0.1",
-        "rehype-react": "^5.0.0",
-        "rehype-remark": "^7.0.0",
-        "rehype-sanitize": "^3.0.1",
-        "rehype-stringify": "^6.0.0",
-        "remark-breaks": "^1.0.0",
-        "remark-parse": "^7.0.2",
-        "remark-rehype": "^5.0.0",
-        "remark-stringify": "^7.0.4",
-        "unified": "^8.4.0",
-        "unist-util-map": "^2.0.0",
-        "unist-util-visit": "^2.0.1"
-      }
-    },
-    "@readme/markdown-magic": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@readme/markdown-magic/-/markdown-magic-6.0.6.tgz",
-      "integrity": "sha512-vyj90L+Ehkxkv3mdE4+SZ61ambBwE/4ClMeuICvIMRSzpBMEZ9I4UesCMEzBrE03EtnNaFxCfxyAAhtp1bSwtw==",
-      "requires": {
-        "@readme/emojis": "^1.0.0",
-        "@readme/syntax-highlighter": "^6.0.5",
-        "@readme/variable": "^6.0.5",
-        "hast-util-sanitize": "^1.2.0",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2",
-        "rehype-raw": "^4.0.1",
-        "rehype-react": "^3.1.0",
-        "rehype-sanitize": "^2.0.1",
-        "remark-breaks": "^1.0.0",
-        "remark-parse": "^7.0.2",
-        "remark-rehype": "^5.0.0",
-        "unified": "^8.4.0"
-      },
-      "dependencies": {
-        "hast-to-hyperscript": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-5.0.0.tgz",
-          "integrity": "sha512-DLl3eYTz8uwwzEubDUdCChsR5t5b2ne+yvHrA2h58Suq/JnN3+Gsb9Tc4iZoCCsykmFUc6UUpwxTmQXs0akSeg==",
-          "requires": {
-            "comma-separated-tokens": "^1.0.0",
-            "property-information": "^4.0.0",
-            "space-separated-tokens": "^1.0.0",
-            "style-to-object": "^0.2.1",
-            "unist-util-is": "^2.0.0",
-            "web-namespaces": "^1.1.2"
-          }
-        },
-        "property-information": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/property-information/-/property-information-4.2.0.tgz",
-          "integrity": "sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==",
-          "requires": {
-            "xtend": "^4.0.1"
-          }
-        },
-        "rehype-react": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-3.1.0.tgz",
-          "integrity": "sha512-7SiLiqNudSGkvhrePkdKqdUvngZqzG+PJhdR5EeIFELz2j2ek4aO5DHbxUXYvaZfqUiBDO2Aeq1OROUmxmu+Vg==",
-          "requires": {
-            "@mapbox/hast-util-table-cell-style": "^0.1.3",
-            "has": "^1.0.1",
-            "hast-to-hyperscript": "^5.0.0"
-          }
-        },
-        "rehype-sanitize": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-2.0.3.tgz",
-          "integrity": "sha512-RZFLBV36yOWNbV4g2WJDfilAzV1Sin/InQHXA+5h9+GkxCFnTJCC7SPrAdVHEIrQ882eAD8/51jEYHD6xrewcw==",
-          "requires": {
-            "hast-util-sanitize": "^1.1.0"
-          }
-        },
-        "unist-util-is": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
-        }
-      }
-    },
     "@readme/oas-examples": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-3.0.0.tgz",
       "integrity": "sha512-8icVZrS+V8DxdFLbErNSxqw6rqXBTa/i6YeNiLdVkqCh2veZ13lvmbgmzg9U3mzINosenqpAeT1bpC41SZ4goQ==",
       "dev": true
     },
-    "@readme/oas-extensions": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-6.0.5.tgz",
-      "integrity": "sha512-x3gLEKhzUnrJjCM6hls2V/QT7u1knrIYhtnXZJ9Ln9NBYU3TKHdW7Cd8vZcoVH0e/w3O/BoCgyHOyb559oVaHQ=="
-    },
-    "@readme/oas-to-har": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-6.0.9.tgz",
-      "integrity": "sha512-cS0IGQqjdJgwk9f22xbfH40tq+bAtQINWVHKpsUEoe3BufcrjhxiLSIcTvddQvXURbGZ4UVnoFvogLkm9HL0XA==",
-      "requires": {
-        "@readme/oas-extensions": "^6.0.5",
-        "@readme/oas-tooling": "^3.1.3",
-        "querystring": "^0.2.0"
-      }
-    },
     "@readme/oas-tooling": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.3.tgz",
-      "integrity": "sha512-oCcMmSWLF1PtU774knEHYsKUNShyhTKNtxZ6NsetpYgJIKPku3BLxWRgrqiccxIZGYLVdRmQ1SzL/DbsGi06uA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.4.tgz",
+      "integrity": "sha512-UGRbOovtJPvwpvBwix/q0zaMVeIAE/Ooi0IRhgxyz1X3e35rEFZO8/+GmPZIr25cX07e6ASKYuf5Y/n+QrmnSw==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"
@@ -1537,26 +1403,6 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
           "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
         }
-      }
-    },
-    "@readme/syntax-highlighter": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-6.0.5.tgz",
-      "integrity": "sha512-i0pCWNxgCkkF5/T8ovE2z3hLLeS+03Z7QwhoZ4OynYBbDaIRh2vHLhHdJIFfCSbfgKhON6K4vD1+XB9z7hWOwQ==",
-      "requires": {
-        "@readme/variable": "^6.0.5",
-        "codemirror": "^5.48.2",
-        "react": "^16.4.2"
-      }
-    },
-    "@readme/variable": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-6.0.5.tgz",
-      "integrity": "sha512-f/f6BFxIJO2Oi9X+sWxixlaik/RFMdNJmKS6nexSbW4CMgr7O5rP9r84yVxds9DjDE+R/6VgTcbpt/jcDhBC1A==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
       }
     },
     "@sinonjs/commons": {
@@ -1646,14 +1492,6 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
-    "@types/mdast": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
-      "integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
-      "requires": {
-        "@types/unist": "*"
-      }
-    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -1665,11 +1503,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
-    },
-    "@types/unist": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "@types/yargs": {
       "version": "15.0.1",
@@ -2122,11 +1955,6 @@
         }
       }
     },
-    "array-iterate": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.4.tgz",
-      "integrity": "sha512-sNRaPGh9nnmdC8Zf+pT3UqP8rnWj5Hf9wiFGsX3wUQ2yVSIhO2ShFwCoceIPpB41QF6i2OEmrHmCo36xronCVA=="
-    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -2397,11 +2225,6 @@
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz",
       "integrity": "sha1-MMWiL0gZeKnn+M399JaxHZS0BNM=",
       "dev": true
-    },
-    "bail": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -2824,11 +2647,6 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "ccount": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
-      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw=="
-    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -2840,26 +2658,6 @@
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
       }
-    },
-    "character-entities": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
-    },
-    "character-entities-html4": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
-      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g=="
-    },
-    "character-entities-legacy": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
-    },
-    "character-reference-invalid": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
     },
     "chardet": {
       "version": "0.7.0",
@@ -3041,16 +2839,6 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
-    "codemirror": {
-      "version": "5.52.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.52.2.tgz",
-      "integrity": "sha512-WCGCixNUck2HGvY8/ZNI1jYfxPG5cRHv0VjmWuNzbtCLz8qYA5d+je4QhSSCtCaagyeOwMi/HmmPTjBgiTm2lQ=="
-    },
-    "collapse-white-space": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
-    },
     "collect-v8-coverage": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.0.tgz",
@@ -3089,11 +2877,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "comma-separated-tokens": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
     },
     "commander": {
       "version": "2.11.0",
@@ -3468,14 +3251,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "detab": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.3.tgz",
-      "integrity": "sha512-Up8P0clUVwq0FnFjDclzZsy9PadzRn5FFxrr47tQQvMHqyiFYVbpH8oXDzWtF0Q7pYy3l+RPmtBl+BsFF6wH0A==",
-      "requires": {
-        "repeat-string": "^1.5.4"
       }
     },
     "detect-file": {
@@ -4530,7 +4305,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -5629,7 +5405,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -5831,6 +5608,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -5935,159 +5713,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hast-to-hyperscript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-7.0.4.tgz",
-      "integrity": "sha512-vmwriQ2H0RPS9ho4Kkbf3n3lY436QKLq6VaGA1pzBh36hBi3tm1DO9bR+kaJIbpT10UqaANDkMjxvjVfr+cnOA==",
-      "requires": {
-        "comma-separated-tokens": "^1.0.0",
-        "property-information": "^5.3.0",
-        "space-separated-tokens": "^1.0.0",
-        "style-to-object": "^0.2.1",
-        "unist-util-is": "^3.0.0",
-        "web-namespaces": "^1.1.2"
-      }
-    },
-    "hast-util-embedded": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-1.0.5.tgz",
-      "integrity": "sha512-0FfLHmfArWOizbdwjL+Rc9QIBzqP80juicNl4S4NEPq5OYWBCgYrtYDPUDoSyQQ9IQlBn9W7++fpYQNzZSq/wQ==",
-      "requires": {
-        "hast-util-is-element": "^1.0.0"
-      }
-    },
-    "hast-util-from-parse5": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz",
-      "integrity": "sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==",
-      "requires": {
-        "ccount": "^1.0.3",
-        "hastscript": "^5.0.0",
-        "property-information": "^5.0.0",
-        "web-namespaces": "^1.1.2",
-        "xtend": "^4.0.1"
-      }
-    },
-    "hast-util-has-property": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz",
-      "integrity": "sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg=="
-    },
-    "hast-util-is-body-ok-link": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-1.0.3.tgz",
-      "integrity": "sha512-NB8jW4iqT+iVld2oCjSk0T2S2FyR86rDZ7nKHx3WNf/WX16fjjdfoog6T+YeJFsPzszVKsNlVJL+k5c4asAHog==",
-      "requires": {
-        "hast-util-has-property": "^1.0.0",
-        "hast-util-is-element": "^1.0.0"
-      }
-    },
-    "hast-util-is-element": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.4.tgz",
-      "integrity": "sha512-NFR6ljJRvDcyPP5SbV7MyPBgF47X3BsskLnmw1U34yL+X6YC0MoBx9EyMg8Jtx4FzGH95jw8+c1VPLHaRA0wDQ=="
-    },
-    "hast-util-parse-selector": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz",
-      "integrity": "sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA=="
-    },
-    "hast-util-raw": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-5.0.2.tgz",
-      "integrity": "sha512-3ReYQcIHmzSgMq8UrDZHFL0oGlbuVGdLKs8s/Fe8BfHFAyZDrdv1fy/AGn+Fim8ZuvAHcJ61NQhVMtyfHviT/g==",
-      "requires": {
-        "hast-util-from-parse5": "^5.0.0",
-        "hast-util-to-parse5": "^5.0.0",
-        "html-void-elements": "^1.0.0",
-        "parse5": "^5.0.0",
-        "unist-util-position": "^3.0.0",
-        "web-namespaces": "^1.0.0",
-        "xtend": "^4.0.0",
-        "zwitch": "^1.0.0"
-      }
-    },
-    "hast-util-sanitize": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz",
-      "integrity": "sha512-AIeKHuHx0Wk45nSkGVa2/ujQYTksnDl8gmmKo/mwQi7ag7IBZ8cM3nJ2G86SajbjGP/HRpud6kMkPtcM2i0Tlw==",
-      "requires": {
-        "xtend": "^4.0.1"
-      }
-    },
-    "hast-util-to-html": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-6.1.0.tgz",
-      "integrity": "sha512-IlC+LG2HGv0Y8js3wqdhg9O2sO4iVpRDbHOPwXd7qgeagpGsnY49i8yyazwqS35RA35WCzrBQE/n0M6GG/ewxA==",
-      "requires": {
-        "ccount": "^1.0.0",
-        "comma-separated-tokens": "^1.0.1",
-        "hast-util-is-element": "^1.0.0",
-        "hast-util-whitespace": "^1.0.0",
-        "html-void-elements": "^1.0.0",
-        "property-information": "^5.2.0",
-        "space-separated-tokens": "^1.0.0",
-        "stringify-entities": "^2.0.0",
-        "unist-util-is": "^3.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "hast-util-to-mdast": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-6.0.0.tgz",
-      "integrity": "sha512-DqG5A0QCi/VACAa9W35aiR0bA1fwYpLgo5IYG6KOQ6v0moT0YhM/JoX25JTmsoyGVy+NC37082shcLefFCL5qA==",
-      "requires": {
-        "extend": "^3.0.2",
-        "hast-util-has-property": "^1.0.0",
-        "hast-util-is-element": "^1.0.0",
-        "hast-util-to-text": "^1.0.0",
-        "mdast-util-phrasing": "^1.0.0",
-        "mdast-util-to-string": "^1.0.4",
-        "rehype-minify-whitespace": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "trim-trailing-lines": "^1.1.0",
-        "unist-util-visit": "^2.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "hast-util-to-parse5": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-5.1.2.tgz",
-      "integrity": "sha512-ZgYLJu9lYknMfsBY0rBV4TJn2xiwF1fXFFjbP6EE7S0s5mS8LIKBVWzhA1MeIs1SWW6GnnE4In6c3kPb+CWhog==",
-      "requires": {
-        "hast-to-hyperscript": "^7.0.0",
-        "property-information": "^5.0.0",
-        "web-namespaces": "^1.0.0",
-        "xtend": "^4.0.0",
-        "zwitch": "^1.0.0"
-      }
-    },
-    "hast-util-to-text": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-1.0.1.tgz",
-      "integrity": "sha512-Xvp9fWiWVb4WaHc1E1g6dtyYlcVwyjRT0CC9oXtVUNhbmIB1gqRVBuBIFJgrFkYxdo+T3UIl5i5ipPGaPRnUOw==",
-      "requires": {
-        "hast-util-is-element": "^1.0.2",
-        "repeat-string": "^1.6.1",
-        "unist-util-find-after": "^2.0.3"
-      }
-    },
-    "hast-util-whitespace": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
-      "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A=="
-    },
-    "hastscript": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
-      "requires": {
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -6128,16 +5753,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
       "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
       "dev": true
-    },
-    "html-void-elements": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
-      "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w=="
-    },
-    "html-whitespace-sensitive-tag-names": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-1.0.2.tgz",
-      "integrity": "sha512-9jCcAq9ZsjUkZjNFDvxalDPhktOijpfzLyzBcqMLOFSbtcDNrPlKDvZeH7KdEbP7C6OjPpIdDMMPm0oq2Dpk0A=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -6270,18 +5885,14 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
-    },
-    "inline-style-parser": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
-      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "inquirer": {
       "version": "7.0.1",
@@ -6397,25 +6008,6 @@
         "kind-of": "^3.0.2"
       }
     },
-    "is-alphabetical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
-    },
-    "is-alphanumeric": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
-      "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ="
-    },
-    "is-alphanumerical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -6466,11 +6058,6 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
-    },
-    "is-decimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -6524,11 +6111,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-hexadecimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
-    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -6542,11 +6124,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-    },
-    "is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -6628,21 +6205,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
-    "is-whitespace-character": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
-    },
-    "is-word-character": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
-      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
     },
     "is-wsl": {
       "version": "1.1.0",
@@ -9204,11 +8771,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "longest-streak": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
-      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="
-    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -9295,16 +8857,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown-escapes": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
-    },
-    "markdown-table": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
-      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -9323,88 +8875,6 @@
           "dev": true
         }
       }
-    },
-    "mdast-util-compact": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.4.tgz",
-      "integrity": "sha512-3YDMQHI5vRiS2uygEFYaqckibpJtKq5Sj2c8JioeOQBU6INpKbdWzfyLqFFnDwEcEnRFIdMsguzs5pC1Jp4Isg==",
-      "requires": {
-        "unist-util-visit": "^1.1.0"
-      },
-      "dependencies": {
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        }
-      }
-    },
-    "mdast-util-definitions": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
-      "integrity": "sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==",
-      "requires": {
-        "unist-util-visit": "^1.0.0"
-      },
-      "dependencies": {
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        }
-      }
-    },
-    "mdast-util-phrasing": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-1.0.3.tgz",
-      "integrity": "sha512-b1Ar28MjmPMMnTDUApnL1AUJY1L/KmBg5+iBLMd8/+0JqXh1sENow9+wj8Mp/SZBYtMlGRUQ1PkBWinPEDVeNQ==",
-      "requires": {
-        "unist-util-is": "^3.0.0"
-      }
-    },
-    "mdast-util-to-hast": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-6.0.2.tgz",
-      "integrity": "sha512-GjcOimC9qHI0yNFAQdBesrZXzUkRdFleQlcoU8+TVNfDW6oLUazUx8MgUoTaUyCJzBOnE5AOgqhpURrSlf0QwQ==",
-      "requires": {
-        "collapse-white-space": "^1.0.0",
-        "detab": "^2.0.0",
-        "mdast-util-definitions": "^1.2.0",
-        "mdurl": "^1.0.1",
-        "trim": "0.0.1",
-        "trim-lines": "^1.0.0",
-        "unist-builder": "^1.0.1",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.0",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        }
-      }
-    },
-    "mdast-util-to-string": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
-      "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A=="
-    },
-    "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "mem": {
       "version": "4.3.0",
@@ -10205,19 +9675,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-      "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -10236,7 +9693,8 @@
     "parse5": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
+      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+      "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -10557,14 +10015,6 @@
         }
       }
     },
-    "property-information": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.4.0.tgz",
-      "integrity": "sha512-nmMWAm/3vKFGmmOWOcdLjgq/Hlxa+hsuR/px1Lp/UGEyc5A22A6l78Shc2C0E71sPmAqglni+HrS7L7VJ7AUCA==",
-      "requires": {
-        "xtend": "^4.0.0"
-      }
-    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -10652,7 +10102,8 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -10925,164 +10376,6 @@
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
-    "rehype-minify-whitespace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-3.0.0.tgz",
-      "integrity": "sha512-Z5NIG9FxTeK2Ta+eTWCnTVPXu1qC58eCXZA3m/Z7PPinKw82KSR+12c2l1sLLSg27QZOmZrrd9piS8dsAVfliQ==",
-      "requires": {
-        "collapse-white-space": "^1.0.0",
-        "hast-util-embedded": "^1.0.0",
-        "hast-util-has-property": "^1.0.0",
-        "hast-util-is-body-ok-link": "^1.0.0",
-        "hast-util-is-element": "^1.0.0",
-        "html-whitespace-sensitive-tag-names": "^1.0.0",
-        "unist-util-is": "^4.0.0",
-        "unist-util-modify-children": "^1.0.0"
-      },
-      "dependencies": {
-        "unist-util-is": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
-          "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
-        }
-      }
-    },
-    "rehype-raw": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-4.0.2.tgz",
-      "integrity": "sha512-xQt94oXfDaO7sK9mJBtsZXkjW/jm6kArCoYN+HqKZ51O19AFHlp3Xa5UfZZ2tJkbpAZzKtgVUYvnconk9IsFuA==",
-      "requires": {
-        "hast-util-raw": "^5.0.0"
-      }
-    },
-    "rehype-react": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-5.0.0.tgz",
-      "integrity": "sha512-siBd7cyMAgJv8yoLOm5Dh2izha2aoKMw01SKN0DTjeEO1r5mSQUjb6LZnGxWs/ip2Lfaso+CjZUXuPlJqC3S4g==",
-      "requires": {
-        "@mapbox/hast-util-table-cell-style": "^0.1.3",
-        "hast-to-hyperscript": "^8.0.0"
-      },
-      "dependencies": {
-        "hast-to-hyperscript": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-8.0.0.tgz",
-          "integrity": "sha512-WgSlKtcjhDeCa6USBnoJwjOmRo81/Ib/MPSASOjTH99XLoPO+R5/1LrCjHJnftM8KTbnf6OV9czQj25mqBXYHw==",
-          "requires": {
-            "comma-separated-tokens": "^1.0.0",
-            "property-information": "^5.0.0",
-            "space-separated-tokens": "^1.0.0",
-            "style-to-object": "^0.3.0",
-            "unist-util-is": "^4.0.0",
-            "web-namespaces": "^1.0.0"
-          }
-        },
-        "style-to-object": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
-          "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
-          "requires": {
-            "inline-style-parser": "0.1.1"
-          }
-        },
-        "unist-util-is": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
-          "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
-        }
-      }
-    },
-    "rehype-remark": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-7.0.0.tgz",
-      "integrity": "sha512-yxlCzwzVWL9QC8a3pZ97z/EVtOIB6SwopYmbWIjTa+QDooK51Mu/qxpO8rJkb8TXTUF7y23hXEFWfI+xlwSWoA==",
-      "requires": {
-        "hast-util-to-mdast": "^6.0.0"
-      }
-    },
-    "rehype-sanitize": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-3.0.1.tgz",
-      "integrity": "sha512-tOXwIVmrFsjwFfhWPF2FYaIJ0LPEfGngQZvRfmqCsCGVCNbRlTMMcJPaLNwdUrNkKPNh/VdmA2ZzzivbQTfIMw==",
-      "requires": {
-        "hast-util-sanitize": "^2.0.0"
-      },
-      "dependencies": {
-        "hast-util-sanitize": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-2.0.2.tgz",
-          "integrity": "sha512-ppfgtI6pVb0/dopboV/N2SZju/CKEJzLs6jm58NxoYU1c1ib+/sh14JV5bjLDOEYvyeb5hYIttFKanYm0rtnHQ==",
-          "requires": {
-            "xtend": "^4.0.0"
-          }
-        }
-      }
-    },
-    "rehype-stringify": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-6.0.1.tgz",
-      "integrity": "sha512-JfEPRDD4DiG7jet4md7sY07v6ACeb2x+9HWQtRPm2iA6/ic31hCv1SNBUtpolJASxQ/D8gicXiviW4TJKEMPKQ==",
-      "requires": {
-        "hast-util-to-html": "^6.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "remark-breaks": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-1.0.5.tgz",
-      "integrity": "sha512-lr8+TlJI273NjEqL27eUthPYPTCgXEj4NaLbnazS3bQaQL2FySlsbtgo52gE36fE1gWeQgkn1VdmWsoT+uA7FA=="
-    },
-    "remark-parse": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.2.tgz",
-      "integrity": "sha512-9+my0lQS80IQkYXsMA8Sg6m9QfXYJBnXjWYN5U+kFc5/n69t+XZVXU/ZBYr3cYH8FheEGf1v87rkFDhJ8bVgMA==",
-      "requires": {
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.1.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "remark-rehype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-5.0.0.tgz",
-      "integrity": "sha512-tgo+AeOotuh9FnGMkEPbE6C3OfdARqqSxT0H/KNGAiTwJLiDoRSm6x/ytqPZTyYSiQ/exbi/kx7k6uUvqYL1wQ==",
-      "requires": {
-        "mdast-util-to-hast": "^6.0.0"
-      }
-    },
-    "remark-stringify": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-7.0.4.tgz",
-      "integrity": "sha512-qck+8NeA1D0utk1ttKcWAoHRrJxERYQzkHDyn+pF5Z4whX1ug98uCNPPSeFgLSaNERRxnD6oxIug6DzZQth6Pg==",
-      "requires": {
-        "ccount": "^1.0.0",
-        "is-alphanumeric": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "longest-streak": "^2.0.1",
-        "markdown-escapes": "^1.0.0",
-        "markdown-table": "^1.1.0",
-        "mdast-util-compact": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "stringify-entities": "^2.0.0",
-        "unherit": "^1.0.4",
-        "xtend": "^4.0.1"
-      }
-    },
     "remove-trailing-separator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
@@ -11098,12 +10391,8 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
-    "replace-ext": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "request": {
       "version": "2.88.0",
@@ -11712,11 +11001,6 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
-    "space-separated-tokens": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
-    },
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -11810,11 +11094,6 @@
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
-    },
-    "state-toggle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
     },
     "static-extend": {
       "version": "0.1.2",
@@ -12057,18 +11336,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "stringify-entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-2.0.0.tgz",
-      "integrity": "sha512-fqqhZzXyAM6pGD9lky/GOPq6V4X0SeTAFBl0iXb/BzOegl40gpf/bV3QQP7zULNYvjr6+Dx8SCaDULjVoOru0A==",
-      "requires": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.2",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
     "stringify-object": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
@@ -12119,14 +11386,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
-    },
-    "style-to-object": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.2.3.tgz",
-      "integrity": "sha512-1d/k4EY2N7jVLOqf2j04dTc37TPOv/hHxZmvpg8Pdh8UYydxeu/C1W1U4vD8alzf5V2Gt7rLsmkr4dxAlDm9ng==",
-      "requires": {
-        "inline-style-parser": "0.1.1"
-      }
     },
     "supports-color": {
       "version": "2.0.0",
@@ -12470,26 +11729,6 @@
         }
       }
     },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-    },
-    "trim-lines": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.3.tgz",
-      "integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA=="
-    },
-    "trim-trailing-lines": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
-      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA=="
-    },
-    "trough": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
-    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -12567,27 +11806,6 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.13.tgz",
       "integrity": "sha1-zZ3S+GSTs/RNvu7zeA/adMXuFL4="
     },
-    "unherit": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
-      "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
-      "requires": {
-        "inherits": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "unified": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-      "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
-      "requires": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^2.0.0",
-        "trough": "^1.0.0",
-        "vfile": "^4.0.0"
-      }
-    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -12616,114 +11834,6 @@
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
-      }
-    },
-    "unist-builder": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
-      "integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
-      "requires": {
-        "object-assign": "^4.1.0"
-      }
-    },
-    "unist-util-find-after": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-2.0.4.tgz",
-      "integrity": "sha512-zo0ShIr+E/aU9xSK7JC9Kb+WP9seTFCuqVYdo5+HJSjN009XMfhiA1FIExEKzdDP1UsgvKGleGlB/pSdTSqZww==",
-      "requires": {
-        "unist-util-is": "^3.0.0"
-      }
-    },
-    "unist-util-generated": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.5.tgz",
-      "integrity": "sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw=="
-    },
-    "unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-    },
-    "unist-util-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-2.0.1.tgz",
-      "integrity": "sha512-VdNvk4BQUUU9Rgr8iUOvclHa/iN9O+6Dt66FKij8l9OVezGG37gGWCPU5KSax1R2degqXFvl3kWTkvzL79e9tQ==",
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "object-assign": "^4.0.0"
-      }
-    },
-    "unist-util-modify-children": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.6.tgz",
-      "integrity": "sha512-TOA6W9QLil+BrHqIZNR4o6IA5QwGOveMbnQxnWYq+7EFORx9vz/CHrtzF36zWrW61E2UKw7sM1KPtIgeceVwXw==",
-      "requires": {
-        "array-iterate": "^1.0.0"
-      }
-    },
-    "unist-util-position": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
-      "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA=="
-    },
-    "unist-util-remove-position": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
-      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
-      "requires": {
-        "unist-util-visit": "^1.1.0"
-      },
-      "dependencies": {
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        }
-      }
-    },
-    "unist-util-stringify-position": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "requires": {
-        "@types/unist": "^2.0.2"
-      }
-    },
-    "unist-util-visit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
-      "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0",
-        "unist-util-visit-parents": "^3.0.0"
-      },
-      "dependencies": {
-        "unist-util-is": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
-          "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
-        },
-        "unist-util-visit-parents": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
-          "integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^4.0.0"
-          }
-        }
-      }
-    },
-    "unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "requires": {
-        "unist-util-is": "^3.0.0"
       }
     },
     "unset-value": {
@@ -12951,39 +12061,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "vfile": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.3.tgz",
-      "integrity": "sha512-lREgT5sF05TQk68LO6APy0In+TkFGnFEgKChK2+PHIaTrFQ9oHCKXznZ7VILwgYVBcl0gv4lGATFZBLhi2kVQg==",
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-message": "^2.0.0"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-        }
-      }
-    },
-    "vfile-location": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
-    },
-    "vfile-message": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.3.tgz",
-      "integrity": "sha512-qQg/2z8qnnBHL0psXyF72kCjb9YioIynvyltuNKFaUhRtqTIcIMP3xnBaPzirVZNuBrUe1qwFciSx2yApa4byw==",
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
-      }
-    },
     "vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -13029,11 +12106,6 @@
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
       }
-    },
-    "web-namespaces": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
-      "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
     },
     "webidl-conversions": {
       "version": "4.0.2",
@@ -13543,7 +12615,8 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",
@@ -13708,11 +12781,6 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
-    },
-    "zwitch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
-      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
     }
   }
 }

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -873,9 +873,9 @@
       }
     },
     "@readme/oas-tooling": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.3.tgz",
-      "integrity": "sha512-oCcMmSWLF1PtU774knEHYsKUNShyhTKNtxZ6NsetpYgJIKPku3BLxWRgrqiccxIZGYLVdRmQ1SzL/DbsGi06uA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.4.tgz",
+      "integrity": "sha512-UGRbOovtJPvwpvBwix/q0zaMVeIAE/Ooi0IRhgxyz1X3e35rEFZO8/+GmPZIr25cX07e6ASKYuf5Y/n+QrmnSw==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^6.0.5",
-    "@readme/oas-tooling": "^3.1.3",
+    "@readme/oas-tooling": "^3.1.4",
     "querystring": "^0.2.0"
   },
   "scripts": {


### PR DESCRIPTION
## 🧰 What's being changed?

This updates our `@readme/oas-tooling` and `@readme/react-jsonschema-form` dependencies to resolve a couple issues with malformed `array` schemas:

* If an `array` schema did not have an `items` property, we would fail to render the operation.
* If an `array` schema had an `items` property that evaluated to `{}`, we would fail to render the operation.

What will happen now is if we encounter one of these malformed schemas where `items` is missing, we'll repair it and add `items: {}` so that the array can be utilized as a standard mixed-data input.

See https://github.com/readmeio/oas/pull/138 and https://github.com/readmeio/react-jsonschema-form/pull/11 for the respective fixes in `@readme/oas-tooling` and `@readme/react-jsonschema-form`.

## 🧪 Testing

Check the updates to `types.json` for the example cases.

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
