### PR TITLE
Better code block dark theme in response schema sidebar.

### DIFF
--- a/packages/api-explorer/__tests__/ResponseSchema.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseSchema.test.jsx
@@ -37,11 +37,10 @@ test.each([[true], [false]])(
     let text;
 
     if (useNewMarkdownEngine) {
-      text = responseSchema.find('div.desc').first().find('div.desc').find('p').first().text();
+      text = responseSchema.find('.markdown-body > .pin > *').first().text();
     } else {
       text = responseSchema.find('div.desc').first().text();
     }
-
     expect(text).toBe(props.operation.responses['200'].description);
   }
 );

--- a/packages/api-explorer/src/ResponseSchema.jsx
+++ b/packages/api-explorer/src/ResponseSchema.jsx
@@ -96,11 +96,14 @@ class ResponseSchema extends React.Component {
       >
         {this.renderHeader()}
         <div className="response-schema">
-          {response.description && (
-            <div className="desc">
-              {useNewMarkdownEngine ? markdown(response.description) : markdownMagic(response.description)}
-            </div>
-          )}
+          {response.description &&
+            (useNewMarkdownEngine ? (
+              <div className="markdown-body" style={{ padding: 0 }}>
+                <div className="pin">{markdown(response.description)}</div>
+              </div>
+            ) : (
+              <div className="desc">{markdownMagic(response.description)}</div>
+            ))}
 
           {schema && <ResponseSchemaBody oas={oas} schema={schema} useNewMarkdownEngine={useNewMarkdownEngine} />}
         </div>


### PR DESCRIPTION
## What's being changed?

- [x] 🐷 wrap sidebar response code samples with a `.markdown-body` class parent
- [x] 🧬 update response schema tests

The before & after:

<img width=49% src=https://user-images.githubusercontent.com/886627/81719604-1d5aff80-9432-11ea-9c62-32a762f4fb25.png> <img width=49% src=https://user-images.githubusercontent.com/886627/81719704-3fed1880-9432-11ea-9b08-aa53405f480f.png>

## Testing

Will open an integration PR in ReadMe and post a link to the demo app.