### PR TITLE
chore(deps): upgrading @readme/react-jsonschema-form to 1.1.4

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1377,9 +1377,9 @@
       }
     },
     "@readme/react-jsonschema-form": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@readme/react-jsonschema-form/-/react-jsonschema-form-1.1.3.tgz",
-      "integrity": "sha512-eJMRNG7H7svsfK1W9Ho93FKnnRLpJ6yScYqgvH2ISj366SkjaFLkrUKc1BYXZP8aqFUq316Y0HOiP4WuprLPwA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@readme/react-jsonschema-form/-/react-jsonschema-form-1.1.4.tgz",
+      "integrity": "sha512-emwvnDA/fRMWz5aDB7MWApeE8gqkgTG15UUD8QKnr0zijpWtFV7+zQ0LrK45ztwGHH+qvtrzYMTf7aLDO9eZrQ==",
       "requires": {
         "@babel/runtime-corejs2": "^7.4.5",
         "ajv": "^6.7.0",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -10,7 +10,7 @@
     "@readme/oas-extensions": "^6.0.5",
     "@readme/oas-to-har": "^6.0.12",
     "@readme/oas-tooling": "^3.1.2",
-    "@readme/react-jsonschema-form": "^1.1.2",
+    "@readme/react-jsonschema-form": "^1.1.4",
     "@readme/syntax-highlighter": "^6.0.10",
     "@readme/variable": "^6.0.10",
     "classnames": "^2.2.5",


### PR DESCRIPTION
## 🧰 What's being changed?

This resolves a bug in RJSF where if an integer or number schema within an `allOf` block had a `format` property, `json-schema-merge-allof` would fail (causing RJSF to fail) because `format` had no set up resolver for it on non-strings.

For example:

```json
"components": {
  "schemas": {
    "WorkItemStatusReason": {
      "enum": [
        0,
        1,
        2,
        3,
        4
      ],
      "type": "integer",
      "format": "int32"
    },
    "CaseModel": {
      "type": "object",
      "properties": {
        "StatusReason": {
          "allOf": [
            {
              "$ref": "#/components/schemas/WorkItemStatusReason"
            }
          ]
        }
      },
      "additionalProperties": false
    }
  }
}
```

## 🧪 Testing

Tests for this have been added to RJSF here: https://github.com/readmeio/react-jsonschema-form/pull/12

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
