### PR TITLE
chore(deps): upgrading httpsnippet-client-api to 2.1.6

### DIFF
--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -3479,9 +3479,9 @@
       }
     },
     "httpsnippet-client-api": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.1.5.tgz",
-      "integrity": "sha512-Yhl+EBFeYq9kngWUX3UhQNpyTknf+vS7k1Ct8IQ9KWwz6j75mw+UkS6lDkVcBok4LwUekVtq6IYfaFyTnM//wA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.1.6.tgz",
+      "integrity": "sha512-xUuAYjXHC34sC2sm9wP9ZbQzgqf2tBs+MHr2IdhGPOCyxubO/kPkHosCJtvr1sB3kAVdWSz2nQBsNXLVjGiTnw==",
       "requires": {
         "@readme/oas-tooling": "^3.4.7",
         "content-type": "^1.0.4",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -8,7 +8,7 @@
     "@readme/oas-to-har": "^6.14.0",
     "@readme/syntax-highlighter": "^6.13.0",
     "httpsnippet": "^1.20.0",
-    "httpsnippet-client-api": "^2.1.5"
+    "httpsnippet-client-api": "^2.1.6"
   },
   "peerDependencies": {
     "@readme/oas-tooling": "^3.4.7"


### PR DESCRIPTION
## 🧰 What's being changed?

Upgrades our `httpsnippet-client-api` package to allow for cleaner `api` code snippets:

![Screen Shot 2020-07-06 at 12 36 52 PM](https://user-images.githubusercontent.com/33762/86633443-8324bd00-bf85-11ea-896e-34de6cb4f61c.png)

Resolves https://github.com/readmeio/api-explorer/issues/823