### PR TITLE
Remove RDMD anchor dash sanitization.

### DIFF
--- a/packages/markdown/processor/plugin/section-anchor-id.js
+++ b/packages/markdown/processor/plugin/section-anchor-id.js
@@ -25,10 +25,7 @@ function transformer(ast) {
       const text = getTexts(node);
       const id = `section-${kebabCase(text)}`;
 
-      if (node?.properties?.id) {
-        // Strip dash prefixes in GitHub slugger IDs
-        node.properties.id = node.properties.id.replace(/^(-+(?=\w))/, '');
-      } else {
+      if (id && !node?.properties?.id) {
         // Use the compat anchor ID as fallback if
         // GitHubs slugger returns an empty string.
         node.properties.id = id;


### PR DESCRIPTION
Per #713, emojis were being stripped from heading anchors and leaving extraneous dashes in their wake. Unfortunately, our fix for this ended up causing some breakage around the in-page linking feature for new search. Specifically, the migrated anchor data no longer matched the rendered markup for certain headings. So clicking an in-page hit from the new search results wouldn't navigate to the correct subsection! This PR reverts the dash sanitization originally added in #714.
