### PR TITLE
chore(deps): upgrading @readme/oas-tooling to 3.3.5

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1333,9 +1333,9 @@
       "dev": true
     },
     "@readme/oas-tooling": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.3.4.tgz",
-      "integrity": "sha512-LPOTQn6J/GCnncf+Qz+BrR5eG2M9hKLbJvEQkJeH4p09+VHG7HticbA4prJs7mZmuNlBrlD6Sf9F3vryH8sNrg==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.3.5.tgz",
+      "integrity": "sha512-aRsxgkiSyD1UCAjM043qf9T9O/7eFQf6aSp1X8+ez9DpGe89vAFLZeM1jGxyKw91G6UT6IW4EhiS354UKm26tw==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -9,7 +9,7 @@
     "@readme/markdown-magic": "^6.6.0",
     "@readme/oas-extensions": "^6.4.0",
     "@readme/oas-to-har": "^6.6.2",
-    "@readme/oas-tooling": "^3.3.4",
+    "@readme/oas-tooling": "^3.3.5",
     "@readme/react-jsonschema-form": "^1.1.5",
     "@readme/syntax-highlighter": "^6.5.0",
     "@readme/variable": "^6.4.0",


### PR DESCRIPTION
## 📖  Release notes
### 3.3.5
- fix: edge case where component would sometimes be marked a string [`#174`](https://github.com/readmeio/oas/pull/174)

## 🗳 Checklist
* [x] **🐛 I'm fixing a bug!**