### PR TITLE
feat: adding support for a handful of language highlight aliases

### DIFF
--- a/packages/syntax-highlighter/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/syntax-highlighter/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`supported languages asp 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-operator\\">&lt;%</span><span class=\\"cm-variable\\">@</span> <span class=\\"cm-variable\\">Language</span><span class=\\"cm-operator\\">=</span> <span class=\\"cm-string\\">&quot;VBScript&quot;</span> <span class=\\"cm-operator\\">%&gt;</span>
+<span class=\\"cm-operator\\">&lt;%</span>
+  <span class=\\"cm-variable\\">Response</span>.<span class=\\"cm-variable\\">Write</span>(<span class=\\"cm-string\\">&quot;Hello World&quot;</span>)
+<span class=\\"cm-operator\\">%&gt;</span></span>"
+`;
+
+exports[`supported languages c 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-variable\\">#include</span> <span class=\\"cm-operator\\">&lt;</span><span class=\\"cm-variable\\">stdio</span>.<span class=\\"cm-variable\\">h</span><span class=\\"cm-operator\\">&gt;</span>
+
+<span class=\\"cm-variable\\">int</span> <span class=\\"cm-variable\\">main</span>() {
+  <span class=\\"cm-variable\\">printf</span>(<span class=\\"cm-string\\">&quot;Hello World</span>
+<span class=\\"cm-string\\">&quot;);</span>
+  <span class=\\"cm-variable\\">return</span> <span class=\\"cm-number\\">0</span>;
+}</span>"
+`;
+
+exports[`supported languages c# 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-keyword\\">class</span> <span class=\\"cm-def\\">HelloWorld</span> {
+  <span class=\\"cm-keyword\\">static</span> <span class=\\"cm-keyword\\">void</span> <span class=\\"cm-variable\\">Main</span>() {
+    <span class=\\"cm-variable\\">System</span>.<span class=\\"cm-variable\\">Console</span>.<span class=\\"cm-variable\\">WriteLine</span>(<span class=\\"cm-string\\">&quot;Hello World&quot;</span>);
+  }
+}</span>"
+`;
+
+exports[`supported languages c++ 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-meta\\">#include &lt;iostream&gt;</span>
+
+<span class=\\"cm-keyword\\">using</span> <span class=\\"cm-keyword\\">namespace</span> <span class=\\"cm-def\\">std</span>;
+
+<span class=\\"cm-type\\">int</span> <span class=\\"cm-def\\">main</span>()
+{
+  <span class=\\"cm-variable\\">cout</span> <span class=\\"cm-operator\\">&lt;&lt;</span> <span class=\\"cm-string\\">&quot;Hello World</span>
+<span class=\\"cm-string\\">&quot;;</span>
+}</span>"
+`;
+
+exports[`supported languages cURL 1`] = `"<span class=\\"cm-s-neo\\"><span class=\\"cm-builtin\\">curl</span> <span class=\\"cm-attribute\\">--request</span> GET   <span class=\\"cm-attribute\\">--url</span> <span class=\\"cm-string\\">&#x27;https://dash.readme.io/api/v1/api-specification?perPage=10&amp;page=1&#x27;</span>   <span class=\\"cm-attribute\\">--header</span> <span class=\\"cm-string\\">&#x27;x-readme-version: v3.0&#x27;</span></span>"`;
+
+exports[`supported languages css flavors 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-tag\\">body</span>::<span class=\\"cm-variable-3\\">before</span> {
+  <span class=\\"cm-property\\">content</span>: <span class=\\"cm-string\\">&quot;Hello World&quot;</span>;
+}</span>"
+`;
+
+exports[`supported languages dart 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-variable\\">main</span>() {
+  <span class=\\"cm-variable\\">print</span>(<span class=\\"cm-string\\">&#x27;Hello World&#x27;</span>);
+}</span>"
+`;
+
+exports[`supported languages dockerfile 1`] = `"<span class=\\"cm-s-neo\\"><span class=\\"cm-keyword\\">FROM</span> alping:3.4</span>"`;
+
+exports[`supported languages go 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-keyword\\">package</span> <span class=\\"cm-variable\\">main</span>
+
+<span class=\\"cm-keyword\\">import</span> <span class=\\"cm-string\\">&quot;fmt&quot;</span>
+
+<span class=\\"cm-keyword\\">func</span> <span class=\\"cm-variable\\">main</span>() {
+  <span class=\\"cm-variable\\">fmt</span><span class=\\"cm-number\\">.</span><span class=\\"cm-variable\\">Println</span>(<span class=\\"cm-string\\">&quot;Hello World&quot;</span>)
+}</span>"
+`;
+
+exports[`supported languages html 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-meta\\">&lt;!DOCTYPE html&gt;</span>
+  <span class=\\"cm-tag cm-bracket\\">&lt;</span><span class=\\"cm-tag\\">html</span> <span class=\\"cm-attribute\\">lang</span>=<span class=\\"cm-string\\">&quot;en&quot;</span><span class=\\"cm-tag cm-bracket\\">&gt;</span>
+  <span class=\\"cm-tag cm-bracket\\">&lt;</span><span class=\\"cm-tag\\">head</span><span class=\\"cm-tag cm-bracket\\">&gt;</span>
+    <span class=\\"cm-tag cm-bracket\\">&lt;</span><span class=\\"cm-tag\\">meta</span> <span class=\\"cm-attribute\\">charset</span>=<span class=\\"cm-string\\">&quot;UTF-8&quot;</span><span class=\\"cm-tag cm-bracket\\">&gt;</span>
+    <span class=\\"cm-tag cm-bracket\\">&lt;</span><span class=\\"cm-tag\\">meta</span> <span class=\\"cm-attribute\\">name</span>=<span class=\\"cm-string\\">&quot;viewport&quot;</span> <span class=\\"cm-attribute\\">content</span>=<span class=\\"cm-string\\">&quot;width=device-width, initial-scale=1.0&quot;</span><span class=\\"cm-tag cm-bracket\\">&gt;</span>
+    <span class=\\"cm-tag cm-bracket\\">&lt;</span><span class=\\"cm-tag\\">title</span><span class=\\"cm-tag cm-bracket\\">&gt;</span>Hello World!<span class=\\"cm-tag cm-bracket\\">&lt;/</span><span class=\\"cm-tag\\">title</span><span class=\\"cm-tag cm-bracket\\">&gt;</span>
+  <span class=\\"cm-tag cm-bracket\\">&lt;/</span><span class=\\"cm-tag\\">head</span><span class=\\"cm-tag cm-bracket\\">&gt;</span>
+  <span class=\\"cm-tag cm-bracket\\">&lt;</span><span class=\\"cm-tag\\">body</span><span class=\\"cm-tag cm-bracket\\">&gt;</span>
+    <span class=\\"cm-tag cm-bracket\\">&lt;</span><span class=\\"cm-tag\\">h1</span><span class=\\"cm-tag cm-bracket\\">&gt;</span>Hello World!<span class=\\"cm-tag cm-bracket\\">&lt;/</span><span class=\\"cm-tag\\">h1</span><span class=\\"cm-tag cm-bracket\\">&gt;</span>
+  <span class=\\"cm-tag cm-bracket\\">&lt;/</span><span class=\\"cm-tag\\">body</span><span class=\\"cm-tag cm-bracket\\">&gt;</span>
+  <span class=\\"cm-tag cm-bracket\\">&lt;/</span><span class=\\"cm-tag\\">html</span><span class=\\"cm-tag cm-bracket\\">&gt;</span></span>"
+`;
+
+exports[`supported languages html 2`] = `
+"<span class=\\"cm-s-neo\\">&lt;!DOCTYPE html&gt;
+  &lt;html lang=&quot;en&quot;&gt;
+  &lt;head&gt;
+    &lt;meta charset=&quot;UTF-8&quot;&gt;
+    &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1.0&quot;&gt;
+    &lt;title&gt;Hello World!&lt;/title&gt;
+  &lt;/head&gt;
+  &lt;body&gt;
+    &lt;h1&gt;Hello World!&lt;/h1&gt;
+  &lt;/body&gt;
+  &lt;/html&gt;</span>"
+`;
+
+exports[`supported languages java 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-keyword\\">public</span> <span class=\\"cm-keyword\\">class</span> <span class=\\"cm-def\\">Java</span> {
+  <span class=\\"cm-keyword\\">public</span> <span class=\\"cm-keyword\\">static</span> <span class=\\"cm-type\\">void</span> <span class=\\"cm-variable\\">main</span>(<span class=\\"cm-type\\">String</span>[] <span class=\\"cm-variable\\">args</span>) {
+    <span class=\\"cm-variable\\">System</span>.<span class=\\"cm-variable\\">out</span>.<span class=\\"cm-variable\\">println</span>(<span class=\\"cm-string\\">&quot;Hello World&quot;</span>);
+  }
+}</span>"
+`;
+
+exports[`supported languages javascript should highlight 1`] = `"<span class=\\"cm-s-neo\\"><span class=\\"cm-variable\\">console</span>.<span class=\\"cm-property\\">log</span>(<span class=\\"cm-string\\">&quot;Hello World&quot;</span>);</span>"`;
+
+exports[`supported languages json 1`] = `"<span class=\\"cm-s-neo\\">{ <span class=\\"cm-property\\">&quot;hello&quot;</span>: <span class=\\"cm-string\\">&quot;world&quot;</span> }</span>"`;
+
+exports[`supported languages kotlin 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-keyword\\">package</span> <span class=\\"cm-variable\\">hello</span>
+
+<span class=\\"cm-keyword\\">fun</span> <span class=\\"cm-def\\">main</span>() {
+  <span class=\\"cm-variable\\">println</span>(<span class=\\"cm-string\\">&quot;Hello World&quot;</span>)
+}</span>"
+`;
+
+exports[`supported languages liquid 1`] = `
+"<span class=\\"cm-s-neo\\">{% if user %}
+  Hello {{ user.name }}!
+{% endif %}</span>"
+`;
+
+exports[`supported languages markdown 1`] = `"<span class=\\"cm-s-neo\\"># Hello World</span>"`;
+
+exports[`supported languages objective-c 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-comment\\">/*</span>
+ <span class=\\"cm-comment\\">Build on OS X:</span>
+ <span class=\\"cm-comment\\">clang -framework Foundation -fobjc-arc objc.m -o objc</span>
+
+ <span class=\\"cm-comment\\">Build on Linux with GNUstep:</span>
+ <span class=\\"cm-comment\\">clang \`gnustep-config --objc-flags\` \`gnustep-config --base-libs\` -fobjc-nonfragile-abi -fobjc-arc objc.m -o objc</span>
+ <span class=\\"cm-comment\\">*/</span>
+
+<span class=\\"cm-meta\\">#import &lt;Foundation/Foundation.h&gt;</span>
+
+<span class=\\"cm-type\\">int</span> <span class=\\"cm-def\\">main</span>(<span class=\\"cm-type\\">void</span>)
+{
+    <span class=\\"cm-variable\\">NSLog</span>(<span class=\\"cm-variable\\">@</span><span class=\\"cm-string\\">&quot;Hello World&quot;</span>);
+}</span>"
+`;
+
+exports[`supported languages php should highlight 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-operator\\">&lt;?</span><span class=\\"cm-variable\\">php</span>
+
+<span class=\\"cm-keyword\\">echo</span> <span class=\\"cm-string\\">&#x27;Hello World&#x27;</span>;</span>"
+`;
+
+exports[`supported languages powershell 1`] = `"<span class=\\"cm-s-neo\\"><span class=\\"cm-string\\">&#x27;Hello World&#x27;</span></span>"`;
+
+exports[`supported languages python 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-comment\\">#!/usr/bin/env python</span>
+<span class=\\"cm-builtin\\">print</span> <span class=\\"cm-string\\">&quot;Hello World&quot;</span></span>"
+`;
+
+exports[`supported languages ruby 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-comment\\">#!/usr/bin/env ruby</span>
+<span class=\\"cm-variable\\">puts</span> <span class=\\"cm-string\\">&quot;Hello World&quot;</span></span>"
+`;
+
+exports[`supported languages scala 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-keyword\\">object</span> <span class=\\"cm-def\\">HelloWorld</span> <span class=\\"cm-keyword\\">extends</span> <span class=\\"cm-type\\">App</span> {
+  <span class=\\"cm-keyword\\">println</span>(<span class=\\"cm-string\\">&quot;Hello World&quot;</span>)
+}</span>"
+`;
+
+exports[`supported languages shell 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-meta\\">#!/bin/sh</span>
+<span class=\\"cm-builtin\\">echo</span> <span class=\\"cm-string\\">&quot;Hello World&quot;</span></span>"
+`;
+
+exports[`supported languages sql 1`] = `"<span class=\\"cm-s-neo\\"><span class=\\"cm-keyword\\">SELECT</span> <span class=\\"cm-string\\">&#x27;Hello World&#x27;</span><span class=\\"cm-punctuation\\">;</span></span>"`;
+
+exports[`supported languages swift 1`] = `"<span class=\\"cm-s-neo\\"><span class=\\"cm-variable\\">print</span><span class=\\"cm-punctuation\\">(</span><span class=\\"cm-string\\">&quot;Hello World&quot;</span><span class=\\"cm-punctuation\\">)</span></span>"`;
+
+exports[`supported languages xml 1`] = `
+"<span class=\\"cm-s-neo\\"><span class=\\"cm-meta\\">&lt;?xml</span> <span class=\\"cm-meta\\">version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;</span>
+<span class=\\"cm-tag cm-bracket\\">&lt;</span><span class=\\"cm-tag\\">text</span><span class=\\"cm-tag cm-bracket\\">&gt;</span><span class=\\"cm-atom\\">&lt;![CDATA[Hello World]]&gt;</span><span class=\\"cm-tag cm-bracket\\">&lt;/</span><span class=\\"cm-tag\\">text</span><span class=\\"cm-tag cm-bracket\\">&gt;</span></span>"
+`;

--- a/packages/syntax-highlighter/__tests__/index.test.js
+++ b/packages/syntax-highlighter/__tests__/index.test.js
@@ -54,48 +54,294 @@ test('should keep enclosing characters around the variable', () => {
   expect(mount(syntaxHighlighter("'<<apiKey>>'", 'json', { tokenizeVariables: true })).text()).toBe("'APIKEY'");
 });
 
-describe('specific languages', () => {
-  it('should work for modes with an array like java', () => {
-    expect(shallow(syntaxHighlighter('service = client.service().messaging();', 'java')).html()).toBe(
-      '<span class="cm-s-neo"><span class="cm-variable">service</span> <span class="cm-operator">=</span> <span class="cm-variable">client</span>.<span class="cm-variable">service</span>().<span class="cm-variable">messaging</span>();</span>'
-    );
+// https://github.com/leachim6/hello-world/
+describe('supported languages', () => {
+  it('asp', () => {
+    const code = `<%@ Language= "VBScript" %>
+<%
+  Response.Write("Hello World")
+%>`;
+
+    expect(shallow(syntaxHighlighter(code, 'asp')).html()).toMatchSnapshot();
   });
 
-  it('should work for html', () => {
-    expect(shallow(syntaxHighlighter('<p>test</p>', 'html')).html()).toBe(
-      '<span class="cm-s-neo"><span class="cm-tag cm-bracket">&lt;</span><span class="cm-tag">p</span><span class="cm-tag cm-bracket">&gt;</span>test<span class="cm-tag cm-bracket">&lt;/</span><span class="cm-tag">p</span><span class="cm-tag cm-bracket">&gt;</span></span>'
-    );
+  it('c', () => {
+    const code = `#include <stdio.h>
+
+int main() {
+  printf("Hello World\n");
+  return 0;
+}`;
+
+    expect(shallow(syntaxHighlighter(code, 'c')).html()).toMatchSnapshot();
   });
 
-  it('should work for php without opening tag', () => {
-    expect(shallow(syntaxHighlighter('echo "Hello World";', 'php')).html()).toContain('cm-keyword');
+  it('c++', () => {
+    const code = `#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  cout << "Hello World\n";
+}`;
+
+    const cplusplus = shallow(syntaxHighlighter(code, 'cplusplus')).html();
+
+    expect(cplusplus).toMatchSnapshot();
+    expect(shallow(syntaxHighlighter(code, 'cpp')).html()).toStrictEqual(cplusplus);
+    expect(shallow(syntaxHighlighter(code, 'c++')).html()).toStrictEqual(cplusplus);
   });
 
-  it('should work for dockerfiles', () => {
-    expect(shallow(syntaxHighlighter('FROM alpine:3.4', 'dockerfile')).html()).toContain('cm-keyword');
+  it('c#', () => {
+    const code = `class HelloWorld {
+  static void Main() {
+    System.Console.WriteLine("Hello World");
+  }
+}`;
+
+    const csharp = shallow(syntaxHighlighter(code, 'csharp')).html();
+
+    expect(csharp).toMatchSnapshot();
+    expect(shallow(syntaxHighlighter(code, 'cs')).html()).toStrictEqual(csharp);
   });
 
-  it('should work for kotlin', () => {
-    expect(shallow(syntaxHighlighter('println("$index: $element")', 'kotlin')).html()).toContain('cm-variable');
+  it('css flavors', () => {
+    const code = `body::before {
+  content: "Hello World";
+}`;
+
+    const css = shallow(syntaxHighlighter(code, 'css')).html();
+
+    expect(css).toMatchSnapshot();
+    expect(shallow(syntaxHighlighter(code, 'scss')).html()).toStrictEqual(css);
+    expect(shallow(syntaxHighlighter(code, 'stylus')).html()).toStrictEqual(css);
   });
 
-  it('should work for go', () => {
-    expect(shallow(syntaxHighlighter('func main() {}', 'go')).html()).toContain('cm-variable');
+  it('cURL', () => {
+    const code = `curl --request GET \
+  --url 'https://dash.readme.io/api/v1/api-specification?perPage=10&page=1' \
+  --header 'x-readme-version: v3.0'`;
+
+    expect(shallow(syntaxHighlighter(code, 'curl')).html()).toMatchSnapshot();
   });
 
-  it('should work for powershell', () => {
-    expect(shallow(syntaxHighlighter('$headers.Add("accept", "application/json")', 'powershell')).html()).toContain(
-      'cm-variable'
-    );
+  it('dart', () => {
+    const code = `main() {
+  print('Hello World');
+}`;
+
+    expect(shallow(syntaxHighlighter(code, 'dart')).html()).toMatchSnapshot();
   });
 
-  it('should work for typescript', () => {
-    expect(shallow(syntaxHighlighter('let { a, b }: { a: string, b: number } = o;', 'typescript')).html()).toContain(
-      'cm-variable'
-    );
+  it('dockerfile', () => {
+    const code = `FROM alping:3.4`;
+    expect(shallow(syntaxHighlighter(code, 'dockerfile')).html()).toMatchSnapshot();
   });
 
-  it('should work for swift', () => {
-    expect(shallow(syntaxHighlighter('var x = 0;', 'swift')).html()).toContain('cm-def');
+  it('go', () => {
+    const code = `package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Hello World")
+}`;
+
+    expect(shallow(syntaxHighlighter(code, 'go')).html()).toMatchSnapshot();
+  });
+
+  it('html', () => {
+    const code = `<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello World!</title>
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+  </body>
+  </html>`;
+
+    const html = shallow(syntaxHighlighter(code, 'html')).html();
+
+    expect(html).toMatchSnapshot();
+    expect(shallow(syntaxHighlighter(code, 'xhtml')).html()).toMatchSnapshot(); // @fix this
+  });
+
+  it('java', () => {
+    const code = `public class Java {
+  public static void main(String[] args) {
+    System.out.println("Hello World");
+  }
+}`;
+
+    expect(shallow(syntaxHighlighter(code, 'java')).html()).toMatchSnapshot();
+  });
+
+  describe('javascript', () => {
+    it('should highlight', () => {
+      const code = `console.log("Hello World");`;
+      const javascript = shallow(syntaxHighlighter(code, 'javascript')).html();
+
+      expect(javascript).toMatchSnapshot();
+      expect(shallow(syntaxHighlighter(code, 'ecmascript')).html()).toStrictEqual(javascript);
+      expect(shallow(syntaxHighlighter(code, 'js')).html()).toStrictEqual(javascript);
+      expect(shallow(syntaxHighlighter(code, 'node')).html()).toStrictEqual(javascript);
+      expect(shallow(syntaxHighlighter(code, 'typescript')).html()).toStrictEqual(javascript);
+    });
+
+    it('should highlight typescript', () => {
+      const code = `let { a, b }: { a: string, b: number } = o;`;
+
+      expect(shallow(syntaxHighlighter(code, 'typescript')).html()).toContain('cm-variable');
+    });
+  });
+
+  it('json', () => {
+    const code = `{ "hello": "world" }`;
+    expect(shallow(syntaxHighlighter(code, 'json')).html()).toMatchSnapshot();
+  });
+
+  it('kotlin', () => {
+    const code = `package hello
+
+fun main() {
+  println("Hello World")
+}`;
+
+    const kotlin = shallow(syntaxHighlighter(code, 'kotlin')).html();
+
+    expect(kotlin).toMatchSnapshot();
+    expect(shallow(syntaxHighlighter(code, 'kt')).html()).toStrictEqual(kotlin);
+  });
+
+  it('liquid', () => {
+    const code = `{% if user %}
+  Hello {{ user.name }}!
+{% endif %}`;
+
+    expect(shallow(syntaxHighlighter(code, 'liquid')).html()).toMatchSnapshot();
+  });
+
+  it('markdown', () => {
+    const code = `# Hello World`;
+    expect(shallow(syntaxHighlighter(code, 'markdown')).html()).toMatchSnapshot();
+  });
+
+  it('objective-c', () => {
+    const code = `/*
+ Build on OS X:
+ clang -framework Foundation -fobjc-arc objc.m -o objc
+
+ Build on Linux with GNUstep:
+ clang \`gnustep-config --objc-flags\` \`gnustep-config --base-libs\` -fobjc-nonfragile-abi -fobjc-arc objc.m -o objc
+ */
+
+#import <Foundation/Foundation.h>
+
+int main(void)
+{
+    NSLog(@"Hello World");
+}`;
+
+    const objc = shallow(syntaxHighlighter(code, 'objc')).html();
+
+    expect(objc).toMatchSnapshot();
+    expect(shallow(syntaxHighlighter(code, 'objective-c')).html()).toStrictEqual(objc);
+    expect(shallow(syntaxHighlighter(code, 'objectivec')).html()).toStrictEqual(objc);
+  });
+
+  describe('php', () => {
+    it('should highlight', () => {
+      const code = `<?php
+
+echo 'Hello World';`;
+
+      expect(shallow(syntaxHighlighter(code, 'php')).html()).toMatchSnapshot();
+    });
+
+    it('should highlight if missing an opening `<?php` tag', () => {
+      expect(shallow(syntaxHighlighter('echo "Hello World";', 'php')).html()).toContain('cm-keyword');
+    });
+  });
+
+  it('powershell', () => {
+    const code = `'Hello World'`;
+    expect(shallow(syntaxHighlighter(code, 'powershell')).html()).toMatchSnapshot();
+  });
+
+  it('python', () => {
+    const code = `#!/usr/bin/env python
+print "Hello World"`;
+
+    const python = shallow(syntaxHighlighter(code, 'python')).html();
+
+    expect(python).toMatchSnapshot();
+    expect(shallow(syntaxHighlighter(code, 'py')).html()).toStrictEqual(python);
+  });
+
+  it('ruby', () => {
+    const code = `#!/usr/bin/env ruby
+puts "Hello World"`;
+
+    const ruby = shallow(syntaxHighlighter(code, 'ruby')).html();
+
+    expect(ruby).toMatchSnapshot();
+    expect(shallow(syntaxHighlighter(code, 'jruby')).html()).toStrictEqual(ruby);
+    expect(shallow(syntaxHighlighter(code, 'macruby')).html()).toStrictEqual(ruby);
+    expect(shallow(syntaxHighlighter(code, 'rake')).html()).toStrictEqual(ruby);
+    expect(shallow(syntaxHighlighter(code, 'rb')).html()).toStrictEqual(ruby);
+    expect(shallow(syntaxHighlighter(code, 'rbx')).html()).toStrictEqual(ruby);
+  });
+
+  it('scala', () => {
+    const code = `object HelloWorld extends App {
+  println("Hello World")
+}`;
+
+    expect(shallow(syntaxHighlighter(code, 'scala')).html()).toMatchSnapshot();
+  });
+
+  it('shell', () => {
+    const code = `#!/bin/sh
+echo "Hello World"`;
+
+    const shell = shallow(syntaxHighlighter(code, 'shell')).html();
+
+    expect(shell).toMatchSnapshot();
+    expect(shallow(syntaxHighlighter(code, 'bash')).html()).toStrictEqual(shell);
+    expect(shallow(syntaxHighlighter(code, 'sh')).html()).toStrictEqual(shell);
+    expect(shallow(syntaxHighlighter(code, 'zsh')).html()).toStrictEqual(shell);
+  });
+
+  it('sql', () => {
+    const code = `SELECT 'Hello World';`;
+
+    const sql = shallow(syntaxHighlighter(code, 'sql')).html();
+
+    expect(sql).toMatchSnapshot();
+    expect(shallow(syntaxHighlighter(code, 'cql')).html()).toStrictEqual(sql);
+    expect(shallow(syntaxHighlighter(code, 'mssql')).html()).toStrictEqual(sql);
+    expect(shallow(syntaxHighlighter(code, 'mysql')).html()).toStrictEqual(sql);
+    expect(shallow(syntaxHighlighter(code, 'plsql')).html()).toStrictEqual(sql);
+    expect(shallow(syntaxHighlighter(code, 'postgres')).html()).toStrictEqual(sql);
+    expect(shallow(syntaxHighlighter(code, 'postgresql')).html()).toStrictEqual(sql);
+    expect(shallow(syntaxHighlighter(code, 'pgsql')).html()).toStrictEqual(sql);
+    expect(shallow(syntaxHighlighter(code, 'sqlite')).html()).toStrictEqual(sql);
+  });
+
+  it('swift', () => {
+    const code = `print("Hello World")`;
+
+    expect(shallow(syntaxHighlighter(code, 'swift')).html()).toMatchSnapshot();
+  });
+
+  it('xml', () => {
+    const code = `<?xml version="1.0" encoding="UTF-8"?>
+<text><![CDATA[Hello World]]></text>`;
+
+    expect(shallow(syntaxHighlighter(code, 'xml')).html()).toMatchSnapshot();
   });
 });

--- a/packages/syntax-highlighter/codemirror.jsx
+++ b/packages/syntax-highlighter/codemirror.jsx
@@ -20,6 +20,7 @@ require('codemirror/mode/ruby/ruby');
 require('codemirror/mode/shell/shell');
 require('codemirror/mode/sql/sql');
 require('codemirror/mode/swift/swift');
+require('codemirror/mode/dart/dart');
 
 function getMode(lang) {
   let mode = lang;

--- a/packages/syntax-highlighter/modes.js
+++ b/packages/syntax-highlighter/modes.js
@@ -1,35 +1,59 @@
-// This is a mapping of potential languages
-// that do not have a direct codemirror mode for them
-// so we need to do a lookup to see what the appropriate
-// mode is.
+// This is a mapping of languages that we support, but aren't directly loading the mode extension
+// for within `codemirror.jsx`.
 //
-// There are 2 types of lookup, single and array.
-// e.g. `html` needs to be rendered using `htmlmixed`, but
-// `java`, needs to be rendered using the `clike` mode.
+// This list also includes a number of language aliases, as because of the way we're using
+// `CodeMirror.runMode` we can't take advantage of its known aliases in the mode extensions that
+// we're loading.
 //
-// We also have the mimeType to potentially in future load
-// in new types dynamically
+// There are 2 types of lookup, single and array. e.g. `html` needs to be rendered using
+// `htmlmixed`, but `java`, needs to be rendered using the `clike` mode.
+//
+// We also have the mimeType to potentially in future load in new types dynamically.
 module.exports = {
   asp: 'clike',
   bash: 'shell',
   c: 'clike',
+  'c++': ['clike', 'text/x-c++src'],
   cplusplus: ['clike', 'text/x-c++src'],
+  cpp: ['clike', 'text/x-c++src'],
+  cql: ['sql', 'text/x-cassandra'],
+  cs: ['clike', 'text/x-csharp'],
   csharp: ['clike', 'text/x-csharp'],
   curl: 'shell',
+  ecmascript: 'javascript',
   go: ['go', 'text/x-go'],
   html: 'htmlmixed',
   java: ['clike', 'text/x-java'],
+  js: 'javascript',
   json: ['javascript', 'application/ld+json'],
+  jruby: 'ruby',
   kotlin: ['clike', 'text/x-kotlin'],
+  kt: ['clike', 'text/x-kotlin'],
   liquid: 'htmlmixed',
+  node: 'javascript',
+  macruby: 'ruby',
   markdown: 'gfm',
-  mysql: 'sql',
+  mssql: ['sql', 'text/x-mssql'],
+  mysql: ['sql', 'text/x-mysql'],
+  objc: ['clike', 'text/x-objectivec'],
   objectivec: ['clike', 'text/x-objectivec'],
+  'objective-c': ['clike', 'text/x-objectivec'],
   php: ['php', 'text/x-php'],
+  pgsql: ['sql', 'text/x-pgsql'],
+  plsql: ['sql', 'text/x-plsql'],
+  postgres: ['sql', 'text/x-pgsql'],
+  postgresql: ['sql', 'text/x-pgsql'],
+  py: 'python',
+  rake: 'ruby',
+  rb: 'ruby',
+  rbx: 'ruby',
   scala: ['clike', 'text/x-scala'],
   scss: 'css',
+  sh: 'shell',
   sql: ['sql', 'text/x-sql'],
-  stylus: 'scss',
+  sqlite: ['sql', 'text/x-sqlite'],
+  stylus: 'css',
   text: ['null', 'text/plain'],
   typescript: ['javascript', 'text/typescript'],
+  zsh: 'shell',
 };


### PR DESCRIPTION
## 🧰 What's being changed?

This adds support for a heap of programming languages aliases that we:

* Said we supported, but didn't actually: `js`, `stylus`
* Should support because they're common aliases: `py` for Python, `rb` for Ruby, `js` for JS, `cpp` for C++
* Should support because they're similar flavors that we can already render: `mssql`, `pgsql`, `sqlite`
* Should support because people have been asking for it: `dart`

Our RDMD docs have already been updated to reflect this PR: https://docs.readme.com/rdmd/docs/code-blocks#highlighting

## 🧪 Testing

I've added comprehensive tests for every language we support now in `@readme/syntax-highlighter` with simple "Hello World" examples sourced from https://github.com/leachim6/hello-world.

## 🗳 Checklist
* [x] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**