### PR TITLE
chore(deps): upgrading @readme/oas-tooling to 3.5.2

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1390,9 +1390,9 @@
       "dev": true
     },
     "@readme/oas-tooling": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.0.tgz",
-      "integrity": "sha512-5HSj/2L2Kpn7+3SUOCh8s826EDXeHDv1AmqeCb7udKfQ4RHCXFB9zQzcERIVISt38D+iidv8l3WBJaj9g1nEYA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.2.tgz",
+      "integrity": "sha512-HoW1QYzQ/CcprbjEfytNS+vNEEgmxz0C4+wYMESm0WeWHgeaaT9/2quvVTKKbIHVmiwUEzFSNc4g30cDurFj5g==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -10,7 +10,7 @@
     "@readme/oas-extensions": "^6.13.0",
     "@readme/oas-to-har": "^6.14.0",
     "@readme/oas-to-snippet": "^6.14.1",
-    "@readme/oas-tooling": "^3.5.0",
+    "@readme/oas-tooling": "^3.5.2",
     "@readme/react-jsonschema-form": "^1.1.5",
     "@readme/syntax-highlighter": "^6.13.0",
     "@readme/variable": "^6.13.0",

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -1018,9 +1018,9 @@
       }
     },
     "@readme/oas-tooling": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.0.tgz",
-      "integrity": "sha512-5HSj/2L2Kpn7+3SUOCh8s826EDXeHDv1AmqeCb7udKfQ4RHCXFB9zQzcERIVISt38D+iidv8l3WBJaj9g1nEYA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.2.tgz",
+      "integrity": "sha512-HoW1QYzQ/CcprbjEfytNS+vNEEgmxz0C4+wYMESm0WeWHgeaaT9/2quvVTKKbIHVmiwUEzFSNc4g30cDurFj5g==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"
@@ -5369,9 +5369,9 @@
       }
     },
     "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
     },
     "jsprim": {
       "version": "1.4.1",

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^6.13.0",
-    "@readme/oas-tooling": "^3.5.0"
+    "@readme/oas-tooling": "^3.5.2"
   },
   "scripts": {
     "inspect": "jsinspect",

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -977,9 +977,9 @@
       "dev": true
     },
     "@readme/oas-tooling": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.4.7.tgz",
-      "integrity": "sha512-Pn3AUo5qJSbjOdVzbuOsQ2ZX5UmZ9wS5Iwf08x6tTpUNKuPh93WJtCUZbndoFv1pIZjzrHWJYdTTaXcwnhj3jg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.2.tgz",
+      "integrity": "sha512-HoW1QYzQ/CcprbjEfytNS+vNEEgmxz0C4+wYMESm0WeWHgeaaT9/2quvVTKKbIHVmiwUEzFSNc4g30cDurFj5g==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"
@@ -5378,9 +5378,9 @@
       }
     },
     "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
     },
     "jsprim": {
       "version": "1.4.1",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@readme/eslint-config": "^3.2.0",
     "@readme/oas-examples": "^3.4.0",
-    "@readme/oas-tooling": "^3.4.7",
+    "@readme/oas-tooling": "^3.5.2",
     "eslint": "^7.0.0",
     "jest": "^26.0.1",
     "prettier": "^2.0.1"


### PR DESCRIPTION
## 🧰 What's being changed?

Updates the Explorer to update `@readme/oas-tooling` to v3.5.2 in order to fix a problem where if an OAS operation was using the same security schemes multiple times across an `||` definition, it would get duped within the `AuthBox` component.

## 🧪  Testing
You can see this broken on http://bin.readme.com/s/5f0e11c383474c0024035f6f by clicking the auth box:

![Screen Shot 2020-07-14 at 1 13 24 PM](https://user-images.githubusercontent.com/33762/87471890-ef31a180-c5d3-11ea-81be-c8a9f79cd196.png)

What it looks like now:

![Screen Shot 2020-07-14 at 1 16 26 PM](https://user-images.githubusercontent.com/33762/87472094-3ddf3b80-c5d4-11ea-99bf-a444feee596c.png)

## 📖  Release Notes
### <small>3.5.2 (2020-07-14)</small>

* fix: dedupe security schemes when plucking them out of an oas (#222) ([acb9bf1](https://github.com/readmeio/oas/commit/acb9bf1)), closes [#222](https://github.com/readmeio/oas/issues/222)

### <small>3.5.1 (2020-07-06)</small>

* docs: regenerating the changelog from scratch ([3d0d3f6](https://github.com/readmeio/oas/commit/3d0d3f6))
* chore: removing some unncessary deps from the lerna-level package ([5432dbe](https://github.com/readmeio/oas/commit/5432dbe))
* build(deps-dev): bump auto-changelog from 2.1.0 to 2.2.0 (#221) ([50945a7](https://github.com/readmeio/oas/commit/50945a7)), closes [#221](https://github.com/readmeio/oas/issues/221)
* build(deps-dev): bump eslint from 7.3.1 to 7.4.0 (#220) ([db1ed83](https://github.com/readmeio/oas/commit/db1ed83)), closes [#220](https://github.com/readmeio/oas/issues/220)
* build(deps): bump inquirer from 7.2.0 to 7.3.0 (#219) ([5b5d5dd](https://github.com/readmeio/oas/commit/5b5d5dd)), closes [#219](https://github.com/readmeio/oas/issues/219)
* build(deps): bump jsonpointer from 4.0.1 to 4.1.0 (#217) ([83b6c88](https://github.com/readmeio/oas/commit/83b6c88)), closes [#217](https://github.com/readmeio/oas/issues/217)
* build(deps): bump swagger-inline from 3.1.0 to 3.1.1 (#218) ([6793732](https://github.com/readmeio/oas/commit/6793732)), closes [#218](https://github.com/readmeio/oas/issues/218)
