### PR TITLE
fix: bug where responses with multiple examples weren't rendered properly

### DIFF
--- a/packages/api-explorer/__tests__/lib/create-code-shower.test.js
+++ b/packages/api-explorer/__tests__/lib/create-code-shower.test.js
@@ -103,21 +103,15 @@ describe('createCodeShower', () => {
               {
                 label: 'cat',
                 code: encodeJsonExample({
-                  summary: 'An example of a cat',
-                  value: {
-                    name: 'Fluffy',
-                    petType: 'Cat',
-                  },
+                  name: 'Fluffy',
+                  petType: 'Cat',
                 }),
               },
               {
                 label: 'dog',
                 code: encodeJsonExample({
-                  summary: "An example of a dog with a cat's name",
-                  value: {
-                    name: 'Puma',
-                    petType: 'Dog',
-                  },
+                  name: 'Puma',
+                  petType: 'Dog',
                 }),
               },
             ],

--- a/packages/api-explorer/src/lib/create-code-shower.js
+++ b/packages/api-explorer/src/lib/create-code-shower.js
@@ -43,9 +43,18 @@ function getMultipleExamples(response, lang) {
 
   const { examples } = response.content[lang];
   return Object.keys(examples).map(key => {
+    let example = examples[key];
+    if (typeof example === 'object') {
+      if ('value' in example) {
+        example = example.value;
+      }
+
+      example = JSON.stringify(example, undefined, 2);
+    }
+
     return {
       label: key,
-      code: typeof examples[key] === 'object' ? JSON.stringify(examples[key], undefined, 2) : examples[key],
+      code: example,
     };
   });
 }


### PR DESCRIPTION
## 🧰 What's being changed?

Fixes a bug where an operation with multiple responses would have that example `value` object showed in full, instead of the contents of the `value` object.

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
