### PR TITLE
RDMD syntax to specify initial active code tab.

### DIFF
--- a/packages/markdown/components/Code/style.scss
+++ b/packages/markdown/components/Code/style.scss
@@ -136,13 +136,13 @@
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%) scale(.33);
+      color: var(--md-code-text, green) !important;
       opacity: 0 !important;
     }
 
     &_copied {
       pointer-events: none;
       &, * {
-        color: var(--md-code-text, green) !important;
         opacity: 1;
       }
       &:before {
@@ -179,6 +179,10 @@
         padding: 1em;
         max-height: 90vh;
       }
+    }
+    
+    button.rdmd-code-copy:not(:hover) {
+      transition-delay: .4s;
     }
     &:not(:hover) button.rdmd-code-copy {
       opacity: 0 !important;

--- a/packages/markdown/components/CodeTabs/index.jsx
+++ b/packages/markdown/components/CodeTabs/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable eqeqeq */
 const React = require('react');
 const PropTypes = require('prop-types');
 
@@ -19,29 +20,43 @@ const CodeTabs = props => {
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
-    <div {...attributes} className="CodeTabs CodeTabs_initial">
+    <div {...attributes} className="CodeTabs --CodeTabs_initial--">
       <div className="CodeTabs-toolbar">
         {children.map(({ props: pre }, i) => {
           const { meta, lang } = pre.children[0].props;
           /* istanbul ignore next */
           return (
-            <button key={i} onClick={e => handleClick(e, i)} type="button">
+            <button
+              key={i}
+              className={`${i == props.activeTab ? 'CodeTabs_active' : ''}`}
+              onClick={e => handleClick(e, i)}
+              type="button"
+            >
               {meta || `${!lang ? 'Text' : upper(lang)}`}
             </button>
           );
         })}
       </div>
-      <div className="CodeTabs-inner">{children}</div>
+      <div className="CodeTabs-inner">
+        {children.map((k, i) => (
+          <pre key={i} className={`${i == props.activeTab ? 'CodeTabs_active' : ''}`}>
+            {k.props.children[0]}
+          </pre>
+        ))}
+      </div>
     </div>
   );
 };
 
 CodeTabs.propTypes = {
+  activeTab: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   attributes: PropTypes.shape({}),
   children: PropTypes.arrayOf(PropTypes.any).isRequired,
 };
 
 CodeTabs.defaultProps = {
+  // eslint-disable-next-line prettier/prettier
+  activeTab: "0",
   attributes: null,
 };
 

--- a/packages/markdown/components/Heading/index.jsx
+++ b/packages/markdown/components/Heading/index.jsx
@@ -18,23 +18,23 @@ function Heading({ tag, ...props }) {
   ]);
 }
 
-function CreateHeading(level, anchors) {
+function CreateHeading(level) {
   // eslint-disable-next-line react/display-name
-  return props => <Heading {...props} anchors={anchors} level={level} tag={`h${level}`} />;
+  return props => <Heading {...props} level={level} tag={`h${level}`} />;
 }
 
 Heading.propTypes = {
   align: PropTypes.oneOf(['left', 'center', 'right', '']),
-  anchors: PropTypes.object,
   children: PropTypes.array.isRequired,
   id: PropTypes.string.isRequired,
   level: PropTypes.number,
   tag: PropTypes.string.isRequired,
 };
+
 Heading.defaultProps = {
   align: '',
   id: '',
   level: 2,
 };
 
-module.exports = (level, anchors) => CreateHeading(level, anchors);
+module.exports = level => CreateHeading(level);

--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -72,10 +72,12 @@ const options = require('./options.json');
 // Sanitization Schema Defaults
 sanitize.clobberPrefix = '';
 
-sanitize.tagNames.push('span', 'style');
+sanitize.tagNames.push('span', 'style', 'pre');
 sanitize.attributes['*'].push('class', 'className', 'align', 'style');
 
 sanitize.tagNames.push('rdme-pin');
+
+sanitize.attributes.pre = ['class', 'className']
 
 sanitize.tagNames.push('embed');
 sanitize.attributes.embed = ['url', 'provider', 'html', 'title', 'href'];
@@ -174,6 +176,9 @@ export function react(text, opts = {}, components = {}) {
   if (!text) return null;
   [text, opts] = setup(text, opts);
 
+  // eslint-disable-next-line react/jsx-props-no-spreading, react/prop-types
+  const Pre = ({ children, ...attr }) => <pre {...attr}>{children}</pre>;
+
   // eslint-disable-next-line react/prop-types
   const PinWrap = ({ children }) => <div className="pin">{children}</div>;
 
@@ -197,6 +202,7 @@ export function react(text, opts = {}, components = {}) {
         h4: Heading(4),
         h5: Heading(5),
         h6: Heading(6),
+        pre: Pre,
         code: Code(sanitize),
         img: Image(sanitize),
         ...components,

--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -176,7 +176,6 @@ export function react(text, opts = {}, components = {}) {
 
   // eslint-disable-next-line react/prop-types
   const PinWrap = ({ children }) => <div className="pin">{children}</div>;
-  const count = {};
 
   return processor(opts)
     .use(rehypeReact, {
@@ -192,12 +191,12 @@ export function react(text, opts = {}, components = {}) {
         'rdme-pin': PinWrap,
         table: Table(sanitize),
         a: Anchor(sanitize),
-        h1: Heading(1, count),
-        h2: Heading(2, count),
-        h3: Heading(3, count),
-        h4: Heading(4, count),
-        h5: Heading(5, count),
-        h6: Heading(6, count),
+        h1: Heading(1),
+        h2: Heading(2),
+        h3: Heading(3),
+        h4: Heading(4),
+        h5: Heading(5),
+        h6: Heading(6),
         code: Code(sanitize),
         img: Image(sanitize),
         ...components,

--- a/packages/markdown/processor/parse/magic-block-parser.js
+++ b/packages/markdown/processor/parse/magic-block-parser.js
@@ -37,20 +37,24 @@ function tokenize(eat, value) {
 
   switch (type) {
     case 'code': {
-      const children = json.codes.map(obj => ({
-        type: 'code',
-        value: obj.code.trim(),
-        meta: obj.name || null,
-        lang: obj.language,
-        className: 'tab-panel',
-        data: {
-          hName: 'code',
-          hProperties: {
-            meta: obj.name || null,
-            lang: obj.language,
+      let activeTab;
+      const children = json.codes.map((obj, ix) => {
+        if (obj.open) activeTab = ix;
+        return {
+          type: 'code',
+          value: obj.code.trim(),
+          meta: obj.name || null,
+          lang: obj.language,
+          className: 'tab-panel',
+          data: {
+            hName: 'code',
+            hProperties: {
+              meta: obj.name || null,
+              lang: obj.language,
+            },
           },
-        },
-      }));
+        };
+      });
       if (children.length === 1) {
         if (!children[0].value) return eat(match); // skip empty code tabs
         if (children[0].name) return eat(match)(WrapPinnedBlocks(children[0], json));
@@ -60,7 +64,10 @@ function tokenize(eat, value) {
           {
             children,
             className: 'tabs',
-            data: { hName: 'code-tabs' },
+            data: {
+              hName: 'code-tabs',
+              hProperties: { activeTab },
+            },
             type: 'code-tabs',
           },
           json
@@ -169,7 +176,7 @@ function tokenize(eat, value) {
 
           sum[row].children[col] = {
             type: row ? 'tableCell' : 'tableHead',
-            children: this.tokenizeInline(val, eat.now()),
+            children: this.tokenizeBlock(val, eat.now()),
           };
           // convert falsey values to empty strings
           sum[row].children = [...sum[row].children].map(v => v || '');


### PR DESCRIPTION
Specify the initially visible tab by adding the `[open]` attribute after the code block's lang and title metadata. If multiple tabs are open, the last one will be visible. So in this example, the fourth tab would start opened on page load:

    ```js Tab 1
    First tab.
    ```
    ``` Tab 2 [open]
    Open tab, with title and no lang.
    ```
    ``` [open]
    Open tab, with no title or lang.
    ```
    ```php [open]
    Open tab, with no lang but no lang.
    ```
    ``` Last Tab
    Last tab.
    ```

This is compatible with magic blocks too, jic:

```
[block:code]
{
  "codes": [
    {
      "code": "hello world",
      "open": true
    }
  ]
}
[/block]
```