### PR TITLE
fix: if we have a value property in an example, return that

### DIFF
--- a/example/swagger-files/examples.json
+++ b/example/swagger-files/examples.json
@@ -31,6 +31,23 @@
               }
             }
           },
+          "201": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "user": {
+                    "value": {
+                      "user": {
+                        "email": "test@example.com",
+                        "name": "Test user name"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "202": {
             "description": "OK",
             "content": {

--- a/packages/api-explorer/__tests__/lib/create-code-shower.test.js
+++ b/packages/api-explorer/__tests__/lib/create-code-shower.test.js
@@ -61,11 +61,8 @@ describe('createCodeShower', () => {
         languages: [
           {
             code: encodeJsonExample({
-              summary: 'An example of a cat',
-              value: {
-                name: 'Fluffy',
-                petType: 'Cat',
-              },
+              name: 'Fluffy',
+              petType: 'Cat',
             }),
             language: 'application/json',
             multipleExamples: false,

--- a/packages/api-explorer/src/lib/create-code-shower.js
+++ b/packages/api-explorer/src/lib/create-code-shower.js
@@ -17,6 +17,7 @@ function getExample(response, lang) {
     return false;
   }
 
+  // This isn't actually something that's defined in the spec. Do we really need to support this?
   if (response.content[lang].examples.response) {
     return response.content[lang].examples.response.value;
   }
@@ -28,9 +29,13 @@ function getExample(response, lang) {
     return false;
   }
 
-  const example = examples[0];
+  let example = examples[0];
+  example = response.content[lang].examples[example];
+  if ('value' in example) {
+    return example.value;
+  }
 
-  return response.content[lang].examples[example];
+  return example;
 }
 
 function getMultipleExamples(response, lang) {


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a bug in our spec coverage of response examples where if an example within an `examples` array had a `value` property, we were returning that whole object (value included) instead of the *contents* of the `value` property.

![Screen Shot 2020-04-08 at 4 35 11 PM](https://user-images.githubusercontent.com/33762/78843229-15cdb400-79b7-11ea-8ac3-0aed49d4fe0e.png)

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
