### PR TITLE
chore(deps): upgrading @readme/syntax-highlighter to 10.0.0

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1481,6 +1481,21 @@
         "@readme/oas-to-har": "^7.3.0",
         "@readme/syntax-highlighter": "^9.0.1",
         "httpsnippet-client-api": "^2.3.0"
+      },
+      "dependencies": {
+        "@readme/syntax-highlighter": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-9.0.1.tgz",
+          "integrity": "sha512-Y00mh2i6HKBSUF2T66T5hCk+8w7UqYago9YaWkZsys1f333oSpyIAcNtnB4AvAnTw1SnuzIjuEi7CW2AgT/fuw==",
+          "requires": {
+            "@readme/variable": "^7.2.1",
+            "codemirror": "^5.48.2",
+            "prop-types": "^15.7.2",
+            "react": "^16.13.1",
+            "react-codemirror2": "^7.2.1",
+            "react-dom": "^16.13.1"
+          }
+        }
       }
     },
     "@readme/oas-tooling": {
@@ -1522,9 +1537,9 @@
       }
     },
     "@readme/syntax-highlighter": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-9.0.1.tgz",
-      "integrity": "sha512-Y00mh2i6HKBSUF2T66T5hCk+8w7UqYago9YaWkZsys1f333oSpyIAcNtnB4AvAnTw1SnuzIjuEi7CW2AgT/fuw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.0.0.tgz",
+      "integrity": "sha512-UHRR0qBGswUvTdO612PspjO8yWF94bXTJolG2FP/hOzbVFOMXprBDT7BUIYwIaVvMlq2qdVls+KERws0luISIA==",
       "requires": {
         "@readme/variable": "^7.2.1",
         "codemirror": "^5.48.2",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -12,7 +12,7 @@
     "@readme/oas-to-snippet": "^7.3.0",
     "@readme/oas-tooling": "^3.5.11",
     "@readme/react-jsonschema-form": "^1.2.1",
-    "@readme/syntax-highlighter": "^9.0.1",
+    "@readme/syntax-highlighter": "^10.0.0",
     "@readme/variable": "^7.3.0",
     "classnames": "^2.2.5",
     "fetch-har": "^4.0.2",

--- a/packages/api-explorer/src/CodeSample.jsx
+++ b/packages/api-explorer/src/CodeSample.jsx
@@ -1,7 +1,7 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const extensions = require('@readme/oas-extensions');
-const syntaxHighlighter = require('@readme/syntax-highlighter').default;
+const syntaxHighlighter = require('@readme/syntax-highlighter/dist/index.js').default;
 const Oas = require('@readme/oas-tooling');
 const generateCodeSnippet = require('@readme/oas-to-snippet');
 

--- a/packages/api-explorer/src/ResponseBody.jsx
+++ b/packages/api-explorer/src/ResponseBody.jsx
@@ -1,6 +1,6 @@
 const React = require('react');
 const PropTypes = require('prop-types');
-const syntaxHighlighter = require('@readme/syntax-highlighter').default;
+const syntaxHighlighter = require('@readme/syntax-highlighter/dist/index.js').default;
 const ReactJson = require('react-json-view').default;
 const contentTypeIsJson = require('./lib/content-type-is-json');
 const oauthHref = require('./lib/oauth-href');

--- a/packages/api-explorer/src/ResponseExample.jsx
+++ b/packages/api-explorer/src/ResponseExample.jsx
@@ -1,7 +1,7 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const ReactJson = require('react-json-view').default;
-const syntaxHighlighter = require('@readme/syntax-highlighter').default;
+const syntaxHighlighter = require('@readme/syntax-highlighter/dist/index.js').default;
 const extensions = require('@readme/oas-extensions');
 const Oas = require('@readme/oas-tooling');
 

--- a/packages/api-explorer/src/block-types/CodeElement.jsx
+++ b/packages/api-explorer/src/block-types/CodeElement.jsx
@@ -1,6 +1,6 @@
 const React = require('react');
 const PropTypes = require('prop-types');
-const syntaxHighlighter = require('@readme/syntax-highlighter').default;
+const syntaxHighlighter = require('@readme/syntax-highlighter/dist/index.js').default;
 
 const CopyCode = require('../CopyCode');
 

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -1203,9 +1203,9 @@
       }
     },
     "@readme/syntax-highlighter": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-9.0.1.tgz",
-      "integrity": "sha512-Y00mh2i6HKBSUF2T66T5hCk+8w7UqYago9YaWkZsys1f333oSpyIAcNtnB4AvAnTw1SnuzIjuEi7CW2AgT/fuw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.0.0.tgz",
+      "integrity": "sha512-UHRR0qBGswUvTdO612PspjO8yWF94bXTJolG2FP/hOzbVFOMXprBDT7BUIYwIaVvMlq2qdVls+KERws0luISIA==",
       "requires": {
         "@readme/variable": "^7.2.1",
         "codemirror": "^5.48.2",
@@ -1216,9 +1216,9 @@
       }
     },
     "@readme/variable": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-7.2.2.tgz",
-      "integrity": "sha512-RUlYFs5FfNOZrT7h8O2KZL+eLFo+ckewo+MNWTnNxGo6Qwk7AuRElomw2jAhn35e/XuH58YcaCxamIHRXbiz+w==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-7.3.0.tgz",
+      "integrity": "sha512-SsI/8hgD66NA5mppoNnzHUXvF6QbzE8//pq4y21dCpB17AtVQ12cOu/YIPjNe9sTFnz0EzaJsaZqHVccLJn86Q==",
       "requires": {
         "classnames": "^2.2.6",
         "prop-types": "^15.7.2",
@@ -2159,9 +2159,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.57.0.tgz",
-      "integrity": "sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg=="
+      "version": "5.58.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.58.1.tgz",
+      "integrity": "sha512-UGb/ueu20U4xqWk8hZB3xIfV2/SFqnSLYONiM3wTMDqko0bsYrsAkGGhqUzbRkYm89aBKPyHtuNEbVWF9FTFzw=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -7,7 +7,7 @@
     "@readme/httpsnippet": "^2.1.1",
     "@readme/oas-extensions": "^7.2.3",
     "@readme/oas-to-har": "^7.3.0",
-    "@readme/syntax-highlighter": "^9.0.1",
+    "@readme/syntax-highlighter": "^10.0.0",
     "httpsnippet-client-api": "^2.3.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## 📖  Release Notes
### 10.0.0 (2020-10-05)

* fix(bundle): client and server compatibility (#20) ([bd4362b](https://github.com/readmeio/syntax-highlighter/commit/bd4362b)), closes [#20](https://github.com/readmeio/syntax-highlighter/issues/20)
* chore(deps-dev): bump @commitlint/cli from 9.1.2 to 11.0.0 (#10) ([c466e8d](https://github.com/readmeio/syntax-highlighter/commit/c466e8d)), closes [#10](https://github.com/readmeio/syntax-highlighter/issues/10)
* chore(deps-dev): bump @commitlint/config-conventional (#19) ([b700798](https://github.com/readmeio/syntax-highlighter/commit/b700798)), closes [#19](https://github.com/readmeio/syntax-highlighter/issues/19)
* chore(deps-dev): bump css-loader from 3.6.0 to 4.3.0 (#16) ([e3c0c67](https://github.com/readmeio/syntax-highlighter/commit/e3c0c67)), closes [#16](https://github.com/readmeio/syntax-highlighter/issues/16)
* chore(deps-dev): bump eslint from 7.8.0 to 7.10.0 (#11) ([d5e30e0](https://github.com/readmeio/syntax-highlighter/commit/d5e30e0)), closes [#11](https://github.com/readmeio/syntax-highlighter/issues/11)
* chore(deps-dev): bump husky from 4.2.5 to 4.3.0 (#18) ([7e437fe](https://github.com/readmeio/syntax-highlighter/commit/7e437fe)), closes [#18](https://github.com/readmeio/syntax-highlighter/issues/18)
* chore(deps-dev): bump prettier from 2.1.1 to 2.1.2 (#14) ([f3c572f](https://github.com/readmeio/syntax-highlighter/commit/f3c572f)), closes [#14](https://github.com/readmeio/syntax-highlighter/issues/14)
* chore(deps-dev): bump sass-loader from 10.0.1 to 10.0.2 (#12) ([2e9a2e9](https://github.com/readmeio/syntax-highlighter/commit/2e9a2e9)), closes [#12](https://github.com/readmeio/syntax-highlighter/issues/12)
* chore(deps-dev): bump terser-webpack-plugin from 4.1.0 to 4.2.2 (#15) ([9c0d3dc](https://github.com/readmeio/syntax-highlighter/commit/9c0d3dc)), closes [#15](https://github.com/readmeio/syntax-highlighter/issues/15)
* chore(deps-dev): bump webpack from 4.44.1 to 4.44.2 (#17) ([828adca](https://github.com/readmeio/syntax-highlighter/commit/828adca)), closes [#17](https://github.com/readmeio/syntax-highlighter/issues/17)
* chore(deps): bump actions/checkout from v2.3.2 to v2.3.3 (#9) ([6f1fda0](https://github.com/readmeio/syntax-highlighter/commit/6f1fda0)), closes [#9](https://github.com/readmeio/syntax-highlighter/issues/9)
* chore(deps): bump codemirror from 5.57.0 to 5.58.1 (#13) ([7d7c7b3](https://github.com/readmeio/syntax-highlighter/commit/7d7c7b3)), closes [#13](https://github.com/readmeio/syntax-highlighter/issues/13)