### PR TITLE
style(rdmd/callout): fix icon alignment

### DIFF
--- a/packages/markdown/components/Callout/style.scss
+++ b/packages/markdown/components/Callout/style.scss
@@ -66,6 +66,10 @@
     }
     &.empty {
       float: left;
+      margin-top: calc(#{$l-offset} * .5);
+      .callout-icon {
+        line-height: 0;
+      }
     }
     > * {
       color: inherit;


### PR DESCRIPTION
## 🧰 What's being changed?

Fix vertical icon alignment for callouts with empty headings. Resolves #763.

- [x] Null out icons line-height.
- [x] Account for bottom margins.

  ![before-after](https://user-images.githubusercontent.com/886627/88701798-5dd82a00-d0bf-11ea-8dd3-32f18067d9e6.gif)