### PR TITLE
chore(deps): upgrading @readme/oas-tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1557,25 +1557,6 @@
         "conventional-changelog-conventionalcommits": "4.2.1"
       }
     },
-    "@commitlint/config-lerna-scopes": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-lerna-scopes/-/config-lerna-scopes-8.3.4.tgz",
-      "integrity": "sha512-kaSZ4i9uA/v0AS4Nt4E0D+qYtnPEnkYqOYvgxee16rUxP8uCgBbiv6oNnF3Tk/eHxopHzbG80n1YVYcb2s7edw==",
-      "dev": true,
-      "requires": {
-        "import-from": "3.0.0",
-        "resolve-pkg": "2.0.0",
-        "semver": "6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
     "@commitlint/ensure": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-8.3.4.tgz",
@@ -11390,15 +11371,6 @@
         }
       }
     },
-    "import-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
-      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
-      "dev": true,
-      "requires": {
-        "resolve-from": "^5.0.0"
-      }
-    },
     "import-local": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -15970,15 +15942,6 @@
       "dev": true,
       "requires": {
         "global-dirs": "^0.1.1"
-      }
-    },
-    "resolve-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-2.0.0.tgz",
-      "integrity": "sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==",
-      "dev": true,
-      "requires": {
-        "resolve-from": "^5.0.0"
       }
     },
     "resolve-url": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@babel/preset-react": "^7.0.0",
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
-    "@commitlint/config-lerna-scopes": "^8.3.4",
     "@readme/eslint-config": "^3.0.0",
     "auto-changelog": "^2.0.0",
     "babel-core": "^7.0.0-bridge.0",
@@ -79,8 +78,7 @@
   },
   "commitlint": {
     "extends": [
-      "@commitlint/config-conventional",
-      "@commitlint/config-lerna-scopes"
+      "@commitlint/config-conventional"
     ]
   }
 }

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1507,9 +1507,9 @@
       }
     },
     "@readme/oas-tooling": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.4.0.tgz",
-      "integrity": "sha512-LpeVG4x+iHq12c2YkDgZ3heHUKqAYfwEVcOdNqwlekDIKiUEMmNjLmJ+I1ODfUfbpdGFQkxuX8eS69ozOyKokg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.4.3.tgz",
+      "integrity": "sha512-WU7Uq3yS1gOq7BvtASU5bC0VFkSGrdD2OhNqut0SeO1TCqOB9XKBfrrAofVsPDjmXKmYpLHEtLMJgPLHYV5Opw==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -9,7 +9,7 @@
     "@readme/markdown-magic": "^6.9.6",
     "@readme/oas-extensions": "^6.9.4",
     "@readme/oas-to-har": "^6.9.6",
-    "@readme/oas-tooling": "^3.4.0",
+    "@readme/oas-tooling": "^3.4.3",
     "@readme/react-jsonschema-form": "^1.1.5",
     "@readme/syntax-highlighter": "^6.9.6",
     "@readme/variable": "^6.9.6",

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -1056,9 +1056,9 @@
       "integrity": "sha512-FnuLVigSsmCUHgwIqSkWLrwCdt/7ou2/zKincUgkZbgS422WKMt1LdRpvH7Kg4FzTafuA2bxlyCsbBQVuIBKZw=="
     },
     "@readme/oas-tooling": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.4.0.tgz",
-      "integrity": "sha512-LpeVG4x+iHq12c2YkDgZ3heHUKqAYfwEVcOdNqwlekDIKiUEMmNjLmJ+I1ODfUfbpdGFQkxuX8eS69ozOyKokg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.4.3.tgz",
+      "integrity": "sha512-WU7Uq3yS1gOq7BvtASU5bC0VFkSGrdD2OhNqut0SeO1TCqOB9XKBfrrAofVsPDjmXKmYpLHEtLMJgPLHYV5Opw==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^6.9.4",
-    "@readme/oas-tooling": "^3.4.0",
+    "@readme/oas-tooling": "^3.4.3",
     "querystring": "^0.2.0"
   },
   "scripts": {


### PR DESCRIPTION
## 📖 Release Notes
### 3.4.3
- chore(deps): Bump swagger-inline from 3.0.4 to 3.0.5 [`#191`](https://github.com/readmeio/oas/pull/191)
- chore(deps): Bump oas-normalize from 2.1.0 to 2.2.0 [`#192`](https://github.com/readmeio/oas/pull/192)
- fix: resolving a bug where nested allOf schemas wouldn't get flattened [`#193`](https://github.com/readmeio/oas/pull/193)

### 3.4.2
- feat: bundle $refs, and other minor changes [`#190`](https://github.com/readmeio/oas/pull/190)
- chore(deps-dev): Bump lerna from 3.21.0 to 3.22.0 [`#189`](https://github.com/readmeio/oas/pull/189)

### 3.4.1
- chore(deps): Bump open from 7.0.3 to 7.0.4 [`#188`](https://github.com/readmeio/oas/pull/188)
- chore(deps-dev): Bump lerna from 3.20.2 to 3.21.0 [`#187`](https://github.com/readmeio/oas/pull/187)
- chore(deps): [Security] Bump acorn from 7.1.0 to 7.2.0 [`#185`](https://github.com/readmeio/oas/pull/185)