### PR TITLE
fix: camelcase "allowDangerousHtml"

### DIFF
--- a/packages/markdown-magic/index.js
+++ b/packages/markdown-magic/index.js
@@ -49,7 +49,7 @@ module.exports = function markdown(text, opts = {}) {
     .use(variableParser.sanitize(sanitize))
     .use(!opts.correctnewlines ? breaks : () => {})
     .use(gemojiParser.sanitize(sanitize))
-    .use(remarkRehype, { allowDangerousHTML: true })
+    .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeRaw)
     .use(rehypeSanitize)
     .use(rehypeReact, {


### PR DESCRIPTION
## 🧰 What's being changed?

Fixes this error here: https://developers.logitech.com/circle/reference/accessories-api
```
mdast-util-to-hast: deprecation: `allowDangerousHTML` is nonstandard, use `allowDangerousHtml` instead
```
![image](https://user-images.githubusercontent.com/8854718/95604581-646b1200-0a1d-11eb-9cbd-019481cc8448.png)
