### PR TITLE
feat: swapping request module node samples with node-fetch

### DIFF
--- a/packages/oas-to-snippet/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/oas-to-snippet/__tests__/__snapshots__/index.test.js.snap
@@ -4,7 +4,7 @@ exports[`multipart/form-data handlings should convert a multipart/form-data oper
 Object {
   "code": "curl --request POST \\\\
   --url https://example.com/multipart \\\\
-  --header 'content-type: multipart/form-data; boundary=---011000010111000001101001' \\\\
+  --header 'Content-Type: multipart/form-data; boundary=---011000010111000001101001' \\\\
   --form orderId=10 \\\\
   --form userId=3232 \\\\
   --form documentFile=@owlbert.png",

--- a/packages/oas-to-snippet/__tests__/index.test.js
+++ b/packages/oas-to-snippet/__tests__/index.test.js
@@ -67,7 +67,7 @@ test('should pass through json values to code snippet', () => {
     oasUrl
   );
 
-  expect(code).toStrictEqual(expect.stringMatching("body: {id: '123'}"));
+  expect(code).toMatch('body: \'{"id":"123"}\'');
 });
 
 test('should pass through form encoded values to code snippet', () => {
@@ -97,7 +97,8 @@ test('should pass through form encoded values to code snippet', () => {
     oasUrl
   );
 
-  expect(code).toStrictEqual(expect.stringMatching("form: {id: '123'}"));
+  expect(code).toMatch("encodedParams.set('id', '123');");
+  expect(code).toMatch('body: encodedParams.toString()');
 });
 
 test('should not contain proxy url', () => {

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -1150,9 +1150,9 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.2.0.tgz",
-      "integrity": "sha512-3VUsfcXqqUKhm6Lp0h6I1ZlwDKT0IKWWS3hyKL80QP27ajq69Pw2f3WuctwPySOGCPnkgmita6kDhEnGBOaTyw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.2.2.tgz",
+      "integrity": "sha512-Ejhwekiii6EMcfBKCLsizzQtWf27ipVv0mCtra/0Qj8qBNYlr50OMDxkt56J6nf4C/rH9+AoMsfQUIl3bcXQlA==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -3846,9 +3846,9 @@
       }
     },
     "httpsnippet-client-api": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.3.1.tgz",
-      "integrity": "sha512-y2jltaYdsle4i6vC49nqC1rd9oVNXQYl/VOcRXCk4Sr6mAeTAkSLBZL8k8Xh5LIBlhbwqKlfvlI+99J9vn0qrw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.3.3.tgz",
+      "integrity": "sha512-ngC3I2L3Av0Jd4n1lR58CkqcO41KyRvNWt+SlrhenCf4qx4l25WHZe9UPTwoFdBPX019kTSSmZ2rKEx54pKBbA==",
       "requires": {
         "@readme/httpsnippet": "^2.0.1",
         "@readme/oas-tooling": "^3.5.8",

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -1150,9 +1150,9 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.1.1.tgz",
-      "integrity": "sha512-7vpyeyPqjhIeWI/vFY+eHzebK9cCayDlGYkRRtbpNfpINWEjlONcK6PHs60GS55WJpLhNeECV7UQYEui5QVaiA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.2.0.tgz",
+      "integrity": "sha512-3VUsfcXqqUKhm6Lp0h6I1ZlwDKT0IKWWS3hyKL80QP27ajq69Pw2f3WuctwPySOGCPnkgmita6kDhEnGBOaTyw==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",
@@ -1177,6 +1177,21 @@
       "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-3.6.0.tgz",
       "integrity": "sha512-8wAXHTKOEstiDO5tYxCdVXv9LOTU7xO5OWqcHTlVQwEZ8bXMxiVRgmGbYuAjLvC851J3jaajoNMVvsRxcQ7YMA==",
       "dev": true
+    },
+    "@readme/oas-extensions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-8.0.0.tgz",
+      "integrity": "sha512-pDIFyXAMKgiGbt+BCvkbRuH9LBhm29YjB6mlAc7I5TDOG45O9pxEsTltnO0/0UzyyGSA2GjJp0J6ycTPQIgkzA=="
+    },
+    "@readme/oas-to-har": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-8.0.1.tgz",
+      "integrity": "sha512-oORp/gaLH+16+vKQu7DuBtLyNIeXshen6snK/aB/2OrsOUajKkaGotYauqFlZQO2Zlzb7H/jFOt7mcryo2dgcw==",
+      "requires": {
+        "@readme/oas-extensions": "^8.0.0",
+        "@readme/oas-tooling": "^3.6.1",
+        "parse-data-url": "^3.0.0"
+      }
     },
     "@readme/oas-tooling": {
       "version": "3.6.1",
@@ -6421,6 +6436,14 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-data-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-3.0.0.tgz",
+      "integrity": "sha512-U72k3mbLzeTiPgVbMIJKG+LROejvsniSMwAgz8EM+DhP0C2HYAmXu65uq2IWjYLffgZndFa42E9TCOHJCi37uA==",
+      "requires": {
+        "valid-data-url": "^3.0.1"
+      }
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -8049,6 +8072,11 @@
           "dev": true
         }
       }
+    },
+    "valid-data-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-3.0.1.tgz",
+      "integrity": "sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -4,14 +4,12 @@
   "version": "8.0.1",
   "main": "src/index.js",
   "dependencies": {
-    "@readme/httpsnippet": "^2.1.1",
+    "@readme/httpsnippet": "^2.2.0",
     "@readme/oas-extensions": "^8.0.0",
     "@readme/oas-to-har": "^8.0.1",
+    "@readme/oas-tooling": "^3.6.1",
     "@readme/syntax-highlighter": "^10.0.0",
     "httpsnippet-client-api": "^2.3.0"
-  },
-  "peerDependencies": {
-    "@readme/oas-tooling": "^3.4.7"
   },
   "scripts": {
     "lint": "eslint .",
@@ -33,7 +31,6 @@
   "devDependencies": {
     "@readme/eslint-config": "^3.2.0",
     "@readme/oas-examples": "^3.6.0",
-    "@readme/oas-tooling": "^3.6.1",
     "datauri": "^3.0.0",
     "eslint": "^7.0.0",
     "jest": "^26.0.1",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -9,7 +9,7 @@
     "@readme/oas-to-har": "^8.0.1",
     "@readme/oas-tooling": "^3.6.1",
     "@readme/syntax-highlighter": "^10.0.0",
-    "httpsnippet-client-api": "^2.3.0"
+    "httpsnippet-client-api": "^2.3.3"
   },
   "scripts": {
     "lint": "eslint .",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -4,7 +4,7 @@
   "version": "8.0.1",
   "main": "src/index.js",
   "dependencies": {
-    "@readme/httpsnippet": "^2.2.0",
+    "@readme/httpsnippet": "^2.2.2",
     "@readme/oas-extensions": "^8.0.0",
     "@readme/oas-to-har": "^8.0.1",
     "@readme/oas-tooling": "^3.6.1",

--- a/packages/oas-to-snippet/src/index.js
+++ b/packages/oas-to-snippet/src/index.js
@@ -37,7 +37,7 @@ const supportedLanguages = {
     highlight: 'java',
   },
   node: {
-    httpsnippet: ['node', 'request'],
+    httpsnippet: ['node', 'fetch'],
     highlight: 'javascript',
   },
   'node-simple': {


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] Node code samples now use `node-fetch` instead of `request`.
* [x] Updated our `node-simple` samples to have a `.catch()` statement.

## 🧪 Testing

![Screen Shot 2020-10-15 at 1 19 48 PM](https://user-images.githubusercontent.com/33762/96181588-207a8000-0ee9-11eb-9b7e-1f75c57ee763.png)

![Screen Shot 2020-10-15 at 1 19 52 PM](https://user-images.githubusercontent.com/33762/96181591-22444380-0ee9-11eb-978f-9d9ebac5fd29.png)
