### PR TITLE
test: loading in our new decoupled jest-expect-har package

### DIFF
--- a/packages/oas-to-har/__tests__/index.test.js
+++ b/packages/oas-to-har/__tests__/index.test.js
@@ -1,4 +1,3 @@
-const validate = require('har-validator');
 const extensions = require('@readme/oas-extensions');
 const Oas = require('@readme/oas-tooling');
 
@@ -6,25 +5,6 @@ const oasToHar = require('../src/index');
 const commonParameters = require('./__fixtures__/common-parameters');
 
 const oas = new Oas();
-
-expect.extend({
-  toBeAValidHAR(har) {
-    return validate
-      .request(har.log.entries[0].request)
-      .then(() => {
-        return {
-          message: () => `expected supplied HAR not to be valid`,
-          pass: true,
-        };
-      })
-      .catch(err => {
-        return {
-          message: () => `expected supplied HAR to be valid\n\nError: ${this.utils.printReceived(err.errors)}`,
-          pass: false,
-        };
-      });
-  },
-});
 
 test('should output a har format', async () => {
   const har = oasToHar(oas);

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -4476,6 +4476,15 @@
         "jest-util": "^26.0.1"
       }
     },
+    "jest-expect-har": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jest-expect-har/-/jest-expect-har-1.0.0.tgz",
+      "integrity": "sha512-Du1gPCsp4cl+4h5BHjbKimE3xeocCVu57Wbx6vfKV4lLyocZaLwxQmF3IWH95JFcNSQ1F96itGKAaVCi5fAEIg==",
+      "dev": true,
+      "requires": {
+        "har-validator": "^5.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "26.0.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -28,10 +28,15 @@
   "devDependencies": {
     "@readme/eslint-config": "^3.2.0",
     "eslint": "^7.0.0",
-    "har-validator": "^5.1.3",
     "jest": "^26.0.1",
+    "jest-expect-har": "^1.0.0",
     "jsinspect": "^0.12.6",
     "prettier": "^2.0.1"
   },
-  "prettier": "@readme/eslint-config/prettier"
+  "prettier": "@readme/eslint-config/prettier",
+  "jest": {
+    "setupFilesAfterEnv": [
+      "jest-expect-har"
+    ]
+  }
 }


### PR DESCRIPTION
## 🧰 What's being changed?

I've decoupled the `toBeAValidHAR()` custom Jest matcher I added in #807 into its own package: [jest-expect-har](https://www.npmjs.com/package/jest-expect-har)


## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [x] **🆕 I'm adding something new!**
* [ ] **🐛 I'm fixing a bug!**
* [ ] **📸 I've made some changes to the UI!**
