### PR TITLE
feat: adding support for cookies to oas-to-har

### DIFF
--- a/example/swagger-files/cookies.json
+++ b/example/swagger-files/cookies.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+     "version": "1.0",
+     "title": "cookies"
+  },
+  "servers": [
+     {
+        "url": "http://mockbin.com"
+     }
+  ],
+  "paths": {
+    "/har": {
+      "post": {
+        "parameters": [
+          {
+            "in": "cookie",
+            "name": "foo",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "bar",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "x-samples-languages": ["curl", "node", "node-simple", "ruby", "javascript", "python"]
+}

--- a/packages/oas-to-har/__tests__/__fixtures__/common-parameters.json
+++ b/packages/oas-to-har/__tests__/__fixtures__/common-parameters.json
@@ -16,6 +16,13 @@
           }
         },
         {
+          "in": "cookie",
+          "name": "authtoken",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
           "in": "header",
           "name": "x-extra-id",
           "schema": {

--- a/packages/oas-to-har/src/index.js
+++ b/packages/oas-to-har/src/index.js
@@ -55,6 +55,7 @@ module.exports = (
 
   const formData = { ...defaultFormDataTypes, ...values };
   const har = {
+    cookies: [],
     headers: [],
     queryString: [],
     postData: {},
@@ -103,6 +104,20 @@ module.exports = (
 
       har.queryString.push({
         name: queryString.name,
+        value: String(value),
+      });
+    });
+  }
+
+  // Do we have any `cookie` parameters on the operation?
+  const cookies = parameters && parameters.filter(param => param.in === 'cookie');
+  if (cookies && cookies.length) {
+    cookies.forEach(cookie => {
+      const value = formatter(formData, cookie, 'cookie', true);
+      if (typeof value === 'undefined') return;
+
+      har.cookies.push({
+        name: cookie.name,
         value: String(value),
       });
     });


### PR DESCRIPTION
## 🧰 What's being changed?

This adds general support for cookie parameters into the explorer and our `oas-to-har` library.

Adding this because it's a deficiency of our OpenAPI support, and also the new `api` should support it and that uses `oas-to-har` for the bulk of its processing. If you click on "Node (simple)" in the demo site you'll see that it currently doesn't support cookies (see https://github.com/readmeio/api/issues/38).

## 🧪 Testing

I've added a grip of tests for cookies into the `oas-to-har` suite, all of which are identical to our tests for query string params. To see this in action, load up the demo site and check out the new `cookies` example:

![Screen Shot 2020-06-16 at 5 03 04 PM](https://user-images.githubusercontent.com/33762/84840022-46534f00-aff3-11ea-81cb-6918adbbc816.png)

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [x] **🆕 I'm adding something new!**
* [ ] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
