### PR TITLE
fix: issue in node-simple snippets where basic auth wasn't decoded

### DIFF
--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -3846,12 +3846,12 @@
       }
     },
     "httpsnippet-client-api": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.3.3.tgz",
-      "integrity": "sha512-ngC3I2L3Av0Jd4n1lR58CkqcO41KyRvNWt+SlrhenCf4qx4l25WHZe9UPTwoFdBPX019kTSSmZ2rKEx54pKBbA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.4.0.tgz",
+      "integrity": "sha512-gX3qBlKTth34EnqEFBfVYaAbx4Mzo/Kia0CwV9NR0PIsNhCdgkjvcUDpn0TiV6ZdvB/e2oINf5gyzneNA99LUg==",
       "requires": {
-        "@readme/httpsnippet": "^2.0.1",
-        "@readme/oas-tooling": "^3.5.8",
+        "@readme/httpsnippet": "^2.2.2",
+        "@readme/oas-tooling": "^3.6.1",
         "content-type": "^1.0.4",
         "path-to-regexp": "^6.1.0",
         "stringify-object": "^3.3.0"

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -9,7 +9,7 @@
     "@readme/oas-to-har": "^8.0.1",
     "@readme/oas-tooling": "^3.6.1",
     "@readme/syntax-highlighter": "^10.0.0",
-    "httpsnippet-client-api": "^2.3.3"
+    "httpsnippet-client-api": "^2.4.0"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
## 🧰 What's being changed?

This upgrades the `node-simple` code snippet generator to fix a couple issues, namely being that `Basic` auth wasn't being decoded for `sdk.auth()` calls.

![Screen Shot 2020-10-16 at 4 24 48 PM](https://user-images.githubusercontent.com/33762/96321963-21d0a900-0fcc-11eb-824e-24dc6aaab8a7.png)

With the fixes in the library:

![Screen Shot 2020-10-16 at 4 22 23 PM](https://user-images.githubusercontent.com/33762/96321978-28f7b700-0fcc-11eb-902e-31d91612c418.png)

Resolves https://github.com/readmeio/api-explorer/issues/832

## 🧪 Testing

You can test out basic auth with the [auth-types](http://localhost:9966/?selected=swagger-files%2Fauth-types.json) definition.

## 📖  Release Notes
### 2.4.0 (2020-10-16)

* chore: test cleanup (#181) ([1fe0e95](https://github.com/readmeio/api/commit/1fe0e95)), closes [#181](https://github.com/readmeio/api/issues/181)
* fix: adding support for non-alphanumerical operation ids (#180) ([fd075a0](https://github.com/readmeio/api/commit/fd075a0)), closes [#180](https://github.com/readmeio/api/issues/180)
* fix: basic auth headers now decoded and exploded into `.auth()` calls (#179) ([2351b95](https://github.com/readmeio/api/commit/2351b95)), closes [#179](https://github.com/readmeio/api/issues/179)