### PR TITLE
fix: improper handling of application/x-www-form-urlencoded payloads

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -4547,9 +4547,9 @@
       }
     },
     "fetch-har": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fetch-har/-/fetch-har-3.0.0.tgz",
-      "integrity": "sha512-eZZACbA76wHqfNbdYoP6q1g05nk2xOoQOZz6TTeumtESeGA56VHDjhRSA8n5dGTSCtVV0I2w2sQACrVRQgCTTw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fetch-har/-/fetch-har-3.0.1.tgz",
+      "integrity": "sha512-joxQ5exfg47zhmtc4xaGz+DUgI0EjNgTzbzuKT8JnMfn+J4/Vrtno6dXAiEOeBGzTdwubzEZQembRya6JfY8bQ=="
     },
     "figgy-pudding": {
       "version": "3.5.1",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -15,7 +15,7 @@
     "@readme/syntax-highlighter": "^6.15.0",
     "@readme/variable": "^6.13.0",
     "classnames": "^2.2.5",
-    "fetch-har": "^3.0.0",
+    "fetch-har": "^3.0.1",
     "js-cookie": "^2.1.4",
     "lodash.kebabcase": "^4.1.1",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
## 🧰 What's being changed?

This updates `fetch-har` to resolve some improper handling of `application/x-www-form-urlencoded` payloads where they would be sent as JSON through the "Try It" request instead of as URLencoded data.

See https://github.com/readmeio/fetch-har/pull/69 for the fix, and https://app.asana.com/0/0/1183793140674162/f for background.

## 🧪 Testing

Here's a sample OAS you can test with to see it in action.

```json
{
  "openapi": "3.0.0",
  "info": {
    "title": "urlencoded fix",
    "version": "2.0"
  },
  "servers": [
    {
      "url": "http://httpbin.org"
    }
  ],
  "security": [
    {
      "basicAuth": []
    }
  ],
  "paths": {
    "/post": {
      "post": {
        "operationId": "getToken",
        "security": [
          {
            "basicAuth": []
          }
        ],
        "requestBody": {
          "required": true,
          "content": {
            "application/x-www-form-urlencoded": {
              "schema": {
                "type": "object",
                "properties": {
                  "grant_type": {
                    "enum": [
                      "client_credentials"
                    ]
                  }
                }
              }
            }
          }
        },
        "responses": {
          "200": {
            "description": "OK"
          }
        }
      }
    }
  },
  "components": {
    "securitySchemes": {
      "basicAuth": {
        "type": "http",
        "scheme": "basic"
      }
    }
  }
}
```

Here's what the payloads looked like before the fix:

![Screen Shot 2020-07-15 at 5 26 47 PM](https://user-images.githubusercontent.com/33762/87613099-30ec4600-c6c1-11ea-962a-418775b43d65.png)

And fixed:

![Screen Shot 2020-07-15 at 5 27 18 PM](https://user-images.githubusercontent.com/33762/87613102-32b60980-c6c1-11ea-845f-f70f962c6c14.png)