### PR TITLE
chore(deps): upgrading @readme/react-jsonschema-form" to 1.1.5

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1359,16 +1359,6 @@
       "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-6.0.5.tgz",
       "integrity": "sha512-x3gLEKhzUnrJjCM6hls2V/QT7u1knrIYhtnXZJ9Ln9NBYU3TKHdW7Cd8vZcoVH0e/w3O/BoCgyHOyb559oVaHQ=="
     },
-    "@readme/oas-to-har": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-6.2.0.tgz",
-      "integrity": "sha512-hC2QVIWUK2cJAB888WTt5+asOz+XlzJc5T1As/rqRB0foFYNe3bPt9lX5yiIWIuUqwF4OGWCit8H3aaEo/hTFg==",
-      "requires": {
-        "@readme/oas-extensions": "^6.0.5",
-        "@readme/oas-tooling": "^3.1.5",
-        "querystring": "^0.2.0"
-      }
-    },
     "@readme/oas-tooling": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.1.7.tgz",
@@ -1379,9 +1369,9 @@
       }
     },
     "@readme/react-jsonschema-form": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@readme/react-jsonschema-form/-/react-jsonschema-form-1.1.4.tgz",
-      "integrity": "sha512-emwvnDA/fRMWz5aDB7MWApeE8gqkgTG15UUD8QKnr0zijpWtFV7+zQ0LrK45ztwGHH+qvtrzYMTf7aLDO9eZrQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@readme/react-jsonschema-form/-/react-jsonschema-form-1.1.5.tgz",
+      "integrity": "sha512-kfcdpB5LLtc+e0HfWcbVB/gR9426NusQpWV0DJrNhSpTdNZkxO5blkbSyNsBZ3whS+t9Kjl8hyRUU5if7mMjbQ==",
       "requires": {
         "@babel/runtime-corejs2": "^7.4.5",
         "ajv": "^6.7.0",
@@ -9989,7 +9979,8 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -10048,9 +10039,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.6.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
         },
         "promise": {
           "version": "8.1.0",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -10,7 +10,7 @@
     "@readme/oas-extensions": "^6.0.5",
     "@readme/oas-to-har": "^6.3.1",
     "@readme/oas-tooling": "^3.1.7",
-    "@readme/react-jsonschema-form": "^1.1.4",
+    "@readme/react-jsonschema-form": "^1.1.5",
     "@readme/syntax-highlighter": "^6.2.0",
     "@readme/variable": "^6.2.0",
     "classnames": "^2.2.5",


### PR DESCRIPTION
## 🧰 What's being changed?

This upgrades  `@readme/react-jsonschema-form` to fix a bug with our handling of JSON Schema where if a schema with `allOf` had an adjacent `example` property, `json-schema-merge-allof` would throw a fatal error because `example` is an unknown JSON Schema property.

![Screen Shot 2020-04-09 at 9 54 13 AM](https://user-images.githubusercontent.com/33762/78920414-34c85680-7a48-11ea-8d1e-6cc871a38d84.png)

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
