### PR TITLE
Fix Firefox lightbox bug.

### DIFF
--- a/packages/markdown/components/Image/Lightbox.jsx
+++ b/packages/markdown/components/Image/Lightbox.jsx
@@ -9,13 +9,13 @@ const React = require('react');
  *       use a single React portal component with public APIs.
  */
 // eslint-disable-next-line react/prop-types
-const Lightbox = ({ alt, close, opened, ...attr }, ref) => {
+const Lightbox = ({ alt, onScroll, opened, ...attr }, ref) => {
   return (
     <span
       ref={ref}
       autoFocus={true}
       className="lightbox"
-      onScroll={() => opened && close(false)}
+      onScrollCapture={onScroll}
       open={opened}
       role="dialog"
       tabIndex={0}

--- a/packages/markdown/components/Image/index.jsx
+++ b/packages/markdown/components/Image/index.jsx
@@ -37,7 +37,6 @@ class Image extends React.Component {
     const $el = this.lightbox.current;
     setTimeout(() => {
       $el.scrollTop = ($el.scrollHeight - $el.offsetHeight) / 2;
-      this.setState({ lightbox: true });
     }, 0);
   }
 
@@ -68,9 +67,14 @@ class Image extends React.Component {
       return <img {...this.props} alt={alt} loading="lazy" />;
     }
     return (
-      <span className="img" onClick={() => this.toggle()} onKeyDown={this.handleKey} role={'button'} tabIndex={0}>
+      <span className="img" onClick={() => this.toggle(false)} onKeyDown={this.handleKey} role={'button'} tabIndex={0}>
         <img {...this.props} alt={alt} />
-        <Lightbox ref={this.lightbox} {...this.props} close={this.toggle} opened={this.state.lightbox} />
+        <Lightbox
+          ref={this.lightbox}
+          {...this.props}
+          onScroll={() => this.toggle(false)}
+          opened={this.state.lightbox}
+        />
       </span>
     );
   }

--- a/packages/markdown/components/Image/index.jsx
+++ b/packages/markdown/components/Image/index.jsx
@@ -67,7 +67,7 @@ class Image extends React.Component {
       return <img {...this.props} alt={alt} loading="lazy" />;
     }
     return (
-      <span className="img" onClick={() => this.toggle(false)} onKeyDown={this.handleKey} role={'button'} tabIndex={0}>
+      <span className="img" onClick={() => this.toggle()} onKeyDown={this.handleKey} role={'button'} tabIndex={0}>
         <img {...this.props} alt={alt} />
         <Lightbox
           ref={this.lightbox}


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a bug on Firefox where every light box would occasionally open on page load:

- [x] don't force `state.open` during initial scroll positioning
- [x] use generic props for light box

[![image](https://user-images.githubusercontent.com/886627/81215878-d632c180-8f8e-11ea-8773-ba1eac75c0f4.png)](https://readmeio.slack.com/files/U09PK6RK7/F013VM31AN4/screen_recording_2020-05-06_at_10.49.26_am.mov)

---
* 🐛 I'm fixing a bug