### PR TITLE
fix: render 401 JSON resposes if the request was not initiated via OAuth

### DIFF
--- a/packages/api-explorer/src/ResponseBody.jsx
+++ b/packages/api-explorer/src/ResponseBody.jsx
@@ -59,11 +59,31 @@ function hasOauth(oauth) {
   );
 }
 
-function Unauthorized({ isOauth, oauth }) {
+function Unauthorized({ isOauth, oauth, responseBody }) {
+  let unauthorizedResponse;
+  if (isOauth) {
+    unauthorizedResponse = (<div className="text-center hub-expired-token">{hasOauth(oauth)}</div>);
+  } else {
+    unauthorizedResponse = (
+        <ReactJson
+          collapsed={1}
+          collapseStringsAfterLength={100}
+          displayDataTypes={false}
+          displayObjectSize={false}
+          enableClipboard={false}
+          name={null}
+          src={responseBody}
+          style={{
+            padding: '20px 10px',
+            backgroundColor: 'transparent',
+            fontSize: '12px',
+          }}
+          theme="tomorrow"
+        />
+    );
+  }
   return (
-    <div className="text-center hub-expired-token">
-      {isOauth ? hasOauth(oauth) : <p>You couldn&apos;t be authenticated</p>}
-    </div>
+    unauthorizedResponse
   );
 }
 
@@ -80,7 +100,7 @@ function ResponseBody({ result, isOauth, oauth }) {
   return (
     <div className="tabber-body tabber-body-result" style={{ display: 'block' }}>
       {result.status !== 401 && <Authorized result={result} />}
-      {result.status === 401 && <Unauthorized isOauth={isOauth} oauth={oauth} />}
+      {result.status === 401 && <Unauthorized isOauth={isOauth} oauth={oauth} responseBody={result.responseBody} />}
     </div>
   );
 }

--- a/packages/api-explorer/src/ResponseBody.jsx
+++ b/packages/api-explorer/src/ResponseBody.jsx
@@ -62,29 +62,27 @@ function hasOauth(oauth) {
 function Unauthorized({ isOauth, oauth, responseBody }) {
   let unauthorizedResponse;
   if (isOauth) {
-    unauthorizedResponse = (<div className="text-center hub-expired-token">{hasOauth(oauth)}</div>);
+    unauthorizedResponse = <div className="text-center hub-expired-token">{hasOauth(oauth)}</div>;
   } else {
     unauthorizedResponse = (
-        <ReactJson
-          collapsed={1}
-          collapseStringsAfterLength={100}
-          displayDataTypes={false}
-          displayObjectSize={false}
-          enableClipboard={false}
-          name={null}
-          src={responseBody}
-          style={{
-            padding: '20px 10px',
-            backgroundColor: 'transparent',
-            fontSize: '12px',
-          }}
-          theme="tomorrow"
-        />
+      <ReactJson
+        collapsed={1}
+        collapseStringsAfterLength={100}
+        displayDataTypes={false}
+        displayObjectSize={false}
+        enableClipboard={false}
+        name={null}
+        src={responseBody}
+        style={{
+          padding: '20px 10px',
+          backgroundColor: 'transparent',
+          fontSize: '12px',
+        }}
+        theme="tomorrow"
+      />
     );
   }
-  return (
-    unauthorizedResponse
-  );
+  return unauthorizedResponse;
 }
 
 Unauthorized.propTypes = {


### PR DESCRIPTION
## 🧰 What's being changed?
When we get a 401 response, if the response isn't initiated via OAuth, we just show:
> You couldn't be authenticated

Now, I added some logic to render the responseBody if there isn't OAuth. The logic I have feels a little bad, though. Definitely want to chat about it when you get back!

## 🧪 Testing

Provide as much information as you can on how to test what you've done.
