### PR TITLE
fix(markdown): add missing compilers

### DIFF
--- a/packages/markdown/__tests__/__snapshots__/flavored-compilers.test.js.snap
+++ b/packages/markdown/__tests__/__snapshots__/flavored-compilers.test.js.snap
@@ -30,3 +30,17 @@ exports[`ReadMe Magic Blocks Embed 1`] = `
 "[](https://youtu.be/J3-uKv1DShQ \\"@youtu.be\\")
 "
 `;
+
+exports[`ReadMe Magic Blocks Figure 1`] = `
+"<div class=\\"rdmd-pinned\\">
+
+<figure>
+
+![](https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg \\"rdme-blue.svg\\")
+
+<figcaption>Ok, pizza man.</figcaption>
+</figure>
+
+</div>
+"
+`;

--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -53,14 +53,7 @@ const {
 
 /* Custom Unified Compilers
  */
-const {
-  rdmeDivCompiler,
-  codeTabsCompiler,
-  rdmeEmbedCompiler,
-  rdmeVarCompiler,
-  rdmeCalloutCompiler,
-  rdmePinCompiler,
-} = require('./processor/compile');
+const customCompilers = require('./processor/compile');
 
 /* Custom Unified Plugins
  */
@@ -266,10 +259,7 @@ export function md(tree, opts = {}) {
   if (!tree) return null;
   [, opts] = setup('', opts);
 
-  return processor(opts)
-    .use(remarkStringify, opts.markdownOptions)
-    .use([rdmeDivCompiler, codeTabsCompiler, rdmeCalloutCompiler, rdmeEmbedCompiler, rdmeVarCompiler, rdmePinCompiler])
-    .stringify(tree);
+  return processor(opts).use(remarkStringify, opts.markdownOptions).use(Object.values(customCompilers)).stringify(tree);
 }
 
 const ReadMeMarkdown = (text, opts = {}) => react(text, opts);

--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -41,19 +41,11 @@ const {
 
 /* Custom Unified Parsers
  */
-const {
-  flavorCodeTabs,
-  flavorCallout,
-  flavorEmbed,
-  magicBlockParser,
-  variableParser,
-  gemojiParser,
-  compactHeadings,
-} = require('./processor/parse');
+const customParsers = Object.values(require('./processor/parse')).map(parser => parser.sanitize(sanitize));
 
 /* Custom Unified Compilers
  */
-const customCompilers = require('./processor/compile');
+const customCompilers = Object.values(require('./processor/compile'));
 
 /* Custom Unified Plugins
  */
@@ -145,12 +137,8 @@ export function processor(opts = {}) {
     .use(remarkParse, opts.markdownOptions)
     .data('settings', opts.settings)
     .data('compatibilityMode', opts.compatibilityMode)
-    .use(magicBlockParser.sanitize(sanitize))
-    .use([flavorCodeTabs.sanitize(sanitize), flavorCallout.sanitize(sanitize), flavorEmbed.sanitize(sanitize)])
-    .use(compactHeadings.sanitize(sanitize))
-    .use(variableParser.sanitize(sanitize))
     .use(!opts.correctnewlines ? remarkBreaks : () => {})
-    .use(gemojiParser.sanitize(sanitize))
+    .use(customParsers)
     .use(remarkSlug)
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeRaw)
@@ -259,7 +247,7 @@ export function md(tree, opts = {}) {
   if (!tree) return null;
   [, opts] = setup('', opts);
 
-  return processor(opts).use(remarkStringify, opts.markdownOptions).use(Object.values(customCompilers)).stringify(tree);
+  return processor(opts).use(remarkStringify, opts.markdownOptions).use(customCompilers).stringify(tree);
 }
 
 const ReadMeMarkdown = (text, opts = {}) => react(text, opts);

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -41,7 +41,8 @@
     "inspect": "jsinspect",
     "pretest": "npm run lint && npm run prettier && npm run inspect",
     "prettier": "prettier --list-different --write \"./**/**.{js,jsx}\"",
-    "test": "jest --coverage --runInBand"
+    "test": "jest --coverage --runInBand",
+    "test.watch": "npm test -- --watch --coverage=false"
   },
   "publishConfig": {
     "registry": "http://registry.npmjs.org",

--- a/packages/markdown/processor/compile/figure.js
+++ b/packages/markdown/processor/compile/figure.js
@@ -1,11 +1,18 @@
+const nodeToString = require('hast-util-to-string');
+
 module.exports = function FigureCompiler() {
   const { Compiler } = this;
   const { visitors } = Compiler.prototype;
-  visitors.figure = function compile(node) {
+
+  visitors.figure = function figureCompiler(node) {
+    const [image, caption] = node.children;
     return `<figure>
 
-${visitors.div.call(this, node)}
+  ${visitors.image.call(this, image)}
 
+  <figcaption>
+    ${nodeToString(caption)}
+  </figcaption>
 </figure>`;
   };
 };

--- a/packages/markdown/processor/compile/figure.js
+++ b/packages/markdown/processor/compile/figure.js
@@ -1,0 +1,11 @@
+module.exports = function FigureCompiler() {
+  const { Compiler } = this;
+  const { visitors } = Compiler.prototype;
+  visitors.figure = function compile(node) {
+    return `<figure>
+
+${visitors.div.call(this, node)}
+
+</figure>`;
+  };
+};

--- a/packages/markdown/processor/compile/figure.js
+++ b/packages/markdown/processor/compile/figure.js
@@ -4,15 +4,18 @@ module.exports = function FigureCompiler() {
   const { Compiler } = this;
   const { visitors } = Compiler.prototype;
 
+  visitors.figcaption = function figcaptionCompiler(node) {
+    const caption = nodeToString(node);
+    return `<figcaption>${caption}</figcaption>`;
+  };
+
   visitors.figure = function figureCompiler(node) {
     const [image, caption] = node.children;
     return `<figure>
 
-  ${visitors.image.call(this, image)}
+${visitors.image.call(this, image)}
 
-  <figcaption>
-    ${nodeToString(caption)}
-  </figcaption>
+${visitors.figcaption.call(this, caption)}
 </figure>`;
   };
 };

--- a/packages/markdown/processor/compile/index.js
+++ b/packages/markdown/processor/compile/index.js
@@ -1,4 +1,7 @@
-export { default as rdmeDivCompiler } from './div';
+export { default as divCompiler } from './div';
+export { default as tableHeadCompiler } from './table-head';
+export { default as figureCompiler } from './figure';
+
 export { default as codeTabsCompiler } from './code-tabs';
 export { default as rdmeEmbedCompiler } from './embed';
 export { default as rdmeVarCompiler } from './var';

--- a/packages/markdown/processor/compile/pin.js
+++ b/packages/markdown/processor/compile/pin.js
@@ -1,8 +1,8 @@
-/* div blocks directly alias the paragraph container; use for display only! */
-module.exports = function DivCompiler() {
+module.exports = function PinCompiler() {
   const { Compiler } = this;
   const { visitors } = Compiler.prototype;
-  visitors.div = function compile(/* node */) {
-    return 'PINNNED';
-  };
+  function compiler(node) {
+    return [`<div class="rdmd-pinned">`, this.block(node), `</div>`].join('\n\n');
+  }
+  visitors['rdme-pin'] = compiler;
 };

--- a/packages/markdown/processor/compile/table-head.js
+++ b/packages/markdown/processor/compile/table-head.js
@@ -1,0 +1,7 @@
+module.exports = function TableHeadCompiler() {
+  const { Compiler } = this;
+  const { visitors } = Compiler.prototype;
+  visitors.tableHead = function compile(node) {
+    return visitors.tableCell.call(this, node);
+  };
+};

--- a/packages/markdown/processor/parse/index.js
+++ b/packages/markdown/processor/parse/index.js
@@ -1,7 +1,9 @@
+export { default as magicBlockParser } from './magic-block-parser';
+
 export { default as flavorCodeTabs } from './flavored/code-tabs';
 export { default as flavorCallout } from './flavored/callout';
 export { default as flavorEmbed } from './flavored/embed';
-export { default as magicBlockParser } from './magic-block-parser';
+
+export { default as compactHeadings } from './compact-headings';
 export { default as variableParser } from './variable-parser';
 export { default as gemojiParser } from './gemoji-parser';
-export { default as compactHeadings } from './compact-headings';


### PR DESCRIPTION
💂‍♀️ [Sentry Ticket](https://sentry.io/organizations/readme/issues/1694192811)
|:---:|

## Changes

- [x] Add `tableHead` markdown compiler. Fixes #772. (4d88fb9)
- [x] Add `figure`, `figcaption` compilers. (4d88fb9, 19ad148, 1e12e0c)
- [x] Fix pinned block compiler naming conflict.
- [x] Test figure compiler for magic image blocks. (c6319d6)
- [x] Restructure custom parser and compiler imports. (6e49a17, b49ff91) 