### PR TITLE
fix: removing some environmental exclusions of styles

### DIFF
--- a/packages/markdown/components/Callout/index.jsx
+++ b/packages/markdown/components/Callout/index.jsx
@@ -1,12 +1,4 @@
-// There's a bug in jsdom where Jest spits out heaps of errors from it not being able to interpret
-// this file, so let's not include this when running tests since we aren't doing visual testing
-// anyways.
-// https://github.com/jsdom/jsdom/issues/217
-/* istanbul ignore next */
-if (process.env.NODE_ENV !== 'test') {
-  // eslint-disable-next-line global-require
-  require('./style.scss');
-}
+require('./style.scss');
 
 const React = require('react');
 const PropTypes = require('prop-types');

--- a/packages/markdown/components/CodeTabs/index.jsx
+++ b/packages/markdown/components/CodeTabs/index.jsx
@@ -1,12 +1,4 @@
-// There's a bug in jsdom where Jest spits out heaps of errors from it not being able to interpret
-// this file, so let's not include this when running tests since we aren't doing visual testing
-// anyways.
-// https://github.com/jsdom/jsdom/issues/217
-/* istanbul ignore next */
-if (process.env.NODE_ENV !== 'test') {
-  // eslint-disable-next-line global-require
-  require('./style.scss');
-}
+require('./style.scss');
 
 const React = require('react');
 const PropTypes = require('prop-types');

--- a/packages/markdown/components/Heading/index.jsx
+++ b/packages/markdown/components/Heading/index.jsx
@@ -1,12 +1,4 @@
-// There's a bug in jsdom where Jest spits out heaps of errors from it not being able to interpret
-// this file, so let's not include this when running tests since we aren't doing visual testing
-// anyways.
-// https://github.com/jsdom/jsdom/issues/217
-/* istanbul ignore next */
-if (process.env.NODE_ENV !== 'test') {
-  // eslint-disable-next-line global-require
-  require('./style.scss');
-}
+require('./style.scss');
 
 const React = require('react');
 const PropTypes = require('prop-types');

--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -1,12 +1,4 @@
-// There's a bug in jsdom where Jest spits out heaps of errors from it not being able to interpret
-// this file, so let's not include this when running tests since we aren't doing visual testing
-// anyways.
-// https://github.com/jsdom/jsdom/issues/217
-/* istanbul ignore next */
-if (process.env.NODE_ENV !== 'test') {
-  // eslint-disable-next-line global-require
-  require('./styles/main.scss');
-}
+require('./styles/main.scss');
 
 const React = require('react');
 const unified = require('unified');


### PR DESCRIPTION
## 🧰 What's being changed?

With the inclusion of `identity-obj-proxy` in our Jest setup for mocking style imports, we no longer need these hacky exclusionary blocks of code.

## 🧪 Testing

If tests pass, we good.

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
