### PR TITLE
chore(deps): upgrading httpsnippet-client-api to 2.1.1

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -5941,9 +5941,9 @@
       }
     },
     "httpsnippet-client-api": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.1.0.tgz",
-      "integrity": "sha512-hwWULiDUI4MbY5eVvOPx21NrRlVL1rjCyC9xuC4RsQPhROPTvYkbJH0tjqGUvIS5eoIaRvAUyUXnnMXYhW85GQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.1.1.tgz",
+      "integrity": "sha512-UclzFu95V/doMiV/3pUBiH2zWi51K4sWuU0jcCia8S4vhsk67jCnHduWB7vw8Hp6JaeZoStvMe2b6FIOAsfldg==",
       "requires": {
         "@readme/oas-tooling": "^3.4.5",
         "content-type": "^1.0.4",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -16,7 +16,7 @@
     "classnames": "^2.2.5",
     "fetch-har": "^2.2.1",
     "httpsnippet": "^1.20.0",
-    "httpsnippet-client-api": "^2.1.0",
+    "httpsnippet-client-api": "^2.1.1",
     "js-cookie": "^2.1.4",
     "lodash.kebabcase": "^4.1.1",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
## 📖  Release Notes
### 2.1.1
* fix: snippet paths should not include the server url (#77) ([a812f0b](https://github.com/readmeio/api/commit/a812f0b)), closes [#77](https://github.com/readmeio/api/issues/77)
* chore(deps-dev): bump lerna from 3.22.0 to 3.22.1 (#74) ([7c270c2](https://github.com/readmeio/api/commit/7c270c2)), closes [#74](https://github.com/readmeio/api/issues/74)
* chore(deps): bump @readme/oas-to-har from 6.10.0 to 6.10.2 (#73) ([1b4568c](https://github.com/readmeio/api/commit/1b4568c)), closes [#73](https://github.com/readmeio/api/issues/73)
* chore(deps): bump @readme/oas-tooling from 3.4.3 to 3.4.5 (#75) ([05e5204](https://github.com/readmeio/api/commit/05e5204)), closes [#75](https://github.com/readmeio/api/issues/75