### PR TITLE
fix: issue where polymorphism titles in refs wouldn't be surfaced

### DIFF
--- a/example/swagger-files/polymorphism.json
+++ b/example/swagger-files/polymorphism.json
@@ -386,6 +386,7 @@
         }
       },
       "Dog": {
+        "title": "Woof",
         "allOf": [
           {
             "$ref": "#/components/schemas/Pet"
@@ -405,6 +406,7 @@
         ]
       },
       "Cat": {
+        "title": "Meow",
         "type": "object",
         "allOf": [
           {

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1474,9 +1474,9 @@
       "dev": true
     },
     "@readme/oas-tooling": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.10.tgz",
-      "integrity": "sha512-pxbj528IUUWHuI3+9iI2DbSzBrDi0boMEHL/6USI8GKo0AvPFvk0imrsecX9OtK1FGBdIOgMREZPxU7IXp107A==",
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.11.tgz",
+      "integrity": "sha512-1ALxepsUPlOwsqCxkj/HY0s001xHtzyyINZ+1qfGf+gVJKK2GwXj2h3LGfqizjIDi14la09VMr1qGTcuawZFmA==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -10,7 +10,7 @@
     "@readme/oas-extensions": "^7.1.0",
     "@readme/oas-to-har": "^7.1.0",
     "@readme/oas-to-snippet": "^7.1.1",
-    "@readme/oas-tooling": "^3.5.10",
+    "@readme/oas-tooling": "^3.5.11",
     "@readme/react-jsonschema-form": "^1.2.0",
     "@readme/syntax-highlighter": "^7.1.0",
     "@readme/variable": "^7.1.0",

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -1018,9 +1018,9 @@
       }
     },
     "@readme/oas-tooling": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.10.tgz",
-      "integrity": "sha512-pxbj528IUUWHuI3+9iI2DbSzBrDi0boMEHL/6USI8GKo0AvPFvk0imrsecX9OtK1FGBdIOgMREZPxU7IXp107A==",
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.11.tgz",
+      "integrity": "sha512-1ALxepsUPlOwsqCxkj/HY0s001xHtzyyINZ+1qfGf+gVJKK2GwXj2h3LGfqizjIDi14la09VMr1qGTcuawZFmA==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^7.1.0",
-    "@readme/oas-tooling": "^3.5.10",
+    "@readme/oas-tooling": "^3.5.11",
     "parse-data-url": "^2.0.0"
   },
   "scripts": {

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -1000,9 +1000,9 @@
       "dev": true
     },
     "@readme/oas-tooling": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.10.tgz",
-      "integrity": "sha512-pxbj528IUUWHuI3+9iI2DbSzBrDi0boMEHL/6USI8GKo0AvPFvk0imrsecX9OtK1FGBdIOgMREZPxU7IXp107A==",
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.5.11.tgz",
+      "integrity": "sha512-1ALxepsUPlOwsqCxkj/HY0s001xHtzyyINZ+1qfGf+gVJKK2GwXj2h3LGfqizjIDi14la09VMr1qGTcuawZFmA==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@readme/eslint-config": "^3.2.0",
     "@readme/oas-examples": "^3.4.0",
-    "@readme/oas-tooling": "^3.5.10",
+    "@readme/oas-tooling": "^3.5.11",
     "datauri": "^3.0.0",
     "eslint": "^7.0.0",
     "jest": "^26.0.1",


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a bug in how we generate JSON Schema for the `Params` component where under certain conditions, `title` properties on polymorphism schemas (`oneOf`, `anyOf`, and `allOf`) would be deleted.

This also patches in a workaround for a bug in RJSF where if a `title` property is within a `$ref` and not at the level of the `$ref`, it wouldn't be used when constructing a dropdown for the schemas, instead displaying a placeholder label of "Option 1". [Bug ticketed here.](https://github.com/rjsf-team/react-jsonschema-form/issues/2016)

## 🧪 Testing

You can see this bug in action here: http://bin.readme.com/s/5f46ce04c46abe00244f41f6

Though the `Cat` and `Dog` schemas have a `title` property, it's not used in the dropdown.

With this fix, it now looks like:

![Screen Shot 2020-08-26 at 2 03 43 PM](https://user-images.githubusercontent.com/33762/91356732-fa681780-e7a4-11ea-93d0-ca33ac8ff874.png)
