### PR TITLE
fix(rdmd): don't set scrollTop if el is undefined

### DIFF
--- a/packages/markdown/components/Image/index.jsx
+++ b/packages/markdown/components/Image/index.jsx
@@ -35,9 +35,10 @@ class Image extends React.Component {
 
   lightboxSetup() {
     const $el = this.lightbox.current;
-    setTimeout(() => {
-      $el.scrollTop = ($el.scrollHeight - $el.offsetHeight) / 2;
-    }, 0);
+    if ($el)
+      setTimeout(() => {
+        $el.scrollTop = ($el.scrollHeight - $el.offsetHeight) / 2;
+      }, 0);
   }
 
   handleKey(e) {


### PR DESCRIPTION
## 🧰 Changes

This fixes a Sentry issue with the RDMD lightbox. ([🎟](https://app.asana.com/0/1178558593295409/1179794959743395/f "Asana ticket→"))

- [x] adds a conditional to check the current ref element exists before setting the scroll height of the lightbox.