### PR TITLE
fix: cases where markdown headers dont have content

### DIFF
--- a/packages/markdown-magic/components/Heading.jsx
+++ b/packages/markdown-magic/components/Heading.jsx
@@ -9,6 +9,13 @@ function generateHeadingId(e) {
 }
 
 function Heading(props) {
+  // Sometimes there might be a case where someone types a header as `#` but doesnt attach any
+  // content to it. We shouldn't try to render it because we'll fail as  `props.children` will be
+  // empty!
+  if (typeof props.children === 'undefined') {
+    return null;
+  }
+
   const id = `section-${generateHeadingId(props.children[0])}`;
   return React.createElement(props.level, { className: 'header-scroll' }, [
     <div key={`anchor-${id}`} className="anchor waypoint" id={id} />,


### PR DESCRIPTION
## 🧰 What's being changed?

Fixes a case where docs are written as this:

![Screen Shot 2020-04-16 at 5 07 20 PM](https://user-images.githubusercontent.com/33762/79518272-8010d500-8005-11ea-8200-28fc8c59f793.png)

## 🧪 Testing

https://developer.goacoustic.com/acoustic-content/reference#authoring-resources

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
