### PR TITLE
Fix RDMD lightbox landscape aspect ratios.

### DIFF
--- a/packages/markdown/components/Image/style.scss
+++ b/packages/markdown/components/Image/style.scss
@@ -159,9 +159,9 @@
     img {
       width: auto !important;
       height: auto !important;
-      max-height: 95vh !important;
-      max-width: unset !important;
       min-width: unset !important;
+      max-width: 97.5vw !important;
+      max-height: 97.5vh !important;
       &.border, &:not([src$=".png"]):not([src$=".svg"]):not([src$=".jp2"]):not([src$=".tiff"]) {
         box-shadow: 0 .5em 3em -1em rgba(0, 0, 0, .2);
       }


### PR DESCRIPTION
## 🧰 What's being changed?
Landscape images are displayed very awkwardly in the new light box. We should resize the dimensions based on a max-width so that _all_ images fit nicely within the viewport.

- [x] set lightbox img max width (re-resolves #666)

## 🗳 Checklist
* 🐛 I'm fixing a bug