### PR TITLE
Strip preceding dashes from anchor IDs.

### DIFF
--- a/packages/markdown/processor/plugin/section-anchor-id.js
+++ b/packages/markdown/processor/plugin/section-anchor-id.js
@@ -20,16 +20,29 @@ const getTexts = node => {
 function transformer(ast) {
   return flatMap(ast, node => {
     if (matchTag.test(node.tagName)) {
-      if (node?.properties?.id) node.properties.id = node.properties.id.replace(/^(-+(?=\w))/, '');
+      // Parse the node texts to construct
+      // a backwards-compatible anchor ID.
       const text = getTexts(node);
       const id = `section-${kebabCase(text)}`;
-      const element = {
+
+      if (node?.properties?.id) {
+        // Strip dash prefixes in GitHub slugger IDs
+        node.properties.id = node.properties.id.replace(/^(-+(?=\w))/, '');
+      } else {
+        // Use the compat anchor ID as fallback if
+        // GitHubs slugger returns an empty string.
+        node.properties.id = id;
+      }
+
+      // Create and append a compat anchor element
+      // to the section heading.
+      const anchor = {
         type: 'element',
         tagName: 'div',
         properties: { id, className: 'heading-anchor_backwardsCompatibility' },
       };
-      if (node.children) node.children.unshift(element);
-      else node.children = [element];
+      if (node.children) node.children.unshift(anchor);
+      else node.children = [anchor];
     }
     return [node];
   });

--- a/packages/markdown/processor/plugin/section-anchor-id.js
+++ b/packages/markdown/processor/plugin/section-anchor-id.js
@@ -20,7 +20,9 @@ const getTexts = node => {
 function transformer(ast) {
   return flatMap(ast, node => {
     if (matchTag.test(node.tagName)) {
-      const id = `section-${kebabCase(getTexts(node))}`;
+      if (node?.properties?.id) node.properties.id = node.properties.id.replace(/^(-+(?=\w))/, '');
+      const text = getTexts(node);
+      const id = `section-${kebabCase(text)}`;
       const element = {
         type: 'element',
         tagName: 'div',


### PR DESCRIPTION
Polish some more rough edges around section anchor generation. Specifically:

- [x] strip prefixed dashes from section anchors; resolves #713 (ac7f762)
- [x] use compat anchor IDs as fallback when the GitHub slugger returns an empty string (b2fdac4)