### PR TITLE
Fix @readme/markdown CSS imports.

### DIFF
--- a/packages/markdown/package-lock.json
+++ b/packages/markdown/package-lock.json
@@ -924,19 +924,19 @@
       }
     },
     "@readme/syntax-highlighter": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-6.0.5.tgz",
-      "integrity": "sha512-i0pCWNxgCkkF5/T8ovE2z3hLLeS+03Z7QwhoZ4OynYBbDaIRh2vHLhHdJIFfCSbfgKhON6K4vD1+XB9z7hWOwQ==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-6.0.10.tgz",
+      "integrity": "sha512-MSduhApQu6+L2jGAobBNS+YMW+/AN2PgC77YT2QNFF/s3m3M7ue/T6/BuAcxSlzTs7hw1h5lRzdPhpLdC+dKYg==",
       "requires": {
-        "@readme/variable": "^6.0.5",
+        "@readme/variable": "^6.0.10",
         "codemirror": "^5.48.2",
         "react": "^16.4.2"
       }
     },
     "@readme/variable": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-6.0.5.tgz",
-      "integrity": "sha512-f/f6BFxIJO2Oi9X+sWxixlaik/RFMdNJmKS6nexSbW4CMgr7O5rP9r84yVxds9DjDE+R/6VgTcbpt/jcDhBC1A==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-6.0.10.tgz",
+      "integrity": "sha512-lqonZDwZg/TvmQ8RbxyY+T4uciiQn8UEbjlfc36M3lLpexOQwKCjlFniXM00gqmUECArl0HpHrulz1tCTw2hiA==",
       "requires": {
         "classnames": "^2.2.6",
         "prop-types": "^15.7.2",
@@ -8169,9 +8169,9 @@
       }
     },
     "postcss-modules-scope": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.1.tgz",
-      "integrity": "sha512-OXRUPecnHCg8b9xWvldG/jUpRIGPNRka0r4D4j0ESUU2/5IOnpsjfPPmDprM3Ih8CgZ8FXjWqaniK5v4rWt3oQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
+      "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.6",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -41,7 +41,7 @@
   "repository": "https://github.com/readmeio/api-explorer/tree/master/packages/markdown",
   "devDependencies": {
     "@readme/eslint-config": "^2.0.0",
-    "css-loader": "^3.2.0",
+    "css-loader": "^3.4.2",
     "eslint": "^6.5.0",
     "isomorphic-style-loader": "^5.1.0",
     "jest": "^25.1.0",

--- a/packages/markdown/webpack.config.js
+++ b/packages/markdown/webpack.config.js
@@ -21,11 +21,11 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loader: ['isomorphic-style-loader', 'css-loader'],
+        loader: ['style-loader', 'css-loader'],
       },
       {
         test: /\.scss$/,
-        loaders: ['isomorphic-style-loader', 'css-loader', 'sass-loader'],
+        loaders: ['style-loader', 'css-loader', 'sass-loader'],
       },
       {
         // eslint-disable-next-line unicorn/no-unsafe-regex

--- a/packages/syntax-highlighter/codemirror.jsx
+++ b/packages/syntax-highlighter/codemirror.jsx
@@ -1,5 +1,4 @@
-const CodeMirror =
-  typeof window === 'undefined' ? require('codemirror/addon/runmode/runmode.node.js') : require('codemirror');
+const CodeMirror = require('codemirror');
 const React = require('react');
 const Variable = require('@readme/variable');
 const modes = require('./modes');


### PR DESCRIPTION
## 🧰 What's being changed?

Swapping out the `isomorphic-style-loader` in favor of the default. This addresses some issues with broken CSS compilation and imports that were introduced in #537.

## 🧪 Testing

All guides, endpoint docs, and other content rendered via the `rdmd` directive should be appropriately styled. (Once this is merged and released I'll set up a PR in ReadMe proper where we can test out this fix.)

## 🗳 Checklist

* [x] **🐛 I'm fixing a bug!**
* [ ] **🆕 I'm adding something new!**
* [ ] **📸 I've made some changes to the UI!**
