### PR TITLE
chore(deps): upgrading @readme/oas-tooling to 3.1.5

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1368,9 +1368,9 @@
       "dev": true
     },
     "@readme/oas-tooling": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.4.tgz",
-      "integrity": "sha512-UGRbOovtJPvwpvBwix/q0zaMVeIAE/Ooi0IRhgxyz1X3e35rEFZO8/+GmPZIr25cX07e6ASKYuf5Y/n+QrmnSw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.5.tgz",
+      "integrity": "sha512-MILtuCc7y2zIW/E+ownTwFQ/96UFXvdtSDRasTaIZ1Hque/0TVeZC5jmvUqi/UywmgOjRf7aJKlprrquDZA4BQ==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -9,7 +9,7 @@
     "@readme/markdown-magic": "^6.0.10",
     "@readme/oas-extensions": "^6.0.5",
     "@readme/oas-to-har": "^6.0.12",
-    "@readme/oas-tooling": "^3.1.2",
+    "@readme/oas-tooling": "^3.1.5",
     "@readme/react-jsonschema-form": "^1.1.4",
     "@readme/syntax-highlighter": "^6.0.10",
     "@readme/variable": "^6.0.10",

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -873,9 +873,9 @@
       }
     },
     "@readme/oas-tooling": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.4.tgz",
-      "integrity": "sha512-UGRbOovtJPvwpvBwix/q0zaMVeIAE/Ooi0IRhgxyz1X3e35rEFZO8/+GmPZIr25cX07e6ASKYuf5Y/n+QrmnSw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.5.tgz",
+      "integrity": "sha512-MILtuCc7y2zIW/E+ownTwFQ/96UFXvdtSDRasTaIZ1Hque/0TVeZC5jmvUqi/UywmgOjRf7aJKlprrquDZA4BQ==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^6.0.5",
-    "@readme/oas-tooling": "^3.1.4",
+    "@readme/oas-tooling": "^3.1.5",
     "querystring": "^0.2.0"
   },
   "scripts": {


### PR DESCRIPTION
## 🧰 What's being changed?

This updates `@readme/oas-tooling` to resolve a bug in our handling of `$ref` pointers where now if one is empty, we'll no longer try to process it.

We've seen this issue crop up on https://docs.hikeup.com/reference#customers_getall because most, if not all, of their `$ref` pointers are empty.

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
