### PR TITLE
docs: update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This repo consists of the following npm modules:
 git clone git@github.com:readmeio/api-explorer.git
 cd api-explorer
 npm install
-npx lerna bootstrap
 ```
 
 ## Running the tests


### PR DESCRIPTION
## 🧰 What's being changed?

Removed a now unnecessary line since we do this on the postinstall now, right? https://github.com/readmeio/api-explorer/blob/dacbe08d5c3c4cb0aa9a6f19b2af95a9ba20380c/package.json#L13

(also we should update the husky rules for this repo so I can add permalinks in commit messages, since those are typically >100 characters)
