### PR TITLE
style(rdmd): fix link text-decoration

### DIFF
--- a/packages/markdown/styles/gfm.scss
+++ b/packages/markdown/styles/gfm.scss
@@ -60,8 +60,9 @@
     outline-width: 0
   }
 
-  a {
-    text-decoration: underline;
+  a:not([href]) {
+    color: inherit;
+    text-decoration: none
   }
 
   strong {
@@ -232,11 +233,6 @@
     margin-bottom: 0 !important
   }
 
-  a:not([href]) {
-    color: inherit;
-    text-decoration: none
-  }
-
   blockquote,
   dl,
   ol,
@@ -327,7 +323,6 @@
 }
 
 @mixin markdownOverrides {
-
   h5,
   h6 {
     font-size: .9em;
@@ -350,6 +345,9 @@
     margin: 0 .5em .25em -1.25em;
   }
 
+  a[href], a:not([href=""]) {
+    text-decoration: underline
+  }
 }
 
 @mixin _clearfix() {

--- a/packages/markdown/styles/gfm.scss
+++ b/packages/markdown/styles/gfm.scss
@@ -60,7 +60,7 @@
     outline-width: 0
   }
 
-  p a {
+  a {
     text-decoration: underline;
   }
 


### PR DESCRIPTION
🎫 [Ticket][ticket]
:---:

### 🧰 Changes

"Despecify" the ruleset that adds `text-decoration` to markdown links in order to better account for the hard override we have on this rule in ReadMe's [base CSS](https://github.com/readmeio/readme/blob/next/hub2/public/css/layout.styl#L21-L25).

[ticket]: https://app.asana.com/0/1183788502758137/1183776386684939/f
