### PR TITLE
feat: upgrading @readme/react-jsonschema-form to v1.2.0

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -415,9 +415,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.9.2.tgz",
-      "integrity": "sha512-ayjSOxuK2GaSDJFCtLgHnYjuMyIpViNujWrZo8GUpN60/n7juzJKK5yOo6RFVb0zdU9ACJFK+MsZrUnj3OmXMw==",
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.5.tgz",
+      "integrity": "sha512-LJwyb1ac//Jr2zrGTTaNJhrP1wYCgVw9rzHbQPogKXCTLQ60EEWgeNtuqs6cLsq64O557SYzziCrOxNp0rRi8w==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1389,11 +1389,6 @@
       "integrity": "sha512-Wc682b1UMkVZ8YjdEGVglYNy0+UCrBc8Ark9O32pt7/kRWWoWzTrTZCpLqyiyMIC5vAV8LQkzq49MhE0+hnosA==",
       "dev": true
     },
-    "@readme/oas-extensions": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-6.13.0.tgz",
-      "integrity": "sha512-VSKMnyuCYKjlnVBF4gS08iav+g1iNeYp5hz5F7ldO9UXbJcYeGF43xNidNncootxPyRY0NQZeRYIFW/QsChK/Q=="
-    },
     "@readme/oas-tooling": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.4.tgz",
@@ -1404,9 +1399,9 @@
       }
     },
     "@readme/react-jsonschema-form": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@readme/react-jsonschema-form/-/react-jsonschema-form-1.1.5.tgz",
-      "integrity": "sha512-kfcdpB5LLtc+e0HfWcbVB/gR9426NusQpWV0DJrNhSpTdNZkxO5blkbSyNsBZ3whS+t9Kjl8hyRUU5if7mMjbQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/react-jsonschema-form/-/react-jsonschema-form-1.2.0.tgz",
+      "integrity": "sha512-28hdQ+kWunuf37J+LivlfH8AZrj5AjR2mQMbotuvImck2D9tzuB3aGjFIKlggwRpiuKeA2SDzBJDDfZpwX50tA==",
       "requires": {
         "@babel/runtime-corejs2": "^7.4.5",
         "ajv": "^6.7.0",
@@ -1430,16 +1425,6 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
-      }
-    },
-    "@readme/variable": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-6.13.0.tgz",
-      "integrity": "sha512-ztCkWP295VzRAnXMT8wRjaC8oDpdYFW/2RYd1oW7JcTrDbRgf/TN1O6qrDi5Fp3b28JgV8kybycdjSZfoES25Q==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
       }
     },
     "@sinonjs/commons": {

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -11,7 +11,7 @@
     "@readme/oas-to-har": "^6.15.2",
     "@readme/oas-to-snippet": "^6.15.2",
     "@readme/oas-tooling": "^3.5.4",
-    "@readme/react-jsonschema-form": "^1.1.5",
+    "@readme/react-jsonschema-form": "^1.2.0",
     "@readme/syntax-highlighter": "^6.15.2",
     "@readme/variable": "^6.15.2",
     "classnames": "^2.2.5",


### PR DESCRIPTION
## 🧰 What's being changed?

Updates our fork of RJSF to pull in the potential fix for circular refs in https://github.com/readmeio/react-jsonschema-form/pull/14.

## 🧪 Testing

We have a demo circular ref definition that's currently failing here: https://preview.readme.io/?selected=swagger-files%2Fcyclical-refs.json

Loading it up locally via http://localhost:9966/?selected=swagger-files%2Fcyclical-refs.json you'll now see:

![Screen Shot 2020-07-23 at 3 10 17 PM](https://user-images.githubusercontent.com/33762/88343642-b2ae2600-ccf6-11ea-8aa0-c75597d85a9a.png)