### PR TITLE
Fix error when passing an empty array for keys

### DIFF
--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -50,7 +50,11 @@ class ApiExplorer extends React.Component {
   }
 
   getGroup() {
-    if (this.props.variables.user.keys && this.props.variables.user.keys[0].id) {
+    if (
+      this.props.variables.user.keys &&
+      this.props.variables.user.keys.length &&
+      this.props.variables.user.keys[0].id
+    ) {
       return this.props.variables.user.keys[0].id;
     }
 

--- a/packages/api-explorer/src/lib/get-auth.js
+++ b/packages/api-explorer/src/lib/get-auth.js
@@ -18,7 +18,7 @@ function getKey(user, scheme) {
 }
 
 function getSingle(user, scheme = {}, selectedApp = false) {
-  if (user.keys) {
+  if (user.keys && user.keys.length) {
     if (selectedApp) {
       return getKey(
         user.keys.find(key => key.name === selectedApp),


### PR DESCRIPTION
## 🧰 What's being changed?

When passing an empty array through jwt in user.keys, it caused the entire reference section to break. This is what happens on our docs if a user logs in that doesn't have any projects in ReadMe.

Fixes README-FN

## 🧪 Testing

You can see this in action by commenting out lines 125 and 126 in Demo.jsx. Without this fix the reference section will show an error. 

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
