### PR TITLE
fix: decouple react highlight from code snippets

### DIFF
--- a/packages/api-explorer/__tests__/CodeSample.test.jsx
+++ b/packages/api-explorer/__tests__/CodeSample.test.jsx
@@ -191,6 +191,7 @@ describe('code examples', () => {
     const codeSample = shallow(component);
     expect(codeSample.find('.code-sample-tabs a')).toHaveLength(1);
     expect(codeSample.find('.hub-code-auto pre')).toHaveLength(0);
+    expect(codeSample.find('.hub-no-code')).toHaveLength(1);
   });
 
   it('should not render sample if language is missing', () => {

--- a/packages/api-explorer/src/CodeSample.jsx
+++ b/packages/api-explorer/src/CodeSample.jsx
@@ -89,7 +89,11 @@ class CodeSample extends React.Component {
             return <div className="hub-no-code">No code samples available</div>;
           }
 
-          const { snippet, code } = generateCodeSnippet(oas, operation, formData, auth, language, oasUrl);
+          let snippet;
+          const { code, highlightMode } = generateCodeSnippet(oas, operation, formData, auth, language, oasUrl);
+          if (code && highlightMode) {
+            snippet = syntaxHighlighter(code, highlightMode, { dark: true });
+          }
 
           return (
             <div>
@@ -112,11 +116,15 @@ class CodeSample extends React.Component {
                 ))}
               </ul>
 
-              {snippet && (
+              {snippet ? (
                 <div className="hub-code-auto">
                   <CopyCode code={code} />
                   <pre className={`tomorrow-night hub-lang hub-lang-${language}`}>{snippet}</pre>
                 </div>
+              ) : (
+                // If we were unable to create a snippet or highlight one for any reason, instead of rendering an empty
+                // box, show a friendly message instead.
+                <div className="hub-no-code">No code sample available</div>
               )}
             </div>
           );

--- a/packages/oas-to-snippet/README.md
+++ b/packages/oas-to-snippet/README.md
@@ -45,10 +45,10 @@ const language = 'node';
 // See https://www.npmjs.com/package/api for more information.
 const url = 'https://example.com/petstore.json';
 
-// This will return an object containing `snippet` and `code`. `snippet` is a syntax-highlighted
-// React element containing the generated code snippet, while `code` is the plaintext version of the
-// same.
-const { code, snippet } = generateSnippet(apiDefinition, operation, formData, auth, language, url);
+// This will return an object containing `code` and `highlightMode`. `code` is the generated code
+// snippet, while `highlightMode` is the language mode you can use to render it for syntax
+// highlighting (with @readme/syntax-highlighter, for example).
+const { code, highlightMode } = generateSnippet(apiDefinition, operation, formData, auth, language, url);
 ```
 
 ## Supported Languages

--- a/packages/oas-to-snippet/__tests__/index.test.js
+++ b/packages/oas-to-snippet/__tests__/index.test.js
@@ -1,4 +1,3 @@
-const { shallow } = require('enzyme');
 const extensions = require('@readme/oas-extensions');
 const Oas = require('@readme/oas-tooling');
 const petstore = require('@readme/oas-examples/3.0/json/petstore.json');
@@ -27,24 +26,20 @@ const formData = { path: { id: 123 } };
 test('should return falsy values for an unknown language', () => {
   const codeSnippet = generateCodeSnippet(oas, operation, {}, {}, 'css', oasUrl);
 
-  expect(codeSnippet.snippet).toBe(false);
-  expect(codeSnippet.code).toBe('');
-});
-
-test('should generate a HTML snippet for each lang', () => {
-  const { snippet } = generateCodeSnippet(oas, operation, {}, {}, 'node', oasUrl);
-
-  expect(shallow(snippet).hasClass('cm-s-tomorrow-night')).toBe(true);
+  expect(codeSnippet).toStrictEqual({
+    code: '',
+    highlightMode: false,
+  });
 });
 
 test('should pass through values to code snippet', () => {
-  const { snippet } = generateCodeSnippet(oas, operation, formData, {}, 'node', oasUrl);
+  const { code } = generateCodeSnippet(oas, operation, formData, {}, 'node', oasUrl);
 
-  expect(shallow(snippet).text()).toStrictEqual(expect.stringMatching('https://example.com/path/123'));
+  expect(code).toStrictEqual(expect.stringMatching('https://example.com/path/123'));
 });
 
 test('should pass through json values to code snippet', () => {
-  const { snippet } = generateCodeSnippet(
+  const { code } = generateCodeSnippet(
     oas,
     {
       path: '/path',
@@ -70,11 +65,11 @@ test('should pass through json values to code snippet', () => {
     oasUrl
   );
 
-  expect(shallow(snippet).text()).toStrictEqual(expect.stringMatching("body: {id: '123'}"));
+  expect(code).toStrictEqual(expect.stringMatching("body: {id: '123'}"));
 });
 
 test('should pass through form encoded values to code snippet', () => {
-  const { snippet } = generateCodeSnippet(
+  const { code } = generateCodeSnippet(
     oas,
     {
       path: '/path',
@@ -100,11 +95,11 @@ test('should pass through form encoded values to code snippet', () => {
     oasUrl
   );
 
-  expect(shallow(snippet).text()).toStrictEqual(expect.stringMatching("form: {id: '123'}"));
+  expect(code).toStrictEqual(expect.stringMatching("form: {id: '123'}"));
 });
 
 test('should not contain proxy url', () => {
-  const { snippet } = generateCodeSnippet(
+  const { code } = generateCodeSnippet(
     new Oas({ [extensions.PROXY_ENABLED]: true }),
     operation,
     formData,
@@ -113,13 +108,13 @@ test('should not contain proxy url', () => {
     oasUrl
   );
 
-  expect(shallow(snippet).text()).toStrictEqual(expect.stringMatching('https://example.com/path/123'));
+  expect(code).toStrictEqual(expect.stringMatching('https://example.com/path/123'));
 });
 
 test('javascript should not contain `withCredentials`', () => {
-  const { snippet } = generateCodeSnippet(oas, operation, {}, {}, 'javascript', oasUrl);
+  const { code } = generateCodeSnippet(oas, operation, {}, {}, 'javascript', oasUrl);
 
-  expect(shallow(snippet).text()).not.toMatch(/withCredentials/);
+  expect(code).not.toMatch(/withCredentials/);
 });
 
 test('should return with unhighlighted code', () => {
@@ -130,7 +125,7 @@ test('should return with unhighlighted code', () => {
 
 test('should support node-simple', () => {
   const petstoreOas = new Oas(petstore);
-  const { snippet, code } = generateCodeSnippet(
+  const snippet = generateCodeSnippet(
     petstoreOas,
     petstoreOas.operation('/pets', 'get'),
     {
@@ -141,8 +136,8 @@ test('should support node-simple', () => {
     oasUrl
   );
 
-  expect(shallow(snippet).text()).toStrictEqual(expect.stringMatching('https://example.com/openapi.json'));
-  expect(code).toStrictEqual(expect.stringMatching('https://example.com/openapi.json'));
+  expect(snippet.code).toStrictEqual(expect.stringMatching('https://example.com/openapi.json'));
+  expect(snippet.highlightMode).toBe('javascript');
 });
 
 describe('#getLangName()', () => {

--- a/packages/oas-to-snippet/jest.config.js
+++ b/packages/oas-to-snippet/jest.config.js
@@ -1,6 +1,0 @@
-const config = require('../../jest.config');
-
-module.exports = {
-  ...config,
-  rootDir: './',
-};

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -976,21 +976,6 @@
       "integrity": "sha512-Wc682b1UMkVZ8YjdEGVglYNy0+UCrBc8Ark9O32pt7/kRWWoWzTrTZCpLqyiyMIC5vAV8LQkzq49MhE0+hnosA==",
       "dev": true
     },
-    "@readme/oas-extensions": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-6.10.2.tgz",
-      "integrity": "sha512-+M68oHORq/jA9DuJfMPySg8/iitpitQLd/SC+Zr5ADspK3lArBfXRXPkEyhRKI8peAFexXK2MeSag+WbMt70+Q=="
-    },
-    "@readme/oas-to-har": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-6.11.1.tgz",
-      "integrity": "sha512-zaTtLyG10CyDhpnijsTm0wyEZhO9iupuMLqmDZGHPQP9pDaBTzkZBVnsgFq3Ah01+OmOZAzyWqObybaKHRc+8Q==",
-      "requires": {
-        "@readme/oas-extensions": "^6.10.2",
-        "@readme/oas-tooling": "^3.4.7",
-        "querystring": "^0.2.0"
-      }
-    },
     "@readme/oas-tooling": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.4.7.tgz",
@@ -998,26 +983,6 @@
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"
-      }
-    },
-    "@readme/syntax-highlighter": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-6.10.2.tgz",
-      "integrity": "sha512-qsmHLgy9qHKPhyFGyGr6s5GbqtnbhgWRpJqpkVYJIpAd255akGwFeNLtJjFVQzcRdp9mo9pBVTSX6STnDxGKzg==",
-      "requires": {
-        "@readme/variable": "^6.10.2",
-        "codemirror": "^5.48.2",
-        "react": "^16.4.2"
-      }
-    },
-    "@readme/variable": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-6.10.2.tgz",
-      "integrity": "sha512-HTHT9toIvaeJkQV71ry3TAbc9aRcQhI/uY0UlbVq0Yk3lRA0t5k9u6fJVI58DYaFsHg+kINwBuK1N/xejbSESw==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
       }
     },
     "@sinonjs/commons": {
@@ -1778,11 +1743,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -1833,11 +1793,6 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
-    },
-    "codemirror": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.55.0.tgz",
-      "integrity": "sha512-TumikSANlwiGkdF/Blnu/rqovZ0Y3Jh8yy9TqrPbSM0xxSucq3RgnpVDQ+mD9q6JERJEIT2FMuF/fBGfkhIR/g=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -5325,7 +5280,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.0",
@@ -5547,6 +5503,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -5810,7 +5767,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -6212,6 +6170,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6245,25 +6204,11 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
-    "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "read-pkg": {
       "version": "2.0.0",

--- a/packages/oas-to-snippet/src/index.js
+++ b/packages/oas-to-snippet/src/index.js
@@ -1,6 +1,5 @@
 const HTTPSnippet = require('httpsnippet');
 const HTTPSnippetSimpleApiClient = require('httpsnippet-client-api');
-const syntaxHighlighter = require('@readme/syntax-highlighter');
 const uppercase = require('@readme/syntax-highlighter/uppercase');
 const generateHar = require('@readme/oas-to-har');
 
@@ -87,7 +86,7 @@ module.exports = (oas, operation, values, auth, lang, oasUrl) => {
   // Prevents errors if non-generated code snippet is selected and there isn't a way to generate a code snippet for it
   // (like for example `shell`).
   if (!language) {
-    return { snippet: false, code: '' };
+    return { code: '', highlightMode: false };
   }
 
   if (lang === 'node-simple') {
@@ -97,11 +96,9 @@ module.exports = (oas, operation, values, auth, lang, oasUrl) => {
     };
   }
 
-  const code = snippet.convert(...language.httpsnippet);
-
   return {
-    snippet: syntaxHighlighter(code, language.highlight, { dark: true }),
-    code,
+    code: snippet.convert(...language.httpsnippet),
+    highlightMode: language.highlight,
   };
 };
 


### PR DESCRIPTION
## 🧰 What's being changed?

This decouples the React syntax highlighting portion of `@readme/syntax-highlighter` from `@readme/oas-to-snippet` so it can be used in non-React environments.

While in the process of this, I slightly reworked how we render errors for cases where we can't generate a code snippet for a specific language and instead of rendering an empty box, we now show a friendly message:

![ezgif-4-e500073352d2](https://user-images.githubusercontent.com/33762/86291018-42066480-bba3-11ea-9db8-343434e0fe20.gif)

## 🧪 Testing

Slightly reworked a lot of the unit tests so `@readme/oas-to-snippet` continues to assert that snippets are good, and left the existing tests in the `CodeSample` component of the Explorer alone since they already testing the full integration of `@readme/oas-to-snippet` + `@readme/syntax-highlighter`.