### PR TITLE
Keyboard accessible RDMD lightboxes.

### DIFF
--- a/packages/markdown/components/Callout/style.scss
+++ b/packages/markdown/components/Callout/style.scss
@@ -2,10 +2,12 @@
   --background: #{lighten(#dfe2e5, 8.75%)};
   --border: #{lighten(#6a737d, 12.5%)};
 
-  background: var(--background);
-  border-color: var(--border);
-  color: var(--text);
-  padding: $l-offset;
+  & {
+    background: var(--background);
+    border-color: var(--border);
+    color: var(--text);
+    padding: $l-offset;
+  }
 
   &_info {
     $color: #46b8da;
@@ -45,6 +47,15 @@
 
   a {
     color: inherit;
+  }
+  hr {
+    border-color: var(--border, var(--markdown-edge, #eee));
+  }
+  blockquote {
+    color: var(--text);
+    border-color: var(--border);
+    border-width: 3px;
+    padding: 0 0 0 .8em;
   }
 
   .callout-heading {

--- a/packages/markdown/components/Code/style.scss
+++ b/packages/markdown/components/Code/style.scss
@@ -87,18 +87,18 @@
     
     & {
       -webkit-appearance: unset;
-      color: var(--md-code-text, inherit);
-      background: transparent;
-      backdrop-filter: blur(6px);
-      border: none;
-      margin: .75em .6em 0 0;
-      padding: .33em .6em;
-      font: inherit;
-      border-radius: 2px;
-      outline: none !important;
-      box-shadow: inset 0 0 0 1px rgba(#8B8B8B, 0.33);
-      background: var(--md-code-background, rgba(white, .1));
+      margin: .5em .6em 0 0;
+      padding: .25em .7em;
       cursor: copy;
+      font: inherit;
+      color: var(--md-code-text, inherit);
+      border: none;
+      border-radius: 3px;
+      outline: none !important;
+      background: var(--md-code-background, inherit);
+      box-shadow:
+        inset 0 0 0 1px rgba(#aaa, .66),
+        -1px 2px 6px -3px rgba(black, .1);
       transition: .15s ease-out;
     }
 
@@ -109,11 +109,17 @@
     }
 
     &:hover {
-      background: rgba(white, .125);
+      &:not(:active) {
+        box-shadow:
+          inset 0 0 0 1px rgba(#8B8B8B, .75),
+          -1px 2px 6px -3px rgba(black, .2);
+      }
     }
 
     &:active {
-      background: rgba(black, .088);
+      box-shadow:
+        inset 0 0 0 1px rgba(#8B8B8B, .5),
+        inset 1px 4px 6px -2px rgba(0, 0, 0, .175);
       &:before, &:after {
         opacity: .75;
       }
@@ -124,19 +130,27 @@
       font: normal normal normal 1em/1 "Font Awesome 5 Free", "FontAwesome";
       text-rendering: auto;
       -webkit-font-smoothing: antialiased;
+
+      line-height: 2;
+      font-family: 'ReadMe-Icons';
+      font-variant-ligatures: discretionary-ligatures;
+      font-feature-settings: "liga";
     }
     &:before {
+      content: "\e6c9";
+      font-weight: 800;
       transition: .3s .15s ease;
-      content: "\f0c5"
     }
     &:after {
-      transition: .3s 0s ease;
-      content: "\f00c" !important;
+      // @todo why are these !important @rafe, you dumbell?
+      content: "\e942" !important;
+      font-weight: 900 !important;
       position: absolute;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%) scale(.33);
       opacity: 0 !important;
+      transition: .3s 0s ease;
     }
 
     &_copied {
@@ -158,9 +172,12 @@
     }
   }
   
-
   pre {
     position: relative;
+
+    > code {
+      background: inherit;
+    }
 
     button.rdmd-code-copy {
       display: inline-block !important;
@@ -169,8 +186,8 @@
       top: 0;
     }
 
+    // manage overflow scrolling
     & {
-      // manage overflow scrolling
       overflow: hidden;
       padding: 0;
       > code {
@@ -180,8 +197,15 @@
         max-height: 90vh;
       }
     }
-    &:not(:hover) button.rdmd-code-copy {
-      opacity: 0 !important;
+
+    // manage copied state style
+    & {
+      &:hover button.rdmd-code-copy:not(:hover) {
+        transition-delay: .4s;
+      }
+      &:not(:hover) button.rdmd-code-copy:not(.rdmd-code-copy_copied) {
+        opacity: 0 !important;
+      }
     }
   }
 }

--- a/packages/markdown/components/Image/Lightbox.jsx
+++ b/packages/markdown/components/Image/Lightbox.jsx
@@ -1,0 +1,39 @@
+/*
+eslint-disable jsx-a11y/no-autofocus, jsx-a11y/no-noninteractive-tabindex, jsx-a11y/no-noninteractive-element-interactions, react/jsx-props-no-spreading
+ */
+
+const React = require('react');
+const PropTypes = require('prop-types');
+
+/**
+ * A very simple, CSS-driven lightbox.
+ * @todo currently, a new <Lightbox> instance is rendered for
+ *       each individual image! We should refactor to this to
+ *       use a single React portal component with public APIs.
+ */
+const Lightbox = ({ alt, close, opened, src }, ref) => (
+  <span
+    ref={ref}
+    autoFocus={true}
+    className="lightbox"
+    onClick={() => close()}
+    onKeyDown={this.handleKey}
+    onScroll={e => opened && close(false)}
+    open={opened}
+    role="dialog"
+    tabIndex={0}
+  >
+    <span className="lightbox-inner">
+      <img {...this.props} alt={alt} className="lightbox-img" loading="lazy" src={src} title="Click to close..." />
+    </span>
+  </span>
+);
+
+Lightbox.propTypes = {
+  alt: PropTypes.string,
+  close: PropTypes.func,
+  opened: PropTypes.bool,
+  src: PropTypes.string,
+};
+
+module.exports = React.forwardRef(Lightbox);

--- a/packages/markdown/components/Image/Lightbox.jsx
+++ b/packages/markdown/components/Image/Lightbox.jsx
@@ -1,9 +1,5 @@
-/*
-eslint-disable jsx-a11y/no-autofocus, jsx-a11y/no-noninteractive-tabindex, jsx-a11y/no-noninteractive-element-interactions, react/jsx-props-no-spreading
- */
-
+/* eslint-disable jsx-a11y/no-autofocus, jsx-a11y/no-noninteractive-tabindex, jsx-a11y/no-noninteractive-element-interactions, react/jsx-props-no-spreading */
 const React = require('react');
-const PropTypes = require('prop-types');
 
 /**
  * A very simple, CSS-driven lightbox.
@@ -11,29 +7,33 @@ const PropTypes = require('prop-types');
  *       each individual image! We should refactor to this to
  *       use a single React portal component with public APIs.
  */
-const Lightbox = ({ alt, close, opened, src }, ref) => (
-  <span
-    ref={ref}
-    autoFocus={true}
-    className="lightbox"
-    onClick={() => close()}
-    onKeyDown={this.handleKey}
-    onScroll={e => opened && close(false)}
-    open={opened}
-    role="dialog"
-    tabIndex={0}
-  >
-    <span className="lightbox-inner">
-      <img {...this.props} alt={alt} className="lightbox-img" loading="lazy" src={src} title="Click to close..." />
+const Lightbox = ({ alt, close, opened, src }, ref) => {
+  return (
+    <span
+      ref={ref}
+      autoFocus={true}
+      className="lightbox"
+      onClick={() => close(false)}
+      onKeyDown={this.handleKey}
+      onScroll={e => opened && close(false)}
+      open={opened}
+      role="dialog"
+      tabIndex={0}
+    >
+      <span className="lightbox-inner">
+        <img {...this.props} alt={alt} className="lightbox-img" loading="lazy" src={src} title="Click to close..." />
+      </span>
     </span>
-  </span>
-);
+  );
+};
 
-Lightbox.propTypes = {
+// forwardRef render functions do not support propTypes
+// or defaultProps
+/* Lightbox.propTypes = {
   alt: PropTypes.string,
   close: PropTypes.func,
   opened: PropTypes.bool,
   src: PropTypes.string,
-};
+}; */
 
 module.exports = React.forwardRef(Lightbox);

--- a/packages/markdown/components/Image/index.jsx
+++ b/packages/markdown/components/Image/index.jsx
@@ -37,6 +37,7 @@ class Image extends React.Component {
     const $el = this.lightbox.current;
     setTimeout(() => {
       $el.scrollTop = ($el.scrollHeight - $el.offsetHeight) / 2;
+      this.setState({ lightbox: true });
     }, 0);
   }
 
@@ -70,15 +71,8 @@ class Image extends React.Component {
       return <img {...this.props} alt={alt} loading="lazy" />;
     }
     return (
-      <span className="img">
-        <img
-          {...this.props}
-          alt={alt}
-          onClickCapture={this.toggle}
-          onKeyDown={this.handleKey}
-          role={'button'}
-          tabIndex={0}
-        />
+      <span className="img" onKeyDown={this.handleKey} role={'button'} tabIndex={0}>
+        <img {...this.props} alt={alt} onClickCapture={e => this.toggle(true) | e.preventDefault()} />
         <Lightbox ref={this.lightbox} {...this.props} close={this.toggle} opened={this.state.lightbox} />
       </span>
     );

--- a/packages/markdown/components/Image/index.jsx
+++ b/packages/markdown/components/Image/index.jsx
@@ -1,43 +1,86 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-/* eslint-disable react/jsx-props-no-spreading */
+/* eslint-disable no-param-reassign, jsx-a11y/no-noninteractive-element-to-interactive-role, react/jsx-props-no-spreading, no-fallthrough */
 
 const React = require('react');
 const PropTypes = require('prop-types');
+const Lightbox = require('./Lightbox');
 
 class Image extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { lightbox: false };
+
+    this.state = {
+      lightbox: false,
+    };
+    this.lightbox = React.createRef();
+
+    this.toggle = this.toggle.bind(this);
+    this.handleKey = this.handleKey.bind(this);
+
+    this.isEmoji = props.className === 'emoji';
+  }
+
+  componentDidMount() {
+    this.lightboxSetup();
+  }
+
+  toggle(toState) {
+    if (this.props.className === 'emoji') return;
+
+    if (typeof toState === 'undefined') toState = !this.state.lightbox;
+
+    if (toState) this.lightboxSetup();
+
+    this.setState({ lightbox: toState });
+  }
+
+  lightboxSetup() {
+    const $el = this.lightbox.current;
+    setTimeout(() => {
+      $el.scrollTop = ($el.scrollHeight - $el.offsetHeight) / 2;
+    }, 0);
+  }
+
+  handleKey(e) {
+    let { key, metaKey: cmd } = e;
+
+    cmd = cmd ? 'cmd+' : '';
+    key = `${cmd}${key.toLowerCase()}`;
+
+    switch (key) {
+      case 'ArrowDown':
+      case 'ArrowUp':
+        break;
+      case 'cmd+.':
+      case 'escape':
+        // CLOSE
+        this.toggle(false);
+        break;
+      case ' ':
+      case 'enter':
+        // OPEN
+        if (!this.state.open) this.toggle(true);
+        e.preventDefault();
+      default:
+    }
   }
 
   render() {
-    const { align, title, alt, width, height, className = '' } = this.props;
-    const extras = { align, width, height };
+    const { alt } = this.props;
+    if (this.isEmoji) {
+      return <img {...this.props} alt={alt} loading="lazy" />;
+    }
     return (
-      <React.Fragment>
+      <span className="img">
         <img
           {...this.props}
           alt={alt}
-          title={title}
-          {...extras}
-          loading="lazy"
-          onClick={() => className !== 'emoji' && this.setState({ lightbox: true })}
+          onClickCapture={this.toggle}
+          onKeyDown={this.handleKey}
+          role={'button'}
+          tabIndex={0}
         />
-        {className === 'emoji' || (
-          <span
-            className="lightbox"
-            onClick={() => this.setState({ lightbox: false })}
-            onScrollCapture={() => this.setState({ lightbox: false })}
-            open={this.state.lightbox}
-            role="dialog"
-          >
-            <span className="lightbox-inner">
-              <img {...this.props} alt={alt} title="Click to close..." {...extras} loading="lazy" />
-            </span>
-          </span>
-        )}
-      </React.Fragment>
+        <Lightbox ref={this.lightbox} {...this.props} close={this.toggle} opened={this.state.lightbox} />
+      </span>
     );
   }
 }

--- a/packages/markdown/components/Image/style.scss
+++ b/packages/markdown/components/Image/style.scss
@@ -22,6 +22,8 @@
       margin-left: auto;
       margin-right: auto;
       border-style: none;
+
+      outline: 1px solid transparent;
     }
 
     &[align=right],
@@ -32,6 +34,7 @@
     &[alt~=align-left] {
       @extend %img-align-left;
     }
+    &[width="80%"],
     &[align=center],
     &[alt~=align-center] {
       @extend %img-align-center;
@@ -44,7 +47,7 @@
     }
 
     &.border {
-      border: 1px solid 0 0 0 1px rgba(0,0,0,.2);
+      border: 1px solid rgba(0,0,0,.2);
     }
   }
 
@@ -64,6 +67,13 @@
     @extend %img-align-center;
   }
 
+  figure .img {
+    display: inline-block;
+    &, >img:only-of-type {
+      display: block;
+    }
+  }
+
   .lightbox {
     & {
       position: fixed;
@@ -73,25 +83,27 @@
 
       display: flex;
       flex-flow: nowrap column;
-      justify-content: center;
+      justify-content: flex-start;
       align-items: center;
 
       width: 100vw;
       height: 100vh;
       overflow: hidden;
       overflow-y: scroll;
-      background: linear-gradient(to bottom, rgba(245, 245, 250, .88) 50%, #f5f5fa);
-      backdrop-filter: blur(6px) saturate(1.2) brightness(1.075);
+      background: rgba(white, .966);
       user-select: none;
 
       margin-top: 0;
       margin-bottom: 0;
     }
+    &:not([open]) {
+      pointer-events: none;
+    }
 
     // Close Button
     // 
     &:after {
-      position: absolute;
+      position: fixed;
       top: 1em;
       right: 1em;
       content: '\f00d';
@@ -122,11 +134,13 @@
       min-height: calc(100vh + 8px);
       margin: auto;
       margin: 8px auto auto;
+      padding: 5em 0;
+      box-sizing: content-box;
     }
 
     & { // transition
       transition: .3s ease-out;
-      transition-property: opacity z-index;
+      transition-property: opacity, z-index, transform;
       img {
         transform: scale(1);
         transition: .25s .05s ease-in;
@@ -134,7 +148,6 @@
       &:not([open]) {
         opacity: 0 !important;
         pointer-events: none;
-        z-index: -1;
         img {
           transform: scale(0);
           opacity: 0;
@@ -149,7 +162,7 @@
       max-height: 95vh !important;
       max-width: unset !important;
       min-width: unset !important;
-      &:not([src$=".png"]):not([src$=".svg"]):not([src$=".jp2"]):not([src$=".tiff"]) {
+      &.border, &:not([src$=".png"]):not([src$=".svg"]):not([src$=".jp2"]):not([src$=".tiff"]) {
         box-shadow: 0 .5em 3em -1em rgba(0, 0, 0, .2);
       }
     }

--- a/packages/markdown/styles/gfm.scss
+++ b/packages/markdown/styles/gfm.scss
@@ -1,9 +1,9 @@
 @mixin gfm {
-  @include markdown-body-defaults;
-  @include markdown-body-overrides;
+  @include markdownDefaults;
+  @include markdownOverrides;
 }
 
-@mixin markdown-body-defaults {
+@mixin markdownDefaults {
   & {
     -ms-text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%;
@@ -11,7 +11,8 @@
     font-family: var(--markdown-font);
     line-height: var(--markdown-lineHeight);
     color: var(--markdown-text);
-    word-wrap: break-word
+    word-wrap: break-word;
+    @include _clearfix();
   }
 
   ul {
@@ -75,8 +76,16 @@
 
   hr {
     box-sizing: content-box;
+
     height: 0;
-    overflow: visible
+    overflow: hidden;
+    margin: 15px 0;
+
+    border-width: 0 0 1px;
+    border-bottom: 1px solid var(--markdown-edge, #dfe2e5);
+    background: transparent;
+
+    @include _clearfix();
   }
 
   input {
@@ -105,26 +114,6 @@
 
   strong {
     font-weight: 600
-  }
-
-  hr {
-    background: 0 0;
-    border: 0;
-    border-bottom: 1px solid #dfe2e5;
-    height: 0;
-    margin: 15px 0;
-    overflow: hidden
-  }
-
-  hr:before {
-    content: "";
-    display: table
-  }
-
-  hr:after {
-    clear: both;
-    content: "";
-    display: table
   }
 
   details summary {
@@ -236,17 +225,6 @@
     margin: 0
   }
 
-  &:before {
-    content: "";
-    display: table
-  }
-
-  &:after {
-    clear: both;
-    content: "";
-    display: table
-  }
-
   &> :first-child {
     margin-top: 0 !important
   }
@@ -347,12 +325,9 @@
     vertical-align: middle
   }
 
-  hr {
-    border-bottom-color: #eee
-  }
 }
 
-@mixin markdown-body-overrides {
+@mixin markdownOverrides {
 
   h5,
   h6 {
@@ -397,4 +372,12 @@
       }
     }
   }
+}
+
+@mixin _clearfix(){
+  &:before, &:after {
+    content: "";
+    display: table;
+  }
+  &:after { clear: both }
 }

--- a/packages/markdown/styles/main.scss
+++ b/packages/markdown/styles/main.scss
@@ -2,7 +2,8 @@
 @import './components.scss';
 
 :root {
-  // --markdown-radius: 3px; // fallback to defaults
+  // --markdown-radius: 3px;
+  // --markdown-edge: #eee;
   --markdown-font: inherit;
   --markdown-text: inherit;
   --markdown-title: inherit;


### PR DESCRIPTION
## 🧰 What's being changed?

- [ ] 🐛 fix lightbox image display aspect ratio (#666)
- [x] 🆕 extract lightbox in to it's own component
- [x] 🆕 full keyboard accessibility for lightboxes (traps focus for `escape`, `space`, and `enter` keys)
- [x] 🐷 fix magic block `.border` class support
- [x] 🐷 support old engine-style centering for `[width=80%]` magic images
- [x] 🐷 polish lightbox styles
- [x] 🆕 ~render component in a portal? (maybe?)~

## 🗳 Checklist

* 🆕 I'm adding something new
* 📸 I've made some changes to the UI!