### PR TITLE
fix: if an OAS has an empty examples object, don't parse it

### DIFF
--- a/packages/api-explorer/__tests__/__fixtures__/example-results/oas.json
+++ b/packages/api-explorer/__tests__/__fixtures__/example-results/oas.json
@@ -180,6 +180,21 @@
         "summary": "Update Password"
       }
     },
+    "/emptyexample": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "examples": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/nolang": {
       "get": {
         "description": ""

--- a/packages/api-explorer/__tests__/lib/create-code-shower.test.js
+++ b/packages/api-explorer/__tests__/lib/create-code-shower.test.js
@@ -137,7 +137,7 @@ describe('createCodeShower', () => {
     expect(createCodeShower(operation, oas)).toStrictEqual([]);
   });
 
-  it('should erturn early if there is an empty example', () => {
+  it('should return early if there is an empty example', () => {
     const operation = oas.operation('/emptyexample', 'get');
     expect(createCodeShower(operation, oas)).toStrictEqual([]);
   });

--- a/packages/api-explorer/__tests__/lib/create-code-shower.test.js
+++ b/packages/api-explorer/__tests__/lib/create-code-shower.test.js
@@ -137,6 +137,11 @@ describe('createCodeShower', () => {
     expect(createCodeShower(operation, oas)).toStrictEqual([]);
   });
 
+  it('should erturn early if there is an empty example', () => {
+    const operation = oas.operation('/emptyexample', 'get');
+    expect(createCodeShower(operation, oas)).toStrictEqual([]);
+  });
+
   it('should return early if there is no response', () => {
     const operation = oas.operation('/nolang', 'get');
     expect(createCodeShower(operation, oas)).toStrictEqual([]);

--- a/packages/api-explorer/src/lib/create-code-shower.js
+++ b/packages/api-explorer/src/lib/create-code-shower.js
@@ -31,8 +31,10 @@ function getExample(response, lang) {
 
   let example = examples[0];
   example = response.content[lang].examples[example];
-  if ('value' in example) {
-    return example.value;
+  if (example !== null && typeof example === 'object') {
+    if ('value' in example) {
+      return example.value;
+    }
   }
 
   return example;
@@ -42,9 +44,9 @@ function getMultipleExamples(response, lang) {
   if (!response.content[lang].examples || response.content[lang].examples.response) return false;
 
   const { examples } = response.content[lang];
-  return Object.keys(examples).map(key => {
+  const multipleExamples = Object.keys(examples).map(key => {
     let example = examples[key];
-    if (typeof example === 'object') {
+    if (example !== null && typeof example === 'object') {
       if ('value' in example) {
         example = example.value;
       }
@@ -57,15 +59,19 @@ function getMultipleExamples(response, lang) {
       code: example,
     };
   });
+
+  return multipleExamples.length > 0 ? multipleExamples : false;
 }
 
 function constructLanguage(language, response, example) {
   const multipleExamples = getMultipleExamples(response, language);
-  if (!example && !multipleExamples) return false;
+  if (!example && !multipleExamples) {
+    return false;
+  }
 
   return {
     language,
-    code: typeof example === 'object' ? JSON.stringify(example, undefined, 2) : example,
+    code: example !== null && typeof example === 'object' ? JSON.stringify(example, undefined, 2) : example,
     multipleExamples: !example ? multipleExamples : false,
   };
 }


### PR DESCRIPTION
## 🧰 What's being changed?

This resolves a bug that cropped up in Sentry where if an operation response has an empty `examples` object (`examples: {}`), we'd try to parse it and ultimately fail when attempting to extract a `value` out of a non-object.

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
