### PR TITLE
fix: issue where application/x-www-form-urlencoded payloads weren't being handled properly

### DIFF
--- a/example/swagger-files/formdata.json
+++ b/example/swagger-files/formdata.json
@@ -1,0 +1,100 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "version": "0.0.0",
+    "title": "formData handling demo"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/": {
+      "post": {
+        "summary": "Demo handling of formData",
+        "operationId": "demoFormData",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "required": [
+                  "client_id",
+                  "client_secret"
+                ],
+                "type": "object",
+                "properties": {
+                  "client_id": {
+                    "type": "string"
+                  },
+                  "client_secret": {
+                    "type": "string"
+                  },
+                  "scope": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "Valid Token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Token"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Token": {
+        "title": "Token",
+        "required": [
+          "access_token",
+          "token_type",
+          "expires_in"
+        ],
+        "type": "object",
+        "properties": {
+          "access_token": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "token_type": {
+            "type": "string"
+          },
+          "expires_in": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  },
+  "x-samples-languages": [
+    "curl",
+    "python",
+    "java",
+    "javascript",
+    "node",
+    "node-simple",
+    "ruby",
+    "go",
+    "powershell",
+    "php",
+    "swift"
+  ]
+}

--- a/packages/api-explorer/__tests__/lib/generate-code-snippet.test.js
+++ b/packages/api-explorer/__tests__/lib/generate-code-snippet.test.js
@@ -47,7 +47,7 @@ test('should pass through json values to code snippet', () => {
     oas,
     oasUrl,
     {
-      path: '/path/{id}',
+      path: '/path',
       method: 'post',
       requestBody: {
         content: {
@@ -69,7 +69,7 @@ test('should pass through json values to code snippet', () => {
     'node'
   );
 
-  expect(shallow(snippet).text()).toStrictEqual(expect.stringMatching("{id: '123'}"));
+  expect(shallow(snippet).text()).toStrictEqual(expect.stringMatching("body: {id: '123'}"));
 });
 
 test('should pass through form encoded values to code snippet', () => {
@@ -77,7 +77,7 @@ test('should pass through form encoded values to code snippet', () => {
     oas,
     oasUrl,
     {
-      path: '/path/{id}',
+      path: '/path',
       method: 'post',
       requestBody: {
         content: {
@@ -99,7 +99,7 @@ test('should pass through form encoded values to code snippet', () => {
     'node'
   );
 
-  expect(shallow(snippet).text()).toStrictEqual(expect.stringMatching('id=123'));
+  expect(shallow(snippet).text()).toStrictEqual(expect.stringMatching("form: {id: '123'}"));
 });
 
 test('should not contain proxy url', () => {

--- a/packages/api-explorer/__tests__/lib/generate-code-snippet.test.js
+++ b/packages/api-explorer/__tests__/lib/generate-code-snippet.test.js
@@ -42,6 +42,66 @@ test('should pass through values to code snippet', () => {
   expect(shallow(snippet).text()).toStrictEqual(expect.stringMatching('https://example.com/path/123'));
 });
 
+test('should pass through json values to code snippet', () => {
+  const { snippet } = generateCodeSnippet(
+    oas,
+    oasUrl,
+    {
+      path: '/path/{id}',
+      method: 'post',
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    { body: { id: '123' } },
+    {},
+    'node'
+  );
+
+  expect(shallow(snippet).text()).toStrictEqual(expect.stringMatching("{id: '123'}"));
+});
+
+test('should pass through form encoded values to code snippet', () => {
+  const { snippet } = generateCodeSnippet(
+    oas,
+    oasUrl,
+    {
+      path: '/path/{id}',
+      method: 'post',
+      requestBody: {
+        content: {
+          'application/x-www-form-urlencoded': {
+            schema: {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    { formData: { id: '123' } },
+    {},
+    'node'
+  );
+
+  expect(shallow(snippet).text()).toStrictEqual(expect.stringMatching('id=123'));
+});
+
 test('should not contain proxy url', () => {
   const { snippet } = generateCodeSnippet(
     new Oas({ [extensions.PROXY_ENABLED]: true }),

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -4631,9 +4631,9 @@
       }
     },
     "fetch-har": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fetch-har/-/fetch-har-2.3.2.tgz",
-      "integrity": "sha512-usqtxu7Gl3UcWXzfrHRN6TCApoLaUYGCpyL8CZj7bIlufckCW9xwLNkTTJDCzap19PjJT36jx/16Dr5zluoeLg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-har/-/fetch-har-3.0.0.tgz",
+      "integrity": "sha512-eZZACbA76wHqfNbdYoP6q1g05nk2xOoQOZz6TTeumtESeGA56VHDjhRSA8n5dGTSCtVV0I2w2sQACrVRQgCTTw=="
     },
     "figgy-pudding": {
       "version": "3.5.1",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -14,7 +14,7 @@
     "@readme/syntax-highlighter": "^6.10.2",
     "@readme/variable": "^6.10.2",
     "classnames": "^2.2.5",
-    "fetch-har": "^2.2.1",
+    "fetch-har": "^3.0.0",
     "httpsnippet": "^1.20.0",
     "httpsnippet-client-api": "^2.1.5",
     "js-cookie": "^2.1.4",

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -1050,6 +1050,11 @@
         "eslint-plugin-unicorn": "^20.0.0"
       }
     },
+    "@readme/oas-extensions": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-6.10.2.tgz",
+      "integrity": "sha512-+M68oHORq/jA9DuJfMPySg8/iitpitQLd/SC+Zr5ADspK3lArBfXRXPkEyhRKI8peAFexXK2MeSag+WbMt70+Q=="
+    },
     "@readme/oas-tooling": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.4.7.tgz",
@@ -6366,11 +6371,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "react-is": {
       "version": "16.13.1",

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,15 +5,14 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^6.10.2",
-    "@readme/oas-tooling": "^3.4.7",
-    "querystring": "^0.2.0"
+    "@readme/oas-tooling": "^3.4.7"
   },
   "scripts": {
     "inspect": "jsinspect",
     "lint": "eslint .",
     "pretest": "npm run lint && npm run prettier && npm run inspect",
     "prettier": "prettier --list-different --write \"./**/**.{js,jsx}\"",
-    "test": "jest --coverage --runInBand"
+    "test": "jest --coverage"
   },
   "publishConfig": {
     "registry": "http://registry.npmjs.org",
@@ -29,6 +28,7 @@
   "devDependencies": {
     "@readme/eslint-config": "^3.2.0",
     "eslint": "^7.0.0",
+    "har-validator": "^5.1.3",
     "jest": "^26.0.1",
     "jsinspect": "^0.12.6",
     "prettier": "^2.0.1"

--- a/packages/oas-to-har/src/index.js
+++ b/packages/oas-to-har/src/index.js
@@ -194,14 +194,21 @@ module.exports = (
   if (schema.schema && Object.keys(schema.schema).length) {
     // If there is formData, then the type is application/x-www-form-urlencoded
     if (Object.keys(formData.formData).length) {
+      har.postData.params = [];
       har.postData.mimeType = 'application/x-www-form-urlencoded';
-      har.postData.text = querystring.stringify(formData.formData);
+
+      Object.keys(formData.formData).forEach(name => {
+        har.postData.params.push({
+          name,
+          value: String(formData.formData[name]),
+        });
+      });
+    } else if (
       // formData.body can be one of the following:
       // - `undefined` - if the form hasn't been touched yet because of formData.body on:
       // https://github.com/readmeio/api-explorer/blob/b32a2146737c11813bd1b222a137de61854414b3/packages/api-explorer/src/Doc.jsx#L28
       // - a primitive type
       // - an object
-    } else if (
       typeof formData.body !== 'undefined' &&
       (isPrimitive(formData.body) || Object.keys(formData.body).length)
     ) {

--- a/packages/oas-to-har/src/index.js
+++ b/packages/oas-to-har/src/index.js
@@ -1,4 +1,3 @@
-const querystring = require('querystring');
 const extensions = require('@readme/oas-extensions');
 const { findSchemaDefinition, getSchema, parametersToJsonSchema } = require('@readme/oas-tooling/utils');
 const { Operation } = require('@readme/oas-tooling');
@@ -57,10 +56,13 @@ module.exports = (
   const har = {
     cookies: [],
     headers: [],
+    headersSize: 0,
     queryString: [],
     postData: {},
+    bodySize: 0,
     method: operation.method.toUpperCase(),
     url: `${oas.url()}${operation.path}`.replace(/\s/g, '%20'),
+    httpVersion: 'HTTP/1.1',
   };
 
   // TODO look to move this to Oas class as well
@@ -272,6 +274,11 @@ module.exports = (
         har[securityValue.type].push(securityValue.value);
       });
     });
+  }
+
+  // If we didn't end up filling the `postData` object then we don't need it.
+  if (Object.keys(har.postData).length === 0) {
+    delete har.postData;
   }
 
   return { log: { entries: [{ request: har }] } };


### PR DESCRIPTION
## 🧰 What's being changed?

This resolves a couple bugs with how we're generating HAR definitions:

* [x] For `application/x-www-form-urlencoded` operations, we were storing their payloads inside of `postData.text` instead of `postData.params`.
  * This required an update to [fetch-har](https://npm.im/fetch-har) to support `postData.params`. See https://github.com/readmeio/fetch-har/pull/67 for details.
* [x] We were always sending `postData` regardless if there was actually any data for it. For simple GET requests that just have `queryString` populated, the `postData` object is no longer part of the created HAR.
  * This required an update to [fetch-har](https://npm.im/fetch-har) to support `postData` no longer being an expectation. See https://github.com/readmeio/fetch-har/pull/67 for details.
* [x] The HAR definitions that `oas-to-har` was creating didn't actually validate outside of [httpsnippet](https://github.com/Kong/httpsnippet). This was because that library adds some defaults (like `httpVersion`) if they're missing. Since `oas-to-har` should support the HAR spec and not HTTP Snippets handling of it, I've made the decision to:
  * Add those missing defaults to generated definitions.
  * Update the unit test suite to assert that we're always generating valid HAR definitions when running our other assertions.

## 🧪 Testing

You can see this broken in action here: http://bin.readme.com/s/5efbb6ac35bcd40024d60488

![Screen Shot 2020-06-30 at 3 04 39 PM](https://user-images.githubusercontent.com/33762/86181537-0e640580-bae3-11ea-8f95-dfbd8bb7d47c.png)

Load up the local server and the `formData` example to see how it's handled how: http://localhost:9966/?selected=swagger-files%2Fformdata.json

![Screen Shot 2020-06-30 at 3 04 48 PM](https://user-images.githubusercontent.com/33762/86181545-11f78c80-bae3-11ea-9cab-f7c1e8b2b1ff.png)

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**


---
I added two test cases: one for json and one for formData. The json
one passes fine! This code in oas-to-har is working as expected:
https://github.com/readmeio/api-explorer/blob/59a5d060997321936ae356f2ba3f36e34c81c520/packages/oas-to-har/src/index.js#L198

I narrowed down the issue to here:
https://github.com/Kong/httpsnippet/blob/633b825364ab050f02556cfa837148a1e136fd69/src/index.js#L126-L128
httpsnippet is setting it from the value we set back to ""

I'm not sure if this is something that's changed recently in the way
we're generating hars? This part of httpsnippet hasn't been updated
in 5 years. Gunna defer to Jon for this.