### PR TITLE
fix: cases where user auth keys might not have an `id` present

### DIFF
--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -32,8 +32,14 @@ class ApiExplorer extends React.Component {
     };
 
     this.onAuthGroupChange = this.onAuthGroupChange.bind(this);
+
     this.groups =
-      this.props.variables.user.keys && this.props.variables.user.keys.map(key => ({ id: key.id, name: key.name }));
+      this.props.variables.user.keys &&
+      this.props.variables.user.keys.map(key => ({
+        // If we don't have an `id` present, default to the `name` instead.
+        id: 'id' in key ? key.id : key.name,
+        name: key.name,
+      }));
 
     this.lazyHash = this.buildLazyHash();
   }
@@ -110,9 +116,18 @@ class ApiExplorer extends React.Component {
     const { user } = this.props.variables;
     let groupName = false;
     if (user.keys) {
-      // We need to remap the incoming group with the groups name so we can pick out the auth
-      // keys in `getAuth`.
-      groupName = user.keys.find(key => key.id === group).name;
+      // We need to remap the incoming group with the groups name so we can pick out the auth keys in `getAuth`.
+      let keys = user.keys.find(key => key.id === group);
+      if (keys !== undefined) {
+        groupName = keys.name;
+      } else {
+        // If the keys that we have for a user don't have an `id` set up, but does have `name`, we can pull it off that
+        // instead.
+        keys = user.keys.find(key => !('id' in key) && key.name === group);
+        if (keys !== undefined) {
+          groupName = keys.name;
+        }
+      }
     }
 
     this.setState({


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a case where user auth keys coming into the Explorer might not have an `id` present, but have everything else we need. For example:

```js
{
  user: {
    keys: [
      { apiKey: 'Bearer Sp63rycwm', name: 'App 2' },
      { apiKey: 'Bearer NBxd4epaZ', name: 'App 1' },
    ],
  },
}
```

Right now, since `id` is missing, when you toggle between apps in the `AuthBox` dropdown we are throwing the following error:

<img width="1440" alt="Screen Shot 2020-08-11 at 1 22 39 PM" src="https://user-images.githubusercontent.com/33762/91483489-a7519b80-e85c-11ea-8a83-f2e0ea3565e8.png">

So instead of doing that, if `id` is missing, but we've got a `name` in the key present, we're now using that to do auth determinations from the `AuthBox` dropdown to pick the right API key from our stored user keys.