### PR TITLE
fix: vendored json content types being treated as plain text

### DIFF
--- a/packages/api-explorer/__tests__/lib/content-type-is-json.test.js
+++ b/packages/api-explorer/__tests__/lib/content-type-is-json.test.js
@@ -11,6 +11,11 @@ describe('contentTypeIsJson', () => {
     expect(contentTypeIsJson(contentType)).toBe(true);
   });
 
+  it('should return true if application/vnd.github.v3.star+json', () => {
+    const contentType = 'application/vnd.github.v3.star+json';
+    expect(contentTypeIsJson(contentType)).toBe(true);
+  });
+
   it('should return false otherwise', () => {
     const contentType = 'text/html';
     expect(contentTypeIsJson(contentType)).toBe(false);

--- a/packages/api-explorer/src/lib/content-type-is-json.js
+++ b/packages/api-explorer/src/lib/content-type-is-json.js
@@ -1,5 +1,5 @@
 function contentTypeIsJson(contentType) {
-  const jsonContentTypes = ['application/json', 'application/vnd.api+json'];
+  const jsonContentTypes = ['application/json', '+json'];
   return jsonContentTypes.some(ct => contentType.includes(ct));
 }
 


### PR DESCRIPTION
## 🧰 What's being changed?

This resolves a bug where vendored JSON content types, like `application/vnd.github.v3.star+json`, were being treated as plain text.

Resolves https://app.asana.com/0/1177947654981875/1186354765663162/f

## 🧪 Testing

You can see this bug in action here: http://bin.readme.com/s/5f285a019c025c00240f7a31

![Screen Shot 2020-08-03 at 11 41 57 AM](https://user-images.githubusercontent.com/33762/89215932-5a8ce480-d57e-11ea-9fdc-b19acd658abd.png)

And fixed:

![Screen Shot 2020-08-03 at 11 39 29 AM](https://user-images.githubusercontent.com/33762/89215943-5e206b80-d57e-11ea-84b7-e1d425b8b6d7.png)
