### PR TITLE
style(explorer): add .markdown-body class to excerpt

### DIFF
--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -354,7 +354,7 @@ class Doc extends React.Component {
 
               <h2>{doc.title}</h2>
               {doc.excerpt && (
-                <div className="excerpt">
+                <div className="markdown-body excerpt">
                   {useNewMarkdownEngine ? markdown(doc.excerpt) : markdownMagic(doc.excerpt)}
                 </div>
               )}

--- a/packages/api-explorer/style/markdown-overrides.scss
+++ b/packages/api-explorer/style/markdown-overrides.scss
@@ -7,6 +7,12 @@
 #api-explorer .hub-reference-left .markdown-body {
   width: 100%;
   max-width: 100%;
+
+  &.excerpt {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   > .pin {
     display: none !important;
   }
@@ -22,7 +28,7 @@
     > .pin {
       .reference-layout-column & {
         color: #bbbec1;
-        p { color: inherit !important }
+        blockquote, p { color: inherit !important }
         > .CodeTabs, > pre {
           filter: var(--md-code-text, invert(0.9)); /* ¡hacksaurz! */
         }


### PR DESCRIPTION
## 🧰 What's being changed?

##### Broken

![image](https://user-images.githubusercontent.com/886627/80771315-e61e5180-8b07-11ea-9f57-7d827a445d5d.png)

##### Fixed

![image](https://user-images.githubusercontent.com/886627/80771429-46ad8e80-8b08-11ea-923f-aa5ec707453f.png)

## 🗳 Checklist

* 🐛 I'm fixing a bug