### PR TITLE
fix: bug where if no securityschemes were present, we might return valid security

### DIFF
--- a/packages/api-explorer/__tests__/__fixtures__/auth-types/no-security-schemes.json
+++ b/packages/api-explorer/__tests__/__fixtures__/auth-types/no-security-schemes.json
@@ -1,0 +1,18 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Multiple Securities"
+  },
+  "paths": {
+    "/oauth": {
+      "post": {
+        "security": [
+          {
+            "oauth": ["write:things"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/api-explorer/__tests__/lib/is-auth-ready.test.js
+++ b/packages/api-explorer/__tests__/lib/is-auth-ready.test.js
@@ -3,11 +3,22 @@ const Oas = require('@readme/oas-tooling');
 const isAuthReady = require('../../src/lib/is-auth-ready');
 const authTypesOas = require('../__fixtures__/auth-types/oas');
 const multipleSchemes = require('../__fixtures__/multiple-securities/oas');
+const noSecuritySchemes = require('../__fixtures__/auth-types/no-security-schemes');
 
 const oas = new Oas(authTypesOas);
 const oas2 = new Oas(multipleSchemes);
 
 describe('isAuthReady', () => {
+  it('should return true if a security type is defined, but no securitySchemes are present', () => {
+    const operation = new Oas(noSecuritySchemes).operation('/oauth', 'post');
+
+    expect(
+      isAuthReady(operation, {
+        oauth: 'bearer',
+      })
+    ).toBe(true);
+  });
+
   it('should return true if multiple security types required (&&)', () => {
     const operation = oas2.operation('/and-security', 'post');
 

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1586,9 +1586,9 @@
       }
     },
     "@readme/oas-tooling": {
-      "version": "3.5.8",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.8.tgz",
-      "integrity": "sha512-Y70P0qGcz/3Kh1IpDv1hk20VctsiPt5BloXDbpmzyr3LsFTdCzzRIn9zgiE05gNOYNheVeFzXBzqI2SYV/9mNQ==",
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.9.tgz",
+      "integrity": "sha512-3BLahtKCsJI2/7w3jXlCfdBaMY4YJwVNeuAfnF4uQMjNO1tKu11a8vGp07gf68A36ZYRLE0/6HcIVdSSIzUEPQ==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -10,7 +10,7 @@
     "@readme/oas-extensions": "^7.0.0",
     "@readme/oas-to-har": "^7.0.0",
     "@readme/oas-to-snippet": "^7.0.1",
-    "@readme/oas-tooling": "^3.5.8",
+    "@readme/oas-tooling": "^3.5.9",
     "@readme/react-jsonschema-form": "^1.2.0",
     "@readme/syntax-highlighter": "^7.0.0",
     "@readme/variable": "^7.0.0",

--- a/packages/markdown-magic/package-lock.json
+++ b/packages/markdown-magic/package-lock.json
@@ -847,26 +847,6 @@
         "eslint-plugin-unicorn": "^21.0.0"
       }
     },
-    "@readme/syntax-highlighter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-7.0.0.tgz",
-      "integrity": "sha512-+9lOOl0AVdvGpQy86nXVeD/zAH+HQW8dRaznr6AzsPZiwuNj1QJNQOWsaNCSClgUkR7R2TbmyDpDkAvhCDgYBA==",
-      "requires": {
-        "@readme/variable": "^7.0.0",
-        "codemirror": "^5.48.2",
-        "react": "^16.4.2"
-      }
-    },
-    "@readme/variable": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-7.0.0.tgz",
-      "integrity": "sha512-pTIcP7C+O1oywMByP3dVL7qliytq0HYGBc1gqAPYnBjEy98aZ6QHK4JEdDaY70hB2qAYQI5qs94af5M9M7LV3Q==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
@@ -1682,11 +1662,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -1712,11 +1687,6 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
-    },
-    "codemirror": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.57.0.tgz",
-      "integrity": "sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg=="
     },
     "collapse-white-space": {
       "version": "1.0.4",

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -1023,9 +1023,9 @@
       "integrity": "sha512-Z6PxFOZNaM9yM+p/bsXb12pRQcz0+KfvCZBnEGRpALUzpQNjPHK7KzQja3vI0Xeq5vi2fufQd+WPfRH+LqaXpQ=="
     },
     "@readme/oas-tooling": {
-      "version": "3.5.8",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.8.tgz",
-      "integrity": "sha512-Y70P0qGcz/3Kh1IpDv1hk20VctsiPt5BloXDbpmzyr3LsFTdCzzRIn9zgiE05gNOYNheVeFzXBzqI2SYV/9mNQ==",
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.9.tgz",
+      "integrity": "sha512-3BLahtKCsJI2/7w3jXlCfdBaMY4YJwVNeuAfnF4uQMjNO1tKu11a8vGp07gf68A36ZYRLE0/6HcIVdSSIzUEPQ==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^7.0.0",
-    "@readme/oas-tooling": "^3.5.8",
+    "@readme/oas-tooling": "^3.5.9",
     "parse-data-url": "^2.0.0"
   },
   "scripts": {

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -1051,9 +1051,9 @@
       }
     },
     "@readme/oas-tooling": {
-      "version": "3.5.8",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.8.tgz",
-      "integrity": "sha512-Y70P0qGcz/3Kh1IpDv1hk20VctsiPt5BloXDbpmzyr3LsFTdCzzRIn9zgiE05gNOYNheVeFzXBzqI2SYV/9mNQ==",
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.9.tgz",
+      "integrity": "sha512-3BLahtKCsJI2/7w3jXlCfdBaMY4YJwVNeuAfnF4uQMjNO1tKu11a8vGp07gf68A36ZYRLE0/6HcIVdSSIzUEPQ==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@readme/eslint-config": "^3.2.0",
     "@readme/oas-examples": "^3.4.0",
-    "@readme/oas-tooling": "^3.5.8",
+    "@readme/oas-tooling": "^3.5.9",
     "datauri": "^3.0.0",
     "eslint": "^7.0.0",
     "jest": "^26.0.1",


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a bug in our `Operation.getSecurity()` code where if an API definition had a valid `security` definition on either an operation or the root level, we'd return that even if they didn't have any `securitySchemes` set up.

This bug would expose itself by throwing a fatal error when attempting to make an API request.

![Screen Shot 2020-08-24 at 11 52 43 AM](https://user-images.githubusercontent.com/33762/91084123-56456b80-e600-11ea-83b1-0473d60ae71c.png)

See https://github.com/readmeio/oas/pull/259 for the bugfix in `@readme/oas-tooling`.