### PR TITLE
Fix RDMD camelCase anchor splitting.

### DIFF
--- a/packages/markdown/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/markdown/__tests__/__snapshots__/index.test.js.snap
@@ -88,10 +88,10 @@ exports[`export multiple Markdown renderers renders custom React components 1`] 
   <Unknown
     id="hello-world"
   >
-    Hello World
     <div
       id="section-hello-world"
     />
+    Hello World
   </Unknown>
   
 

--- a/packages/markdown/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/markdown/__tests__/__snapshots__/index.test.js.snap
@@ -89,6 +89,7 @@ exports[`export multiple Markdown renderers renders custom React components 1`] 
     id="hello-world"
   >
     <div
+      className="heading-anchor_backwardsCompatibility"
       id="section-hello-world"
     />
     Hello World
@@ -1009,6 +1010,8 @@ exports[`list items 1`] = `
 
 exports[`magic image 1`] = `"<figure><span class=\\"img\\" role=\\"button\\" tabindex=\\"0\\"><img src=\\"https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg\\" title=\\"man-eating-pizza-and-making-an-ok-gesture.jpg\\" class=\\"\\" width=\\"100%\\" align=\\"\\" alt=\\"\\" caption=\\"\\" height=\\"auto\\"><span class=\\"lightbox\\" role=\\"dialog\\" tabindex=\\"0\\"><span class=\\"lightbox-inner\\"><img src=\\"https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg\\" title=\\"Click to close...\\" class=\\"lightbox-img\\" width=\\"100%\\" align=\\"\\" caption=\\"\\" height=\\"auto\\" alt=\\"\\" loading=\\"lazy\\"></span></span></span><figcaption><p>A guy. Eating pizza. And making an OK gesture.</p></figcaption></figure>"`;
 
-exports[`prefix anchors with section- should add a section- prefix to heading anchors 1`] = `"<h1 id=\\"heading\\">heading</h1>"`;
+exports[`prefix anchors with "section-" "section-" anchors should split on camelCased words: section-camel-cased 1`] = `"section-camel-cased"`;
+
+exports[`prefix anchors with "section-" should add a section- prefix to heading anchors 1`] = `"<h1 id=\\"heading\\">heading</h1>"`;
 
 exports[`tables 1`] = `"<div class=\\"rdmd-table\\"><div class=\\"rdmd-table-inner\\"><table><thead><tr><th>Tables</th><th style=\\"text-align: center;\\">Are</th><th style=\\"text-align: right;\\">Cool</th></tr></thead><tbody><tr><td>col 3 is</td><td style=\\"text-align: center;\\">right-aligned</td><td style=\\"text-align: right;\\">$1600</td></tr><tr><td>col 2 is</td><td style=\\"text-align: center;\\">centered</td><td style=\\"text-align: right;\\">$12</td></tr><tr><td>zebra stripes</td><td style=\\"text-align: center;\\">are neat</td><td style=\\"text-align: right;\\">$1</td></tr></tbody></table></div></div>"`;

--- a/packages/markdown/__tests__/index.test.js
+++ b/packages/markdown/__tests__/index.test.js
@@ -322,8 +322,15 @@ Lorem ipsum dolor!`;
   });
 });
 
-describe('prefix anchors with section-', () => {
+describe('prefix anchors with "section-"', () => {
   it('should add a section- prefix to heading anchors', () => {
     expect(markdown.html('# heading')).toMatchSnapshot();
+  });
+
+  it('"section-" anchors should split on camelCased words', () => {
+    const heading = mount(markdown.react('# camelCased'));
+    const anchor = heading.find('.heading-anchor_backwardsCompatibility').at(0);
+
+    expect(anchor.props().id).toMatchSnapshot('section-camel-cased');
   });
 });

--- a/packages/markdown/processor/parse/flavored/callout.js
+++ b/packages/markdown/processor/parse/flavored/callout.js
@@ -22,6 +22,8 @@ function tokenizer(eat, value) {
     '\uD83D\uDED1': 'error',
     '\u2049\uFE0F': 'error',
     '\u203C\uFE0F': 'error',
+    // NOTE: prettier is desperate to convert this in to an emoji.
+    //       PLEASE DON'T COMMIT THIS OR YOU'LL BREAK README IN IE!
     // eslint-disable-next-line prettier/prettier
     '\u2139\uFE0F': 'info',
     '\u26A0': 'warn',

--- a/packages/markdown/processor/plugin/section-anchor-id.js
+++ b/packages/markdown/processor/plugin/section-anchor-id.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 const flatMap = require('unist-util-flatmap');
 const kebabCase = require('lodash/kebabCase');
 
@@ -19,12 +20,9 @@ const getTexts = node => {
  */
 function transformer(ast) {
   return flatMap(ast, node => {
-    if (matchTag.test(node.tagName) || node?.properties?.id) {
-      const useIdProp = node?.properties?.id.match(/^.*[A-Z].*$/);
-
-      const id = `section-${kebabCase(!useIdProp && getTexts(node) || node.properties.id)}`;
+    if (matchTag.test(node.tagName)) {
+      const id = `section-${kebabCase(getTexts(node))}`;
       const element = { type: 'element', tagName: 'div', properties: { id } };
-
       if (node.children) node.children.unshift(element);
       else node.children = [element];
     }

--- a/packages/markdown/processor/plugin/section-anchor-id.js
+++ b/packages/markdown/processor/plugin/section-anchor-id.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 const flatMap = require('unist-util-flatmap');
 const kebabCase = require('lodash/kebabCase');
 

--- a/packages/markdown/processor/plugin/section-anchor-id.js
+++ b/packages/markdown/processor/plugin/section-anchor-id.js
@@ -21,7 +21,11 @@ function transformer(ast) {
   return flatMap(ast, node => {
     if (matchTag.test(node.tagName)) {
       const id = `section-${kebabCase(getTexts(node))}`;
-      const element = { type: 'element', tagName: 'div', properties: { id } };
+      const element = {
+        type: 'element',
+        tagName: 'div',
+        properties: { id, className: 'heading-anchor_backwardsCompatibility' },
+      };
       if (node.children) node.children.unshift(element);
       else node.children = [element];
     }

--- a/packages/markdown/processor/plugin/section-anchor-id.js
+++ b/packages/markdown/processor/plugin/section-anchor-id.js
@@ -1,19 +1,32 @@
 const flatMap = require('unist-util-flatmap');
 const kebabCase = require('lodash/kebabCase');
 
-// Adds an empty <div id='section-slug'> next to all headings.
-// This is for compatibility with how we used to do slugs
+const matchTag = /^h[1-6]$/g;
+
+/** Concat a deep text value from an AST node's children
+ */
+const getTexts = node => {
+  let text = '';
+  flatMap(node, kid => {
+    text += kid.type === 'text' ? kid.value : '';
+    return [kid];
+  });
+  return text;
+};
+
+/** Adds an empty <div id=section-slug> next to all headings
+ *  for backwards-compatibility with how we used to do slugs.
+ */
 function transformer(ast) {
   return flatMap(ast, node => {
-    if (node.type === 'element' && node.properties && node.properties.id) {
-      const id = `section-${kebabCase(node.properties.id)}`;
+    if (matchTag.test(node.tagName) || node?.properties?.id) {
+      const useIdProp = node?.properties?.id.match(/^.*[A-Z].*$/);
+
+      const id = `section-${kebabCase(!useIdProp && getTexts(node) || node.properties.id)}`;
       const element = { type: 'element', tagName: 'div', properties: { id } };
 
-      if (node.children) {
-        node.children.push(element);
-      } else {
-        node.children = [element];
-      }
+      if (node.children) node.children.unshift(element);
+      else node.children = [element];
     }
     return [node];
   });

--- a/packages/markdown/styles/gfm.scss
+++ b/packages/markdown/styles/gfm.scss
@@ -123,52 +123,50 @@
   h1,
   h2 {
     font-size: 1.5em;
-    --markdown-title-size: 1.5em;
-    // border-bottom: 1px solid #eaecef;
-    // padding-bottom: .3em;
+    font-size: var(--markdown-title-size, 1.5em);
   }
 
   h1 {
     font-weight: 700;
-    --markdown-title-weight: 700;
+    font-weight: var(--markdown-title-weight, 700);
   }
 
   h2 {
     font-weight: 400;
-    --markdown-title-weight: 400;
+    font-weight: var(--markdown-title-weight, 400);
   }
 
   h3,
   h4 {
     font-weight: 600;
-    --markdown-title-weight: 600;
+    font-weight: var(--markdown-title-weight, 600);
   }
 
   h3 {
     font-size: 1.25em;
-    --markdown-title-size: 1.25em
+    font-size: var(--markdown-title-size, 1.25em);
   }
 
   h4 {
     font-size: 1em;
-    --markdown-title-size: 1em
+    font-size: var(--markdown-title-size, 1em);
   }
 
   h5,
   h6 {
     font-weight: 600;
-    --markdown-title-weight: 600;
+    font-weight: var(--markdown-title-weight, 600);
   }
 
   h5 {
     font-size: .875em;
-    --markdown-title-size: .875em
+    font-size: var(--markdown-title-size, .875em);
   }
 
   h6 {
-    --markdown-title: #6a737d;
     font-size: .85em;
-    --markdown-title-size: .85em
+    font-size: var(--markdown-title-size, .85em);
+    color: var(--markdown-title, #6a737d);
   }
 
   h1,


### PR DESCRIPTION
## 🧰 What's being changed?
- [x] add anchor gen test cases for `camelCase` scenarios
- [x] run backward-compatible anchor gen on node text (c2ed1dd)
  (the text value retains capitalization, where the `properties.id` we _were_ `kebab`-ing was already lowercased.)

## 🗳 Checklist
* 🐛 I'm fixing a bug