### PR TITLE
chore(deps): upgrading @readme/markdown to hide code copy buttons

### DIFF
--- a/packages/api-explorer/__tests__/form-components/DescriptionField.test.jsx
+++ b/packages/api-explorer/__tests__/form-components/DescriptionField.test.jsx
@@ -9,15 +9,12 @@ test.each([[true], [false]])('should parse description as markdown [new markdown
 
   let html;
   if (useNewMarkdownEngine) {
-    html = mount(markdown.react(actual)).html();
+    html = mount(markdown.react(actual, { copyButtons: false })).html();
   } else {
     html = shallow(markdownMagic(actual)).html();
   }
 
-  // I wanted to use http://airbnb.io/enzyme/docs/api/ShallowWrapper/contains.html here but it wasnt working
-  expect(
-    shallow(<DescriptionField description={actual} formContext={{ useNewMarkdownEngine }} />)
-      .html()
-      .indexOf(html) > 1
-  ).toBe(true);
+  expect(shallow(<DescriptionField description={actual} formContext={{ useNewMarkdownEngine }} />).html()).toContain(
+    html
+  );
 });

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1290,9 +1290,9 @@
       "integrity": "sha512-sC94wCjHfHYt87j+pKnG6FaKMX0N6BLBINPokR3XXGv43lhT32qbFbWDzmBuiJOC4PRHg0M4kMsBToVH47V6mA=="
     },
     "@readme/markdown": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/@readme/markdown/-/markdown-6.20.1.tgz",
-      "integrity": "sha512-qsM7JN5a9UVNVsqxGXA1NfUbaO76PfzeIXBcAmed4+ResFYzEm0AuOzIeTKH/6Jor52o8q0IymwmG1dIR9pW2w==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@readme/markdown/-/markdown-6.21.0.tgz",
+      "integrity": "sha512-ceVa0iLZiXpm+qINDo6qXfqNIusb42stiM6EvyJt9IKr8D/YTniRwj43Zd6d1rQU/dw1yVpzUQlQ2MPdGT9ffg==",
       "requires": {
         "@readme/emojis": "^1.0.0",
         "@readme/syntax-highlighter": "^6.15.2",
@@ -8951,9 +8951,9 @@
       }
     },
     "property-information": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.5.0.tgz",
-      "integrity": "sha512-RgEbCx2HLa1chNgvChcx+rrCWD0ctBmGSE0M7lVm1yyv4UbvbrWoXp/BkVLZefzjrRBGW8/Js6uh/BnlHXFyjA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
       "requires": {
         "xtend": "^4.0.0"
       }

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "@readme/http-status-codes": "^7.1.0",
-    "@readme/markdown": "^6.15.2",
+    "@readme/markdown": "^6.21.0",
     "@readme/markdown-magic": "^8.0.0",
     "@readme/oas-extensions": "^8.0.0",
     "@readme/oas-form": "^8.0.0",

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -364,7 +364,7 @@ class Doc extends React.Component {
               <h2>{doc.title}</h2>
               {doc.excerpt && (
                 <div className="markdown-body excerpt">
-                  {useNewMarkdownEngine ? markdown(doc.excerpt) : markdownMagic(doc.excerpt)}
+                  {useNewMarkdownEngine ? markdown(doc.excerpt, { copyButtons: false }) : markdownMagic(doc.excerpt)}
                 </div>
               )}
             </header>

--- a/packages/api-explorer/src/ResponseSchema.jsx
+++ b/packages/api-explorer/src/ResponseSchema.jsx
@@ -99,7 +99,7 @@ class ResponseSchema extends React.Component {
           {response.description &&
             (useNewMarkdownEngine ? (
               <div className="markdown-body" style={{ padding: 0 }}>
-                <div className="pin">{markdown(response.description)}</div>
+                <div className="pin">{markdown(response.description, { copyButtons: false })}</div>
               </div>
             ) : (
               <div className="desc">{markdownMagic(response.description)}</div>

--- a/packages/api-explorer/src/ResponseSchemaBody.jsx
+++ b/packages/api-explorer/src/ResponseSchemaBody.jsx
@@ -16,7 +16,7 @@ function getSchemaType(schema) {
 
 function getDescriptionMarkdown(useNewMarkdownEngine, description) {
   if (useNewMarkdownEngine) {
-    return markdown(description);
+    return markdown(description, { copyButtons: false });
   }
 
   return markdownMagic(description);

--- a/packages/api-explorer/src/block-types/Content.jsx
+++ b/packages/api-explorer/src/block-types/Content.jsx
@@ -47,8 +47,9 @@ const Content = props => {
 
   if (useNewMarkdownEngine) {
     const content = markdown(body, {
-      showAnchorIcons: splitReferenceDocs,
       compatibilityMode: flags.rdmdCompatibilityMode,
+      copyButtons: false,
+      showAnchorIcons: splitReferenceDocs,
     });
 
     if (isThreeColumn === true) {

--- a/packages/api-explorer/src/form-components/DescriptionField.jsx
+++ b/packages/api-explorer/src/form-components/DescriptionField.jsx
@@ -7,7 +7,7 @@ const markdownMagic = require('@readme/markdown-magic');
 
 function getDescriptionMarkdown(useNewMarkdownEngine, description) {
   if (useNewMarkdownEngine) {
-    return markdown(description);
+    return markdown(description, { copyButtons: false });
   }
 
   return markdownMagic(description);


### PR DESCRIPTION
## 🧰 What's being changed?

Upgrades `@readme/markdown` to take advantage of the new `copyButtons` option I introduced in https://github.com/readmeio/markdown/pull/59 to allow us to hide copy buttons from showing up in rendered `code` markdown.

## 🧪 Testing

Copy buttons are visible here: http://bin.readme.com/s/5f879491410c3700243caa57

![Screen Shot 2020-10-14 at 5 15 30 PM](https://user-images.githubusercontent.com/33762/96058734-e190ef80-0e40-11eb-969f-c45a9dab56a6.png)

With this update:

![Screen Shot 2020-10-14 at 5 15 44 PM](https://user-images.githubusercontent.com/33762/96058741-e9509400-0e40-11eb-8821-a1ad87686f2b.png)

