### PR TITLE
chore(deps): upgrading @readme/react-jsonschema-form to 1.2.1

### DIFF
--- a/example/swagger-files/cyclical-refs.json
+++ b/example/swagger-files/cyclical-refs.json
@@ -1,15 +1,17 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "Document Resource",
-    "description": "Use this for adding, updating or removing documents.",
+    "title": "Cyclical examples",
     "version": "1.0.0"
   },
+  "servers": [
+    {
+      "url": "https://httpbin.org/"
+    }
+  ],
   "paths": {
-    "/document": {
+    "/cyclical": {
       "put": {
-        "summary": "Add or update documents",
-        "operationId": "putMultiPartFormData",
         "parameters": [
           {
             "name": "Authorization",
@@ -50,6 +52,31 @@
           },
           "500": {
             "description": "Server error. Something unexpected happened while processing the request. Try again later."
+          }
+        }
+      }
+    },
+    "/not-quite-cyclical": {
+      "post": {
+        "description": "This is a schema that is technically cyclical, but not in a way that will cause infinite recursion when processing it.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "rules": {
+                    "$ref": "#/components/schemas/ZoneRules"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
           }
         }
       }
@@ -372,6 +399,55 @@
             "type": "object",
             "additionalProperties": {
               "type": "string"
+            }
+          }
+        }
+      },
+      "ZoneId": {
+        "type": "object",
+        "properties": {
+          "rules": {
+            "$ref": "#/components/schemas/ZoneRules"
+          }
+        }
+      },
+      "ZoneOffset": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "rules": {
+            "$ref": "#/components/schemas/ZoneRules"
+          }
+        }
+      },
+      "ZoneOffsetTransition": {
+        "type": "object",
+        "properties": {
+          "offsetBefore": {
+            "$ref": "#/components/schemas/ZoneOffset"
+          },
+          "offsetAfter": {
+            "$ref": "#/components/schemas/ZoneOffset"
+          },
+          "dateTimeAfter": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dateTimeBefore": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ZoneRules": {
+        "type": "object",
+        "properties": {
+          "transitions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ZoneOffsetTransition"
             }
           }
         }

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -510,9 +510,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.5.tgz",
-      "integrity": "sha512-LJwyb1ac//Jr2zrGTTaNJhrP1wYCgVw9rzHbQPogKXCTLQ60EEWgeNtuqs6cLsq64O557SYzziCrOxNp0rRi8w==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.11.2.tgz",
+      "integrity": "sha512-AC/ciV28adSSpEkBglONBWq4/Lvm6GAZuxIoyVtsnUpZMl0bxLtoChEnYAkP+47KyOCayZanojtflUEUJtR/6Q==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1292,17 +1292,6 @@
       "resolved": "https://registry.npmjs.org/@readme/http-status-codes/-/http-status-codes-7.1.0.tgz",
       "integrity": "sha512-sC94wCjHfHYt87j+pKnG6FaKMX0N6BLBINPokR3XXGv43lhT32qbFbWDzmBuiJOC4PRHg0M4kMsBToVH47V6mA=="
     },
-    "@readme/httpsnippet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.1.1.tgz",
-      "integrity": "sha512-7vpyeyPqjhIeWI/vFY+eHzebK9cCayDlGYkRRtbpNfpINWEjlONcK6PHs60GS55WJpLhNeECV7UQYEui5QVaiA==",
-      "requires": {
-        "event-stream": "4.0.1",
-        "form-data": "3.0.0",
-        "har-validator": "^5.0.0",
-        "stringify-object": "^3.3.0"
-      }
-    },
     "@readme/markdown": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/@readme/markdown/-/markdown-6.18.0.tgz",
@@ -1364,127 +1353,11 @@
         }
       }
     },
-    "@readme/markdown-magic": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@readme/markdown-magic/-/markdown-magic-7.2.2.tgz",
-      "integrity": "sha512-MeU7xcv4ymwRz5+rr+zh5CYI3ycnM/v74VkhI4h/+rKg97tsi/4HH0/2L7PpYllrWQTYCxthSAeqAnOyxW5OjA==",
-      "requires": {
-        "@readme/emojis": "1.0.0",
-        "@readme/syntax-highlighter": "^7.2.2",
-        "@readme/variable": "^7.2.2",
-        "hast-util-sanitize": "1.3.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2",
-        "rehype-raw": "4.0.2",
-        "rehype-react": "3.1.0",
-        "rehype-sanitize": "2.0.3",
-        "remark-breaks": "1.0.5",
-        "remark-parse": "7.0.2",
-        "remark-rehype": "7.0.0",
-        "unified": "8.4.2"
-      },
-      "dependencies": {
-        "hast-to-hyperscript": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-5.0.0.tgz",
-          "integrity": "sha512-DLl3eYTz8uwwzEubDUdCChsR5t5b2ne+yvHrA2h58Suq/JnN3+Gsb9Tc4iZoCCsykmFUc6UUpwxTmQXs0akSeg==",
-          "requires": {
-            "comma-separated-tokens": "^1.0.0",
-            "property-information": "^4.0.0",
-            "space-separated-tokens": "^1.0.0",
-            "style-to-object": "^0.2.1",
-            "unist-util-is": "^2.0.0",
-            "web-namespaces": "^1.1.2"
-          }
-        },
-        "hast-util-sanitize": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz",
-          "integrity": "sha512-AIeKHuHx0Wk45nSkGVa2/ujQYTksnDl8gmmKo/mwQi7ag7IBZ8cM3nJ2G86SajbjGP/HRpud6kMkPtcM2i0Tlw==",
-          "requires": {
-            "xtend": "^4.0.1"
-          }
-        },
-        "property-information": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/property-information/-/property-information-4.2.0.tgz",
-          "integrity": "sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==",
-          "requires": {
-            "xtend": "^4.0.1"
-          }
-        },
-        "rehype-react": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-3.1.0.tgz",
-          "integrity": "sha512-7SiLiqNudSGkvhrePkdKqdUvngZqzG+PJhdR5EeIFELz2j2ek4aO5DHbxUXYvaZfqUiBDO2Aeq1OROUmxmu+Vg==",
-          "requires": {
-            "@mapbox/hast-util-table-cell-style": "^0.1.3",
-            "has": "^1.0.1",
-            "hast-to-hyperscript": "^5.0.0"
-          }
-        },
-        "rehype-sanitize": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-2.0.3.tgz",
-          "integrity": "sha512-RZFLBV36yOWNbV4g2WJDfilAzV1Sin/InQHXA+5h9+GkxCFnTJCC7SPrAdVHEIrQ882eAD8/51jEYHD6xrewcw==",
-          "requires": {
-            "hast-util-sanitize": "^1.1.0"
-          }
-        },
-        "unist-util-is": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
-        }
-      }
-    },
     "@readme/oas-examples": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-3.5.5.tgz",
       "integrity": "sha512-La9UukDB4IKkk/XD3CdnTZaI0WP8jF/C2/09HHopB94S1osCyMeHUQWJD2X4iqmZWS0eSQgDAdt252kUXoQFWA==",
       "dev": true
-    },
-    "@readme/oas-extensions": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-7.2.1.tgz",
-      "integrity": "sha512-jibzTRxKNwy9n+OuC5cQN07Eleu/vN6zJd3j32MphgZktIyYZGsUc7TexQ7gMLlz45JuZAZxM2UkRqfRhthrhg=="
-    },
-    "@readme/oas-to-har": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-7.2.1.tgz",
-      "integrity": "sha512-/Wnw7LNSSvFJMR6+SzvgXf+eQAWzUdspksgZUzeURf1gDyNDX/zktndeEIpYIW5tN2VBRz+e0CSg3MhByW5xZA==",
-      "requires": {
-        "@readme/oas-extensions": "^7.2.1",
-        "@readme/oas-tooling": "^3.5.11",
-        "parse-data-url": "^2.0.0"
-      },
-      "dependencies": {
-        "parse-data-url": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-2.0.0.tgz",
-          "integrity": "sha512-6iXM6OBCHADCN9Bzv5QbWm1v41xSH15kIWE5hAJ9+sdkVM6pJFg+FlLm8n7gZ17pmZv6Wdr3+leXB2Uifxm7kw==",
-          "requires": {
-            "valid-data-url": "^2.0.0"
-          }
-        },
-        "valid-data-url": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-2.0.0.tgz",
-          "integrity": "sha512-dyCZnv3aCey7yfTgIqdZanKl7xWAEEKCbgmR7SKqyK6QT/Z07ROactrgD1eA37C69ODRj7rNOjzKWVPh0EUjBA=="
-        }
-      }
-    },
-    "@readme/oas-to-snippet": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-7.2.2.tgz",
-      "integrity": "sha512-tT4+GIT38zp5fxpfTZooR/UhmywN089EPs7D6Pw08y26u6fh63vkQK4OQNec67qchoy6mk+2qowexfkEcJci2A==",
-      "requires": {
-        "@readme/httpsnippet": "^2.1.1",
-        "@readme/oas-extensions": "^7.2.1",
-        "@readme/oas-to-har": "^7.2.1",
-        "@readme/syntax-highlighter": "^7.2.2",
-        "httpsnippet-client-api": "^2.3.0"
-      }
     },
     "@readme/oas-tooling": {
       "version": "3.5.11",
@@ -1496,9 +1369,9 @@
       }
     },
     "@readme/react-jsonschema-form": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/react-jsonschema-form/-/react-jsonschema-form-1.2.0.tgz",
-      "integrity": "sha512-28hdQ+kWunuf37J+LivlfH8AZrj5AjR2mQMbotuvImck2D9tzuB3aGjFIKlggwRpiuKeA2SDzBJDDfZpwX50tA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@readme/react-jsonschema-form/-/react-jsonschema-form-1.2.1.tgz",
+      "integrity": "sha512-qiE5vG/YtHbyAGwQ2Q3iPoOG3KsNOF6q7QYfUPTTfrnKID3Cvh7rmokm342UV3gXD2yD7YtUMZGWL/PWZXErog==",
       "requires": {
         "@babel/runtime-corejs2": "^7.4.5",
         "ajv": "^6.7.0",
@@ -1522,26 +1395,6 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
-      }
-    },
-    "@readme/syntax-highlighter": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-7.2.2.tgz",
-      "integrity": "sha512-dsd9ToFqU8PTKP7EeETMWQkpIi2Rfr7FcShORBbSJnnKlt+15XdkhbKFxAV+pgb9oSL8FNGy+Ij3JyCQbw7TuA==",
-      "requires": {
-        "@readme/variable": "^7.2.2",
-        "codemirror": "^5.48.2",
-        "react": "^16.4.2"
-      }
-    },
-    "@readme/variable": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-7.2.2.tgz",
-      "integrity": "sha512-RUlYFs5FfNOZrT7h8O2KZL+eLFo+ckewo+MNWTnNxGo6Qwk7AuRElomw2jAhn35e/XuH58YcaCxamIHRXbiz+w==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
       }
     },
     "@sinonjs/commons": {
@@ -2362,7 +2215,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -3269,6 +3123,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -3363,11 +3218,6 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
-    },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -3731,7 +3581,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "des.js": {
       "version": "1.0.1",
@@ -3837,11 +3688,6 @@
           "dev": true
         }
       }
-    },
-    "duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "duplexify": {
       "version": "3.7.1",
@@ -4690,20 +4536,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "event-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
-      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
-      "requires": {
-        "duplexer": "^0.1.1",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
-      }
-    },
     "events": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
@@ -5264,16 +5096,6 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
-    "form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -5282,11 +5104,6 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
-    },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "from2": {
       "version": "2.3.0",
@@ -5335,7 +5152,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -5354,11 +5172,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
-    },
-    "get-own-enumerable-property-symbols": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
-      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -5523,12 +5336,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -5538,6 +5353,7 @@
           "version": "6.10.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
           "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -5548,12 +5364,14 @@
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
         }
       }
     },
@@ -5561,6 +5379,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -5895,18 +5714,6 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
-    "httpsnippet-client-api": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.3.0.tgz",
-      "integrity": "sha512-HC0HC/gLa816z2fw0vP0o9zAQ5pV535PuiHnxsHPyqkO6+vgoD+oZnXRvC1P03yLd16Yo6ql2mbVg+UWLCzgKQ==",
-      "requires": {
-        "@readme/httpsnippet": "^2.0.1",
-        "@readme/oas-tooling": "^3.5.8",
-        "content-type": "^1.0.4",
-        "path-to-regexp": "^6.1.0",
-        "stringify-object": "^3.3.0"
-      }
-    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -6240,11 +6047,6 @@
         "kind-of": "^3.0.2"
       }
     },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-    },
     "is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -6281,11 +6083,6 @@
       "requires": {
         "has-symbols": "^1.0.1"
       }
-    },
-    "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -7855,11 +7652,6 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
-    "map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
-    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -8032,12 +7824,14 @@
     "mime-db": {
       "version": "1.35.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.19",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
       "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "dev": true,
       "requires": {
         "mime-db": "~1.35.0"
       }
@@ -8808,14 +8602,6 @@
       "dev": true,
       "requires": {
         "pify": "^2.0.0"
-      }
-    },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "requires": {
-        "through": "~2.3"
       }
     },
     "pbkdf2": {
@@ -10378,14 +10164,6 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "requires": {
-        "through": "2"
-      }
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -10490,15 +10268,6 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      }
-    },
-    "stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-      "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
       }
     },
     "stream-each": {
@@ -10675,16 +10444,6 @@
         "is-alphanumerical": "^1.0.0",
         "is-decimal": "^1.0.2",
         "is-hexadecimal": "^1.0.0"
-      }
-    },
-    "stringify-object": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-      "requires": {
-        "get-own-enumerable-property-symbols": "^3.0.0",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -10998,11 +10757,6 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -11,7 +11,7 @@
     "@readme/oas-to-har": "^7.2.1",
     "@readme/oas-to-snippet": "^7.2.2",
     "@readme/oas-tooling": "^3.5.11",
-    "@readme/react-jsonschema-form": "^1.2.0",
+    "@readme/react-jsonschema-form": "^1.2.1",
     "@readme/syntax-highlighter": "^7.2.2",
     "@readme/variable": "^7.2.2",
     "classnames": "^2.2.5",


### PR DESCRIPTION
## 🧰 What's being changed?

This upgrades `@readme/react-jsonschema-form` to v1.2.1 to resolve an issue introduced in v1.2.0 where we stopped processing schemas that were cyclical, but ones that were so in a safe way that wouldn't cause infinite recursion.

Check https://github.com/readmeio/react-jsonschema-form/pull/15 for more details on the problem and the actual fix.

## 🧪 Testing

You can see an example of this in the `/not-quite-cyclical` example I added into the `cyclical-refs` example definition, which you can also see here: http://bin.readme.com/s/5f63f9352fd27d002432212a

Before our fix, this operation wouldn't have any body parameters rendered:

![Screen Shot 2020-09-17 at 5 03 20 PM](https://user-images.githubusercontent.com/33762/93540179-b7aee080-f907-11ea-8d21-aa678293fe2f.png)

But now:

![Screen Shot 2020-09-17 at 5 03 44 PM](https://user-images.githubusercontent.com/33762/93540190-c3020c00-f907-11ea-9161-1baa56735647.png)