### PR TITLE
fix: filter out nullish arrays from generated HAR objects

### DIFF
--- a/packages/oas-to-har/__tests__/lib/remove-undefined-objects.test.js
+++ b/packages/oas-to-har/__tests__/lib/remove-undefined-objects.test.js
@@ -4,10 +4,19 @@ test('should remove empty objects with only undefined properties', () => {
   expect(removeUndefinedObjects({ a: { b: undefined, c: { d: undefined } } })).toBeUndefined();
 });
 
-test('should not throw on arrays of primitives', () => {
-  expect(removeUndefinedObjects([null])).toStrictEqual([null]);
+test('should remove empty arrays from within object', () => {
+  expect(removeUndefinedObjects({ a: { b: undefined, c: { d: undefined } }, d: [1234, undefined] })).toStrictEqual({
+    d: [1234],
+  });
 });
 
-test('should not throw for null', () => {
-  expect(removeUndefinedObjects({ a: null })).toStrictEqual({ a: null });
+test('should remove undefined and null values from arrays', () => {
+  expect(removeUndefinedObjects([undefined, undefined])).toBeUndefined();
+  expect(removeUndefinedObjects([null])).toBeUndefined();
+  expect(removeUndefinedObjects(['1234', null, undefined, { a: null, b: undefined }])).toStrictEqual([
+    '1234',
+    {
+      a: null,
+    },
+  ]);
 });

--- a/packages/oas-to-har/__tests__/lib/remove-undefined-objects.test.js
+++ b/packages/oas-to-har/__tests__/lib/remove-undefined-objects.test.js
@@ -13,10 +13,12 @@ test('should remove empty arrays from within object', () => {
 test('should remove undefined and null values from arrays', () => {
   expect(removeUndefinedObjects([undefined, undefined])).toBeUndefined();
   expect(removeUndefinedObjects([null])).toBeUndefined();
-  expect(removeUndefinedObjects(['1234', null, undefined, { a: null, b: undefined }])).toStrictEqual([
+  expect(removeUndefinedObjects(['1234', null, undefined, { a: null, b: undefined }, '   ', ''])).toStrictEqual([
     '1234',
     {
       a: null,
     },
+    '   ',
+    '',
   ]);
 });


### PR DESCRIPTION
## 🧰 What's being changed?

This resolves a funky case with HAR generation where if a user clicks add an entry to an `array<primitive>` parameter, we would immediately add `[null]` into their code sample.

![Screen Shot 2020-04-28 at 12 27 38 PM](https://user-images.githubusercontent.com/33762/80529010-b0cd0480-894b-11ea-8160-905f25e6f972.png)

Why this was happening because if you supply `[undefined]` to `JSON.stringify`, it'll transform that into `[null]`, and we didn't have any work to filter out nullish items from arrays.

![Screen Shot 2020-04-28 at 12 28 32 PM](https://user-images.githubusercontent.com/33762/80529107-cfcb9680-894b-11ea-8b47-2cb17993ec9c.png)

## 🧪 Testing

Load up http://localhost:9966/?selected=swagger-files%2Ftypes.json, head to the "Arrays of different data types" operation and play around with adding and removing arrays.

## 🗳 Checklist
* [x] **🐛 I'm fixing a bug!**