### PR TITLE
fix/table-parsing

### DIFF
--- a/packages/markdown/__tests__/index.test.js
+++ b/packages/markdown/__tests__/index.test.js
@@ -3,6 +3,7 @@ const React = require('react');
 const BaseUrlContext = require('../contexts/BaseUrl');
 
 const markdown = require('../index');
+const { tableFlattening } = require('../processor/plugin/table-flattening');
 const settings = require('../options.json');
 
 test('image', () => {
@@ -214,6 +215,24 @@ describe('tree flattening', () => {
     expect(table.children).toHaveLength(2);
     expect(table.children[0].value).toStrictEqual(' Col. B');
     expect(table.children[1].value).toStrictEqual('Cell A1 Cell B1 Cell A2 Cell B2 Cell A3 ');
+  });
+
+  it('should not throw an error if missing values', () => {
+    const tree = {
+      tagName: 'table',
+      children: [
+        {
+          tagName: 'tHead',
+        },
+        {
+          tagName: 'tBody',
+        },
+      ],
+    };
+
+    const [head, body] = tableFlattening(tree).children;
+    expect(head.value).toStrictEqual('');
+    expect(body.value).toStrictEqual('');
   });
 });
 

--- a/packages/markdown/processor/plugin/table-flattening.js
+++ b/packages/markdown/processor/plugin/table-flattening.js
@@ -9,10 +9,11 @@ function transformer(ast) {
       // This is necessary to pullout all the relevant strings
 
       // Parse Header Values
-      const headerChildren = header.children[0].children;
+      const headerChildren = header.children && header.children.length ? header.children[0].children : [];
       const headerValue = headerChildren.map(hc => (hc.children.length && hc.children[0].value) || '').join(' ');
       // Parse Body Values
-      const bodyChildren = body.children.map(bc => bc.children).reduce((a, b) => a.concat(b), []);
+      const bodyChildren =
+        (body.children && body.children.map(bc => bc && bc.children).reduce((a, b) => a.concat(b), [])) || [];
       const bodyValue = bodyChildren.map(bc => (bc.children.length && bc.children[0].value) || '').join(' ');
 
       return [
@@ -37,3 +38,4 @@ function transformer(ast) {
 }
 
 module.exports = () => transformer;
+module.exports.tableFlattening = transformer;


### PR DESCRIPTION
## 🧰 What's being changed?

Fixing issue where nested table parsing failed from null hAST values. We're seeing some extremely large custom markdown tables with missing values. When they are serialized to hAST, and subsequently parsed here, we're not covering the case that they don't exist.

Now we are!

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [X ] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
