### PR TITLE
docs: make cookie example better

### DIFF
--- a/example/swagger-files/auth-types.json
+++ b/example/swagger-files/auth-types.json
@@ -70,8 +70,8 @@
         ]
       }
     },
-    "/anything/apiKey-cookie": {
-      "post": {
+    "/cookies": {
+      "get": {
         "summary": "ApiKey security type via cookie",
         "responses": {
           "200": {


### PR DESCRIPTION
## 🧰 What's being changed?

Use the GET /cookies httpbin endpoint to show the cookie data:

```sh
$ curl --request GET \
  --url http://httpbin.org/cookies \
  --cookie apiKey=456
{
  "cookies": {
    "apiKey": "456"
  }
}
```

## 🧪 Testing

Test auth-types in demo app and run the code sample.
