### PR TITLE
fix: don't set an undefined format on the schema if we don't recognize it

### DIFF
--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -147,6 +147,23 @@ test('should not throw on unknown string format', () => {
   expect(params.find('input')).toHaveLength(1);
 });
 
+// If we have `readOnly` and `allOf` on the same level, with no `format` or `type`, we want to make sure that the form
+// can get properly rendered out, and nothing gets added to either schema that'll cause them to not be able to be merged
+// into each other by `@readme/oas-form`.
+//
+// https://github.com/readmeio/api-explorer/issues/967
+test('should not throw on a readOnly + allOf schema', () => {
+  const testOas = new Oas(polymorphism);
+
+  expect(() => {
+    mount(
+      <div>
+        <Params {...props} oas={testOas} operation={testOas.operation('/pets', 'put')} />
+      </div>
+    );
+  }).not.toThrow('Unsupported field schema for field `body-putpets__self`: Unknown field type undefined.');
+});
+
 test('should convert `mixed type` to string', () => {
   const params = renderParams({ type: 'mixed type' });
 

--- a/packages/api-explorer/__tests__/__fixtures__/polymorphism/oas.json
+++ b/packages/api-explorer/__tests__/__fixtures__/polymorphism/oas.json
@@ -37,6 +37,50 @@
             "description": "Updated"
           }
         }
+      },
+      "put": {
+        "summary": "allOf with a readOnly prop",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "_self": {
+                    "readOnly": true,
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/linkBase"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "$ref": "#/components/schemas/linkBase"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "id": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
       }
     }
   },
@@ -93,6 +137,25 @@
             }
           }
         ]
+      },
+      "linkBase": {
+        "type": "object",
+        "required": [
+          "href",
+          "rel"
+        ],
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "rel": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string",
+            "readOnly": true
+          }
+        }
       }
     }
   }

--- a/packages/api-explorer/src/form-components/SchemaField.jsx
+++ b/packages/api-explorer/src/form-components/SchemaField.jsx
@@ -107,8 +107,11 @@ function SchemaField(props) {
     delete schema.$ref;
   }
 
-  if (!doesFormatExist(props.registry.widgets, schema.type, schema.format)) {
-    schema.format = undefined;
+  // If we have a format that isn't recognized by any widget that we've set up in the form, we should remove it because
+  // we won't know how to render it and schemas without a format will just get rendered automatically a `string`
+  // anyways.
+  if (schema.format && !doesFormatExist(props.registry.widgets, schema.type, schema.format)) {
+    delete schema.format;
   }
 
   if ('name' in props) {


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes an edge case where if a `format` was not present on a schema, we'd add `format: undefined` to it. The problem with doing this however is that on a case of a schema that has no `type` but `readOnly` and `allOf`, we'd create an `allOf` schema that was unable to be handled properly. Reason for this is that deep inside the form module we use [json-schema-merge-allof](https://www.npmjs.com/package/json-schema-merge-allof) that attempts to merge `allOf` schemas into something we can render, but with `format: undefined` at this level it'd try to merge the following arrays into each other and fail:

```js
[
  {readOnly: true, format: undefined},
  {allOf: [...]}
]
```

Remove `format: undefined` and it works as expected. Why was `format: undefined` being added in the first place though? Well that's because we have some protections in place to filter out formats that we don't recognize, like `format: "i32"` instead of `format: "int32"`. When filtering these formats out though, we weren't checking to see if there was a format at all. We now only filter out formats if we have a format.

Five hours of debugging boiled down to a two line fix. 🤦 

Fixes #967 

## 🧪 Testing

You can see the broken case of this happening on http://bin.readme.com/s/5f876263410c3700243caa54

With `readOnly` at the same level as the `allOf`, we'd create a schema that was unable to be merged into the `allOf` which would cause [json-schema-merge-allof](https://www.npmjs.com/package/json-schema-merge-allof) to throw an exception, which would bubble up into the form module.