### PR TITLE
chore(deps): upgrading @readme/httpsnippet to 2.1.0

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1406,17 +1406,6 @@
       "resolved": "https://registry.npmjs.org/@readme/http-status-codes/-/http-status-codes-7.1.0.tgz",
       "integrity": "sha512-sC94wCjHfHYt87j+pKnG6FaKMX0N6BLBINPokR3XXGv43lhT32qbFbWDzmBuiJOC4PRHg0M4kMsBToVH47V6mA=="
     },
-    "@readme/httpsnippet": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.0.1.tgz",
-      "integrity": "sha512-yeQemCwfzF4ll4yqWaJ+Dv2m/srwAf4VxM9E1Kkz75A/q5+uqmX6ttSsK+NJl+s1G4btY30/D3OuEErtCUq6BQ==",
-      "requires": {
-        "event-stream": "4.0.1",
-        "form-data": "3.0.0",
-        "har-validator": "^5.0.0",
-        "stringify-object": "^3.3.0"
-      }
-    },
     "@readme/markdown": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/@readme/markdown/-/markdown-6.18.0.tgz",
@@ -1478,112 +1467,11 @@
         }
       }
     },
-    "@readme/markdown-magic": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/markdown-magic/-/markdown-magic-7.0.0.tgz",
-      "integrity": "sha512-XM8bwMYZdOeEJaABCq3/ESmiG6VZ/JZyrItuRkTQI4xxOo4n1xWqnYTmXtR2dZYy45jGGaLbHZQk3iSP8Ug1sA==",
-      "requires": {
-        "@readme/emojis": "1.0.0",
-        "@readme/syntax-highlighter": "^7.0.0",
-        "@readme/variable": "^7.0.0",
-        "hast-util-sanitize": "1.3.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2",
-        "rehype-raw": "4.0.2",
-        "rehype-react": "3.1.0",
-        "rehype-sanitize": "2.0.3",
-        "remark-breaks": "1.0.5",
-        "remark-parse": "7.0.2",
-        "remark-rehype": "7.0.0",
-        "unified": "8.4.2"
-      },
-      "dependencies": {
-        "hast-to-hyperscript": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-5.0.0.tgz",
-          "integrity": "sha512-DLl3eYTz8uwwzEubDUdCChsR5t5b2ne+yvHrA2h58Suq/JnN3+Gsb9Tc4iZoCCsykmFUc6UUpwxTmQXs0akSeg==",
-          "requires": {
-            "comma-separated-tokens": "^1.0.0",
-            "property-information": "^4.0.0",
-            "space-separated-tokens": "^1.0.0",
-            "style-to-object": "^0.2.1",
-            "unist-util-is": "^2.0.0",
-            "web-namespaces": "^1.1.2"
-          }
-        },
-        "hast-util-sanitize": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz",
-          "integrity": "sha512-AIeKHuHx0Wk45nSkGVa2/ujQYTksnDl8gmmKo/mwQi7ag7IBZ8cM3nJ2G86SajbjGP/HRpud6kMkPtcM2i0Tlw==",
-          "requires": {
-            "xtend": "^4.0.1"
-          }
-        },
-        "property-information": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/property-information/-/property-information-4.2.0.tgz",
-          "integrity": "sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==",
-          "requires": {
-            "xtend": "^4.0.1"
-          }
-        },
-        "rehype-react": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-3.1.0.tgz",
-          "integrity": "sha512-7SiLiqNudSGkvhrePkdKqdUvngZqzG+PJhdR5EeIFELz2j2ek4aO5DHbxUXYvaZfqUiBDO2Aeq1OROUmxmu+Vg==",
-          "requires": {
-            "@mapbox/hast-util-table-cell-style": "^0.1.3",
-            "has": "^1.0.1",
-            "hast-to-hyperscript": "^5.0.0"
-          }
-        },
-        "rehype-sanitize": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-2.0.3.tgz",
-          "integrity": "sha512-RZFLBV36yOWNbV4g2WJDfilAzV1Sin/InQHXA+5h9+GkxCFnTJCC7SPrAdVHEIrQ882eAD8/51jEYHD6xrewcw==",
-          "requires": {
-            "hast-util-sanitize": "^1.1.0"
-          }
-        },
-        "unist-util-is": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
-        }
-      }
-    },
     "@readme/oas-examples": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-3.5.5.tgz",
       "integrity": "sha512-La9UukDB4IKkk/XD3CdnTZaI0WP8jF/C2/09HHopB94S1osCyMeHUQWJD2X4iqmZWS0eSQgDAdt252kUXoQFWA==",
       "dev": true
-    },
-    "@readme/oas-extensions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-7.0.0.tgz",
-      "integrity": "sha512-Z6PxFOZNaM9yM+p/bsXb12pRQcz0+KfvCZBnEGRpALUzpQNjPHK7KzQja3vI0Xeq5vi2fufQd+WPfRH+LqaXpQ=="
-    },
-    "@readme/oas-to-har": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-7.0.0.tgz",
-      "integrity": "sha512-Ugpb03zGufgx3biuiiEVq6bJgUvkhMsIhxggtRNO+Kt3kHYYzNrEgsCZT0aV5T34vEBqt9GIo/MS5i9yo170zQ==",
-      "requires": {
-        "@readme/oas-extensions": "^7.0.0",
-        "@readme/oas-tooling": "^3.5.8",
-        "parse-data-url": "^2.0.0"
-      }
-    },
-    "@readme/oas-to-snippet": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-7.0.1.tgz",
-      "integrity": "sha512-/sq4ocjeCcIziTTexXsIhjgkJymRE/8tjAIkeJ+c+fVJAnnTCzi6e3Frxix8Zxn9uheSJM1TsA+jkav0uJ0/Kw==",
-      "requires": {
-        "@readme/httpsnippet": "^2.0.1",
-        "@readme/oas-extensions": "^7.0.0",
-        "@readme/oas-to-har": "^7.0.0",
-        "@readme/syntax-highlighter": "^7.0.0",
-        "httpsnippet-client-api": "^2.3.0"
-      }
     },
     "@readme/oas-tooling": {
       "version": "3.5.8",
@@ -1621,26 +1509,6 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
-      }
-    },
-    "@readme/syntax-highlighter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-7.0.0.tgz",
-      "integrity": "sha512-+9lOOl0AVdvGpQy86nXVeD/zAH+HQW8dRaznr6AzsPZiwuNj1QJNQOWsaNCSClgUkR7R2TbmyDpDkAvhCDgYBA==",
-      "requires": {
-        "@readme/variable": "^7.0.0",
-        "codemirror": "^5.48.2",
-        "react": "^16.4.2"
-      }
-    },
-    "@readme/variable": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-7.0.0.tgz",
-      "integrity": "sha512-pTIcP7C+O1oywMByP3dVL7qliytq0HYGBc1gqAPYnBjEy98aZ6QHK4JEdDaY70hB2qAYQI5qs94af5M9M7LV3Q==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
       }
     },
     "@sinonjs/commons": {
@@ -2335,7 +2203,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -3173,6 +3042,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -3267,11 +3137,6 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
-    },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -3627,7 +3492,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "des.js": {
       "version": "1.0.1",
@@ -3708,11 +3574,6 @@
           "dev": true
         }
       }
-    },
-    "duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "duplexify": {
       "version": "3.7.1",
@@ -4617,20 +4478,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "event-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
-      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
-      "requires": {
-        "duplexer": "^0.1.1",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
-      }
-    },
     "events": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
@@ -5164,16 +5011,6 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
-    "form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -5182,11 +5019,6 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
-    },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "from2": {
       "version": "2.3.0",
@@ -5779,7 +5611,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -5798,11 +5631,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
-    },
-    "get-own-enumerable-property-symbols": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
-      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -5965,12 +5793,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -5980,6 +5810,7 @@
           "version": "6.10.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
           "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -5990,12 +5821,14 @@
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
         }
       }
     },
@@ -6003,6 +5836,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -6337,18 +6171,6 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
-    "httpsnippet-client-api": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.3.0.tgz",
-      "integrity": "sha512-HC0HC/gLa816z2fw0vP0o9zAQ5pV535PuiHnxsHPyqkO6+vgoD+oZnXRvC1P03yLd16Yo6ql2mbVg+UWLCzgKQ==",
-      "requires": {
-        "@readme/httpsnippet": "^2.0.1",
-        "@readme/oas-tooling": "^3.5.8",
-        "content-type": "^1.0.4",
-        "path-to-regexp": "^6.1.0",
-        "stringify-object": "^3.3.0"
-      }
-    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -6660,11 +6482,6 @@
         "kind-of": "^3.0.2"
       }
     },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-    },
     "is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -6701,11 +6518,6 @@
       "requires": {
         "has-symbols": "^1.0.1"
       }
-    },
-    "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -9058,11 +8870,6 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
-    "map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
-    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -9221,12 +9028,14 @@
     "mime-db": {
       "version": "1.35.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.19",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
       "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "dev": true,
       "requires": {
         "mime-db": "~1.35.0"
       }
@@ -9934,14 +9743,6 @@
       "dev": true,
       "requires": {
         "pify": "^2.0.0"
-      }
-    },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "requires": {
-        "through": "~2.3"
       }
     },
     "pbkdf2": {
@@ -11483,14 +11284,6 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "requires": {
-        "through": "2"
-      }
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -11595,15 +11388,6 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      }
-    },
-    "stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-      "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
       }
     },
     "stream-each": {
@@ -11749,16 +11533,6 @@
         "is-alphanumerical": "^1.0.0",
         "is-decimal": "^1.0.2",
         "is-hexadecimal": "^1.0.0"
-      }
-    },
-    "stringify-object": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-      "requires": {
-        "get-own-enumerable-property-symbols": "^3.0.0",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
       }
     },
     "strip-bom": {
@@ -12071,11 +11845,6 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",

--- a/packages/markdown-magic/package-lock.json
+++ b/packages/markdown-magic/package-lock.json
@@ -847,26 +847,6 @@
         "eslint-plugin-unicorn": "^21.0.0"
       }
     },
-    "@readme/syntax-highlighter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-7.0.0.tgz",
-      "integrity": "sha512-+9lOOl0AVdvGpQy86nXVeD/zAH+HQW8dRaznr6AzsPZiwuNj1QJNQOWsaNCSClgUkR7R2TbmyDpDkAvhCDgYBA==",
-      "requires": {
-        "@readme/variable": "^7.0.0",
-        "codemirror": "^5.48.2",
-        "react": "^16.4.2"
-      }
-    },
-    "@readme/variable": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-7.0.0.tgz",
-      "integrity": "sha512-pTIcP7C+O1oywMByP3dVL7qliytq0HYGBc1gqAPYnBjEy98aZ6QHK4JEdDaY70hB2qAYQI5qs94af5M9M7LV3Q==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
@@ -1682,11 +1662,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -1712,11 +1687,6 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
-    },
-    "codemirror": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.57.0.tgz",
-      "integrity": "sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg=="
     },
     "collapse-white-space": {
       "version": "1.0.4",

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -1017,11 +1017,6 @@
         "eslint-plugin-unicorn": "^21.0.0"
       }
     },
-    "@readme/oas-extensions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-7.0.0.tgz",
-      "integrity": "sha512-Z6PxFOZNaM9yM+p/bsXb12pRQcz0+KfvCZBnEGRpALUzpQNjPHK7KzQja3vI0Xeq5vi2fufQd+WPfRH+LqaXpQ=="
-    },
     "@readme/oas-tooling": {
       "version": "3.5.8",
       "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.8.tgz",

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -971,9 +971,9 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.1.0.tgz",
-      "integrity": "sha512-2hs3aIOnau83HxmPkHR+lsvUQwdriL3anG3trQ6Td7/XS/lZs3otb/SnCQ/AiU2b8CFqu+ii+4qCDjFEr2NJKg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.1.1.tgz",
+      "integrity": "sha512-7vpyeyPqjhIeWI/vFY+eHzebK9cCayDlGYkRRtbpNfpINWEjlONcK6PHs60GS55WJpLhNeECV7UQYEui5QVaiA==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -971,9 +971,9 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.0.1.tgz",
-      "integrity": "sha512-yeQemCwfzF4ll4yqWaJ+Dv2m/srwAf4VxM9E1Kkz75A/q5+uqmX6ttSsK+NJl+s1G4btY30/D3OuEErtCUq6BQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.1.0.tgz",
+      "integrity": "sha512-2hs3aIOnau83HxmPkHR+lsvUQwdriL3anG3trQ6Td7/XS/lZs3otb/SnCQ/AiU2b8CFqu+ii+4qCDjFEr2NJKg==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",
@@ -981,20 +981,6 @@
         "stringify-object": "^3.3.0"
       },
       "dependencies": {
-        "event-stream": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
-          "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
-          "requires": {
-            "duplexer": "^0.1.1",
-            "from": "^0.1.7",
-            "map-stream": "0.0.7",
-            "pause-stream": "^0.0.11",
-            "split": "^1.0.1",
-            "stream-combiner": "^0.2.2",
-            "through": "^2.3.8"
-          }
-        },
         "form-data": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
@@ -1003,28 +989,6 @@
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
-          }
-        },
-        "map-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-          "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
-        },
-        "split": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-          "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-          "requires": {
-            "through": "2"
-          }
-        },
-        "stream-combiner": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-          "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-          "requires": {
-            "duplexer": "~0.1.1",
-            "through": "~2.3.4"
           }
         }
       }
@@ -1035,21 +999,6 @@
       "integrity": "sha512-La9UukDB4IKkk/XD3CdnTZaI0WP8jF/C2/09HHopB94S1osCyMeHUQWJD2X4iqmZWS0eSQgDAdt252kUXoQFWA==",
       "dev": true
     },
-    "@readme/oas-extensions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-7.0.0.tgz",
-      "integrity": "sha512-Z6PxFOZNaM9yM+p/bsXb12pRQcz0+KfvCZBnEGRpALUzpQNjPHK7KzQja3vI0Xeq5vi2fufQd+WPfRH+LqaXpQ=="
-    },
-    "@readme/oas-to-har": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-7.0.0.tgz",
-      "integrity": "sha512-Ugpb03zGufgx3biuiiEVq6bJgUvkhMsIhxggtRNO+Kt3kHYYzNrEgsCZT0aV5T34vEBqt9GIo/MS5i9yo170zQ==",
-      "requires": {
-        "@readme/oas-extensions": "^7.0.0",
-        "@readme/oas-tooling": "^3.5.8",
-        "parse-data-url": "^2.0.0"
-      }
-    },
     "@readme/oas-tooling": {
       "version": "3.5.8",
       "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.8.tgz",
@@ -1057,26 +1006,6 @@
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"
-      }
-    },
-    "@readme/syntax-highlighter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-7.0.0.tgz",
-      "integrity": "sha512-+9lOOl0AVdvGpQy86nXVeD/zAH+HQW8dRaznr6AzsPZiwuNj1QJNQOWsaNCSClgUkR7R2TbmyDpDkAvhCDgYBA==",
-      "requires": {
-        "@readme/variable": "^7.0.0",
-        "codemirror": "^5.48.2",
-        "react": "^16.4.2"
-      }
-    },
-    "@readme/variable": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-7.0.0.tgz",
-      "integrity": "sha512-pTIcP7C+O1oywMByP3dVL7qliytq0HYGBc1gqAPYnBjEy98aZ6QHK4JEdDaY70hB2qAYQI5qs94af5M9M7LV3Q==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
       }
     },
     "@sinonjs/commons": {
@@ -1851,11 +1780,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -1906,11 +1830,6 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
-    },
-    "codemirror": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.57.0.tgz",
-      "integrity": "sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -2211,9 +2130,9 @@
       }
     },
     "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -2884,6 +2803,20 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "requires": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -5302,7 +5235,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.0",
@@ -5530,6 +5464,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -5565,6 +5500,11 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
+    },
+    "map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -5790,7 +5730,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -5975,14 +5916,6 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
-      }
-    },
-    "parse-data-url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-2.0.0.tgz",
-      "integrity": "sha512-6iXM6OBCHADCN9Bzv5QbWm1v41xSH15kIWE5hAJ9+sdkVM6pJFg+FlLm8n7gZ17pmZv6Wdr3+leXB2Uifxm7kw==",
-      "requires": {
-        "valid-data-url": "^2.0.0"
       }
     },
     "parse-json": {
@@ -6180,6 +6113,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6222,20 +6156,11 @@
         "inherits": "~2.0.3"
       }
     },
-    "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -6949,6 +6874,14 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -7024,6 +6957,15 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
     },
     "string-length": {
       "version": "4.0.1",
@@ -7497,11 +7439,6 @@
           "dev": true
         }
       }
-    },
-    "valid-data-url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-2.0.0.tgz",
-      "integrity": "sha512-dyCZnv3aCey7yfTgIqdZanKl7xWAEEKCbgmR7SKqyK6QT/Z07ROactrgD1eA37C69ODRj7rNOjzKWVPh0EUjBA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -4,7 +4,7 @@
   "version": "7.0.1",
   "main": "src/index.js",
   "dependencies": {
-    "@readme/httpsnippet": "^2.0.1",
+    "@readme/httpsnippet": "^2.1.0",
     "@readme/oas-extensions": "^7.0.0",
     "@readme/oas-to-har": "^7.0.0",
     "@readme/syntax-highlighter": "^7.0.0",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -4,7 +4,7 @@
   "version": "7.0.1",
   "main": "src/index.js",
   "dependencies": {
-    "@readme/httpsnippet": "^2.1.0",
+    "@readme/httpsnippet": "^2.1.1",
     "@readme/oas-extensions": "^7.0.0",
     "@readme/oas-to-har": "^7.0.0",
     "@readme/syntax-highlighter": "^7.0.0",

--- a/packages/syntax-highlighter/package-lock.json
+++ b/packages/syntax-highlighter/package-lock.json
@@ -784,16 +784,6 @@
         "eslint-plugin-unicorn": "^21.0.0"
       }
     },
-    "@readme/variable": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-7.0.0.tgz",
-      "integrity": "sha512-pTIcP7C+O1oywMByP3dVL7qliytq0HYGBc1gqAPYnBjEy98aZ6QHK4JEdDaY70hB2qAYQI5qs94af5M9M7LV3Q==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
@@ -1543,11 +1533,6 @@
           }
         }
       }
-    },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clean-regexp": {
       "version": "1.0.0",


### PR DESCRIPTION
## 🧰 What's being changed?

This upgrades `@readme/httpsnippet` to bring us the ability to generate cleaner code snippets for the Python `requests` library.

## 🧪 Testing

![Screen Shot 2020-08-24 at 12 07 43 PM](https://user-images.githubusercontent.com/33762/91086529-e33df400-e603-11ea-9d66-d6c08e6c8943.png)
