### PR TITLE
RDMD magic block null cases.

### DIFF
--- a/packages/markdown/__tests__/magic-block-parser.test.js
+++ b/packages/markdown/__tests__/magic-block-parser.test.js
@@ -30,6 +30,46 @@ test('Blank Magic Blocks', () => {
   { "title": "No Level" }
   [/block]`;
   expect(process(noLevel)).toMatchSnapshot();
+
+  const emptyTable = `[block:parameters]
+  {
+    "data": {},
+    "cols": 3,
+    "rows": 1
+  }
+  [/block]`;
+  expect(process(emptyTable).children).toHaveLength(0);
+
+  const emptyCallout = `[block:callout]
+  {
+    "type": "info",
+    "title": ""
+  }
+  [/block]`;
+  expect(process(emptyCallout).children).toHaveLength(0);
+
+  const emptyCodeTabs = `[block:code]
+  {
+    "codes": [
+      {
+        "code": "",
+        "language": "text"
+      }
+    ]
+  }
+  [/block]`;
+  expect(process(emptyCodeTabs).children).toHaveLength(0);
+
+  const emptyImage = `[block:image]
+  {
+    "images": [
+      {
+        "image": []
+      }
+    ]
+  }
+  [/block]`;
+  expect(process(emptyImage).children).toHaveLength(0);
 });
 
 test('Sanitize Schema', () => {

--- a/packages/markdown/processor/parse/flavored/callout.js
+++ b/packages/markdown/processor/parse/flavored/callout.js
@@ -5,7 +5,7 @@ function tokenizer(eat, value) {
   if (!rgx.test(value)) return true;
 
   // eslint-disable-next-line prefer-const
-  let [match, icon, title, text] = rgx.exec(value);
+  let [match, icon, title = '', text] = rgx.exec(value);
 
   icon = icon.trim();
   text = text.replace(/>(?:(\n)|(\s)?)/g, '$1').trim();

--- a/packages/markdown/processor/parse/magic-block-parser.js
+++ b/packages/markdown/processor/parse/magic-block-parser.js
@@ -126,6 +126,7 @@ function tokenize(eat, value) {
       };
       json.type = json.type in types ? types[json.type] : [json.icon || '👍', json.type];
       const [icon, theme] = json.type;
+      if (!(json.title || json.body)) return eat(match);
       return eat(match)(
         WrapPinnedBlocks(
           {

--- a/packages/markdown/processor/parse/magic-block-parser.js
+++ b/packages/markdown/processor/parse/magic-block-parser.js
@@ -51,7 +51,10 @@ function tokenize(eat, value) {
           },
         },
       }));
-      if (children.length === 1 && children[0].name) return eat(match)(WrapPinnedBlocks(children[0], json));
+      if (children.length === 1) {
+        if (!children[0].value) return eat(match); // skip empty code tabs
+        if (children[0].name) return eat(match)(WrapPinnedBlocks(children[0], json));
+      }
       return eat(match)(
         WrapPinnedBlocks(
           {

--- a/packages/markdown/processor/parse/magic-block-parser.js
+++ b/packages/markdown/processor/parse/magic-block-parser.js
@@ -154,6 +154,9 @@ function tokenize(eat, value) {
     }
     case 'parameters': {
       const { data } = json;
+
+      if (!Object.keys(data).length) return eat(match); // skip empty tables
+
       const children = Object.keys(data)
         .sort()
         .reduce((sum, key) => {


### PR DESCRIPTION
## 🧰 What's being changed?

I definitely thought I'd fixed all of these null cases, but I must have missed a few:

- [x] Skip empty magic table blocks (closes #628)
- [x] Skip empty magic code tab blocks
- [x] Skip empty magic callout blocks
- [x] Don't trim empty callout titles

## 🗳 Checklist

* 🐛 I'm fixing a bug
