### PR TITLE
Add button to open up viewed spec file

### DIFF
--- a/example/src/ApiList.jsx
+++ b/example/src/ApiList.jsx
@@ -79,7 +79,7 @@ class ApiList extends React.Component {
               })}
             </select>
             &nbsp;
-            <a href={selected}>Open Spec</a>
+            <a href={selected}>View document</a>
           </>
         )}
       </h3>

--- a/example/src/ApiList.jsx
+++ b/example/src/ApiList.jsx
@@ -60,6 +60,8 @@ class ApiList extends React.Component {
             );
           })}
         </select>
+        &nbsp;
+        <a href={selected}>Open Spec</a>
       </h3>
     );
   }

--- a/example/src/ApiList.jsx
+++ b/example/src/ApiList.jsx
@@ -8,9 +8,12 @@ class ApiList extends React.Component {
   constructor(props) {
     super(props);
 
+    const qs = parse(document.location.search.replace('?', ''));
+
     this.state = {
       apis: localDirectory,
-      selected: parse(document.location.search.replace('?', '')).selected || 'swagger-files/petstore.json',
+      selected: qs.selected || 'swagger-files/petstore.json',
+      customUrl: qs.customUrl,
     };
 
     this.changeApi = this.changeApi.bind(this);
@@ -33,35 +36,52 @@ class ApiList extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     const { selected } = this.state;
 
-    if (prevState.selected !== selected) {
+    if (prevState.selected !== selected && selected !== 'enter-a-url') {
       this.props.fetchSwagger(selected);
       window.history.pushState('', '', `?${stringify({ selected })}`);
     }
   }
 
   changeApi(e) {
-    this.setState({ selected: e.currentTarget.value });
+    this.setState({ selected: e.currentTarget.value, customUrl: false });
   }
 
   render() {
-    const { apis, selected } = this.state;
+    const { apis, selected, customUrl } = this.state;
 
     return (
       <h3>
         Select an API:&nbsp;
-        <select onChange={this.changeApi} value={selected}>
-          {Object.keys(apis).map(name => {
-            const api = apis[name];
-            const preferred = api.preferred || Object.keys(api.versions)[0];
-            return (
-              <option key={name} value={api.versions[preferred].swaggerUrl}>
-                {name.substring(0, 30)}
-              </option>
-            );
-          })}
-        </select>
-        &nbsp;
-        <a href={selected}>Open Spec</a>
+        {selected === 'enter-a-url' ? (
+          <form style={{ display: 'inline' }}>
+            <input name="selected" type="url" />
+            <input name="customUrl" type="hidden" value="true" />
+            <button type="submit">Go</button>
+          </form>
+        ) : (
+          <>
+            <select onChange={this.changeApi} value={selected}>
+              <option value="enter-a-url">Enter a URL</option>
+              {selected && customUrl && (
+                <option disabled value={selected}>
+                  {selected}
+                </option>
+              )}
+
+              {Object.keys(apis).map(name => {
+                const api = apis[name];
+                const preferred = api.preferred || Object.keys(api.versions)[0];
+                return (
+                  <option key={name} value={api.versions[preferred].swaggerUrl}>
+                    {name.substring(0, 30)}
+                  </option>
+                );
+              })}
+            </select>
+            &nbsp;
+            <a href={selected}>Open Spec</a>
+          </>
+        )}
       </h3>
     );
   }

--- a/example/src/SpecFetcher.jsx
+++ b/example/src/SpecFetcher.jsx
@@ -1,5 +1,6 @@
 const React = require('react');
 const swagger2openapi = require('swagger2openapi');
+const yaml = require('yaml');
 
 const createDocs = require('../../packages/api-explorer/lib/create-docs');
 
@@ -31,9 +32,13 @@ function withSpecFetching(Component) {
           .then(res => {
             if (!res.ok) {
               throw new Error('Failed to fetch.');
-            } else if (url.match(/\.(yaml|yml)/)) {
-              // @todo Should just try to automaticaly convert the spec if it isn't JSON.
-              throw new Error('Please convert your specification to JSON first.');
+            }
+
+            if (res.headers.get('content-type') === 'application/yaml' || url.match(/\.(yaml|yml)/)) {
+              this.updateStatus('Converting YAML to JSON');
+              return res.text().then(text => {
+                return yaml.parse(text);
+              });
             }
 
             return res.json();


### PR DESCRIPTION
Benak uses this website to test OAS files that customers send us and he's asked for an easy way to view that spec file so I added a link to the currently viewed spec:

<img width="628" alt="image" src="https://user-images.githubusercontent.com/848223/80517146-7490a880-8939-11ea-8f18-c6e30ec6e9a9.png">

-----
Also added the ability to enter a URL in the UI:

<img width="521" alt="image" src="https://user-images.githubusercontent.com/848223/80527831-d5c07800-8949-11ea-9a87-04d2ae91b55b.png">

Inline form:

<img width="497" alt="image" src="https://user-images.githubusercontent.com/848223/80527845-deb14980-8949-11ea-8afa-dd37e6db9df9.png">

Disabled option in the dropdown showing the URL:

<img width="694" alt="image" src="https://user-images.githubusercontent.com/848223/80527856-e375fd80-8949-11ea-8924-b668cfb50321.png">

----
We now also support yaml files!

http://localhost:9966/reference/?url=https://petstore.swagger.io/v2/swagger.yaml
http://localhost:9966/?selected=https%3A%2F%2Fpetstore.swagger.io%2Fv2%2Fswagger.yaml&customUrl=true


