### PR TITLE
fix: updating the ResponseSchemaBody for the async flattenSchema changes

### DIFF
--- a/packages/api-explorer/__tests__/ResponseSchemaBody.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseSchemaBody.test.jsx
@@ -1,5 +1,6 @@
 const React = require('react');
 const { shallow, mount } = require('enzyme');
+const { waitFor } = require('@testing-library/dom');
 const Oas = require('oas/tooling');
 
 const ResponseSchemaBody = require('../src/ResponseSchemaBody');
@@ -16,28 +17,14 @@ test('display object properties in the table', () => {
       },
     },
   };
-  const responseSchemaBody = shallow(<ResponseSchemaBody oas={oas} schema={schema} />);
 
-  expect(responseSchemaBody.find('th').text()).toContain('String');
-  expect(responseSchemaBody.find('td').text()).toBe('a');
-});
+  const comp = shallow(<ResponseSchemaBody oas={oas} schema={schema} />);
+  return waitFor(() => {
+    comp.update();
 
-test('display properties if object contains $ref type', () => {
-  const schema = {
-    type: 'object',
-    properties: {
-      category: {
-        $ref: '#/components/schemas/Category',
-      },
-    },
-  };
-
-  expect(
-    shallow(<ResponseSchemaBody oas={oas} schema={schema} />)
-      .find('td')
-      .map(a => a.text())
-      .filter(a => a === 'category.name')
-  ).toHaveLength(1);
+    expect(comp.find('th').text()).toContain('String');
+    expect(comp.find('td').text()).toBe('a');
+  });
 });
 
 test('display object properties inside another object in the table', () => {
@@ -54,58 +41,18 @@ test('display object properties inside another object in the table', () => {
       },
     },
   };
-  expect(
-    shallow(<ResponseSchemaBody oas={oas} schema={schema} />)
-      .find('td')
-      .map(a => a.text())
-      .filter(a => a === 'a.a')
-  ).toHaveLength(1);
-});
 
-test('display $ref items inside object', () => {
-  const schema = {
-    type: 'object',
-    properties: {
-      a: {
-        type: 'object',
-        properties: {
-          pets: {
-            type: 'array',
-            items: {
-              $ref: '#/components/schemas/Pet',
-            },
-          },
-        },
-      },
-    },
-  };
-  const testOas = {
-    components: {
-      schemas: {
-        Pet: {
-          type: 'object',
-          properties: {
-            index: {
-              type: 'integer',
-            },
-          },
-        },
-      },
-    },
-  };
-  const responseSchemaBody = shallow(<ResponseSchemaBody oas={testOas} schema={schema} />);
-  expect(
-    responseSchemaBody
-      .find('th')
-      .map(a => a.text())
-      .filter(a => a === '[Object]')
-  ).toHaveLength(1);
-  expect(
-    responseSchemaBody
-      .find('td')
-      .map(a => a.text())
-      .filter(a => a === 'a.pets[].index')
-  ).toHaveLength(1);
+  const comp = shallow(<ResponseSchemaBody oas={oas} schema={schema} />);
+  return waitFor(() => {
+    comp.update();
+
+    expect(
+      comp
+        .find('td')
+        .map(a => a.text())
+        .filter(a => a === 'a.a')
+    ).toHaveLength(1);
+  });
 });
 
 test('not fail when object property missing', () => {
@@ -113,44 +60,11 @@ test('not fail when object property missing', () => {
     type: 'object',
   };
 
-  expect(shallow(<ResponseSchemaBody oas={oas} schema={schema} />).find('th')).toHaveLength(0);
-});
-
-test('render top level array of $ref', () => {
-  const schema = {
-    type: 'array',
-    items: {
-      $ref: '#/components/schemas/Pet',
-    },
-  };
-
-  const testOas = {
-    components: {
-      schemas: {
-        Pet: {
-          type: 'object',
-          properties: {
-            name: {
-              type: 'string',
-            },
-          },
-        },
-      },
-    },
-  };
-  const responseSchemaBody = shallow(<ResponseSchemaBody oas={testOas} schema={schema} />);
-  expect(
-    responseSchemaBody
-      .find('td')
-      .map(a => a.text())
-      .filter(a => a === 'name')
-  ).toHaveLength(1);
-  expect(
-    responseSchemaBody
-      .find('th')
-      .map(a => a.text())
-      .filter(a => a === 'String')
-  ).toHaveLength(1);
+  const comp = shallow(<ResponseSchemaBody oas={oas} schema={schema} />);
+  return waitFor(() => {
+    comp.update();
+    expect(comp.find('th')).toHaveLength(0);
+  });
 });
 
 test('not render more than 3 level deep object', () => {
@@ -178,19 +92,23 @@ test('not render more than 3 level deep object', () => {
     },
   };
 
-  const responseSchemaBody = shallow(<ResponseSchemaBody oas={oas} schema={schema} />);
-  expect(
-    responseSchemaBody
-      .find('td')
-      .map(a => a.text())
-      .filter(a => a === 'a.a.a')
-  ).toHaveLength(1);
-  expect(
-    responseSchemaBody
-      .find('td')
-      .map(a => a.text())
-      .filter(a => a === 'a.a.a.a')
-  ).toHaveLength(0);
+  const comp = shallow(<ResponseSchemaBody oas={oas} schema={schema} />);
+  return waitFor(() => {
+    comp.update();
+
+    expect(
+      comp
+        .find('td')
+        .map(a => a.text())
+        .filter(a => a === 'a.a.a')
+    ).toHaveLength(1);
+    expect(
+      comp
+        .find('td')
+        .map(a => a.text())
+        .filter(a => a === 'a.a.a.a')
+    ).toHaveLength(0);
+  });
 });
 
 test('render top level array of objects', () => {
@@ -206,19 +124,23 @@ test('render top level array of objects', () => {
     },
   };
 
-  const responseSchemaBody = shallow(<ResponseSchemaBody oas={oas} schema={schema} />);
-  expect(
-    responseSchemaBody
-      .find('td')
-      .map(a => a.text())
-      .filter(a => a === 'name')
-  ).toHaveLength(1);
-  expect(
-    responseSchemaBody
-      .find('th')
-      .map(a => a.text())
-      .filter(a => a === 'String')
-  ).toHaveLength(1);
+  const comp = shallow(<ResponseSchemaBody oas={oas} schema={schema} />);
+  return waitFor(() => {
+    comp.update();
+
+    expect(
+      comp
+        .find('td')
+        .map(a => a.text())
+        .filter(a => a === 'name')
+    ).toHaveLength(1);
+    expect(
+      comp
+        .find('th')
+        .map(a => a.text())
+        .filter(a => a === 'String')
+    ).toHaveLength(1);
+  });
 });
 
 test.each([
@@ -235,11 +157,11 @@ test.each([
     },
   };
 
-  expect(
-    mount(<ResponseSchemaBody oas={oas} schema={schema} useNewMarkdownEngine={useNewMarkdownEngine} />)
-      .find('a')
-      .html()
-  ).toBe(expected);
+  const comp = mount(<ResponseSchemaBody oas={oas} schema={schema} useNewMarkdownEngine={useNewMarkdownEngine} />);
+  return waitFor(() => {
+    comp.update();
+    expect(comp.find('a').html()).toBe(expected);
+  });
 });
 
 test('should show "string" response type for a simple `string` schema', () => {
@@ -247,7 +169,11 @@ test('should show "string" response type for a simple `string` schema', () => {
     type: 'string',
   };
 
-  expect(shallow(<ResponseSchemaBody oas={oas} schema={schema} />).text()).toBe('Response schema type: string');
+  const comp = shallow(<ResponseSchemaBody oas={oas} schema={schema} />);
+  return waitFor(() => {
+    comp.update();
+    expect(comp.text()).toBe('Response schema type: string');
+  });
 });
 
 test('should show "string" response type for an `object` schema that contains a string', () => {
@@ -260,11 +186,12 @@ test('should show "string" response type for an `object` schema that contains a 
     },
   };
 
-  expect(
-    shallow(<ResponseSchemaBody oas={oas} schema={schema} />)
-      .find('p')
-      .text()
-  ).toBe('Response schema type: object');
+  const comp = shallow(<ResponseSchemaBody oas={oas} schema={schema} />);
+  return waitFor(() => {
+    comp.update();
+
+    expect(comp.find('p').text()).toBe('Response schema type: object');
+  });
 });
 
 test('should show "array" response schema type', () => {
@@ -280,9 +207,189 @@ test('should show "array" response schema type', () => {
     },
   };
 
-  expect(
-    shallow(<ResponseSchemaBody oas={oas} schema={schema} />)
-      .find('p')
-      .text()
-  ).toBe('Response schema type: array of objects');
+  const comp = shallow(<ResponseSchemaBody oas={oas} schema={schema} />);
+  return waitFor(() => {
+    comp.update();
+
+    expect(comp.find('p').text()).toBe('Response schema type: array of objects');
+  });
+});
+
+describe('$ref handling', () => {
+  it('display properties if object contains $ref type', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        category: {
+          $ref: '#/components/schemas/Category',
+        },
+      },
+    };
+
+    const comp = shallow(<ResponseSchemaBody oas={oas} schema={schema} />);
+    return waitFor(() => {
+      comp.update();
+
+      expect(
+        comp
+          .find('td')
+          .map(a => a.text())
+          .filter(a => a === 'category.name')
+      ).toHaveLength(1);
+    });
+  });
+
+  it('display $ref items inside object', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        a: {
+          type: 'object',
+          properties: {
+            pets: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/Pet',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const testOas = {
+      components: {
+        schemas: {
+          Pet: {
+            type: 'object',
+            properties: {
+              index: {
+                type: 'integer',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const comp = shallow(<ResponseSchemaBody oas={testOas} schema={schema} />);
+    return waitFor(() => {
+      comp.update();
+
+      expect(
+        comp
+          .find('th')
+          .map(a => a.text())
+          .filter(a => a === '[Object]')
+      ).toHaveLength(1);
+      expect(
+        comp
+          .find('td')
+          .map(a => a.text())
+          .filter(a => a === 'a.pets[].index')
+      ).toHaveLength(1);
+    });
+  });
+
+  it('render top level array of $ref', () => {
+    const schema = {
+      type: 'array',
+      items: {
+        $ref: '#/components/schemas/Pet',
+      },
+    };
+
+    const testOas = {
+      components: {
+        schemas: {
+          Pet: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const comp = shallow(<ResponseSchemaBody oas={testOas} schema={schema} />);
+    return waitFor(() => {
+      comp.update();
+
+      expect(
+        comp
+          .find('td')
+          .map(a => a.text())
+          .filter(a => a === 'name')
+      ).toHaveLength(1);
+      expect(
+        comp
+          .find('th')
+          .map(a => a.text())
+          .filter(a => a === 'String')
+      ).toHaveLength(1);
+    });
+  });
+
+  describe('circular refs', () => {
+    const circularOas = {
+      components: {
+        schemas: {
+          Customfields: {
+            type: 'array',
+            items: {
+              $ref: '#/components/schemas/Customfields',
+            },
+          },
+        },
+      },
+    };
+
+    it('should not fail on a fully circular ref', () => {
+      const schema = {
+        type: 'array',
+        items: {
+          $ref: '#/components/schemas/Customfields',
+        },
+      };
+
+      const comp = shallow(<ResponseSchemaBody oas={circularOas} schema={schema} />);
+      return waitFor(() => {
+        comp.update();
+        expect(comp.find('tr')).toHaveLength(0);
+      });
+    });
+
+    it('should do its best to recognize that a circular ref is present', () => {
+      const schema = {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'number',
+            },
+            fields: {
+              $ref: '#/components/schemas/Customfields',
+            },
+          },
+        },
+      };
+
+      const comp = shallow(<ResponseSchemaBody oas={circularOas} schema={schema} />);
+      return waitFor(() => {
+        comp.update();
+
+        expect(comp.find('tr')).toHaveLength(2);
+
+        expect(comp.find('tr').at(0).find('th').text()).toBe('Number');
+        expect(comp.find('tr').at(0).find('td').text()).toBe('id');
+
+        expect(comp.find('tr').at(1).find('th').text()).toBe('Circular');
+        expect(comp.find('tr').at(1).find('td').text()).toBe('fields');
+      });
+    });
+  });
 });

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -943,22 +943,6 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
-    "@babel/runtime-corejs2": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.1.tgz",
-      "integrity": "sha512-5uSG1M64+OO+DL4U12qTqHDhc1vorwH6suCSPRH+77UVYzxO5TMyziWe/nQNPcPt9Wnl5G7dIYXuZ6MBuW/dFw==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
-        }
-      }
-    },
     "@babel/runtime-corejs3": {
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
@@ -1752,29 +1736,6 @@
       "resolved": "https://registry.npmjs.org/@readme/http-status-codes/-/http-status-codes-7.1.0.tgz",
       "integrity": "sha512-sC94wCjHfHYt87j+pKnG6FaKMX0N6BLBINPokR3XXGv43lhT32qbFbWDzmBuiJOC4PRHg0M4kMsBToVH47V6mA=="
     },
-    "@readme/httpsnippet": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.2.2.tgz",
-      "integrity": "sha512-Ejhwekiii6EMcfBKCLsizzQtWf27ipVv0mCtra/0Qj8qBNYlr50OMDxkt56J6nf4C/rH9+AoMsfQUIl3bcXQlA==",
-      "requires": {
-        "event-stream": "4.0.1",
-        "form-data": "3.0.0",
-        "har-validator": "^5.0.0",
-        "stringify-object": "^3.3.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
     "@readme/markdown": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@readme/markdown/-/markdown-6.21.0.tgz",
@@ -1838,172 +1799,11 @@
         }
       }
     },
-    "@readme/markdown-magic": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@readme/markdown-magic/-/markdown-magic-8.0.3.tgz",
-      "integrity": "sha512-FkdmhDOBE4TmvCa/7hIyBEDR3j6EaiyIr53AIetUzvmYas3Rnjw1yvPL+vVPhn2mHzdae09PCLtf+zy2XJ/b/g==",
-      "requires": {
-        "@readme/emojis": "1.0.0",
-        "@readme/syntax-highlighter": "^7.2.3",
-        "@readme/variable": "^8.0.3",
-        "hast-util-sanitize": "1.3.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2",
-        "rehype-raw": "4.0.2",
-        "rehype-react": "3.1.0",
-        "rehype-sanitize": "2.0.3",
-        "remark-breaks": "1.0.5",
-        "remark-parse": "7.0.2",
-        "remark-rehype": "7.0.0",
-        "unified": "8.4.2"
-      },
-      "dependencies": {
-        "@readme/syntax-highlighter": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-7.2.3.tgz",
-          "integrity": "sha512-BXwNDNLitBpoLqZQ7L7WCTw4/sf6QfkUA7EaeO/qOnE/PKhZC6oA6iTDFW6B0xq1nJy8r8qOK6K/2G1RnAWO4g==",
-          "requires": {
-            "@readme/variable": "^7.2.3",
-            "codemirror": "^5.48.2",
-            "react": "^16.4.2"
-          },
-          "dependencies": {
-            "@readme/variable": {
-              "version": "7.5.0",
-              "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-7.5.0.tgz",
-              "integrity": "sha512-GC0zZA7DD6jT691x5yROUFteJd7j1pkIEQz5tlNodjZcEVaGghU/h9sLyw5KJlj+v3OYuHci69x3SJwbyt/Rug==",
-              "requires": {
-                "classnames": "^2.2.6",
-                "prop-types": "^15.7.2",
-                "react": "^16.4.2"
-              }
-            }
-          }
-        },
-        "hast-to-hyperscript": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-5.0.0.tgz",
-          "integrity": "sha512-DLl3eYTz8uwwzEubDUdCChsR5t5b2ne+yvHrA2h58Suq/JnN3+Gsb9Tc4iZoCCsykmFUc6UUpwxTmQXs0akSeg==",
-          "requires": {
-            "comma-separated-tokens": "^1.0.0",
-            "property-information": "^4.0.0",
-            "space-separated-tokens": "^1.0.0",
-            "style-to-object": "^0.2.1",
-            "unist-util-is": "^2.0.0",
-            "web-namespaces": "^1.1.2"
-          }
-        },
-        "hast-util-sanitize": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz",
-          "integrity": "sha512-AIeKHuHx0Wk45nSkGVa2/ujQYTksnDl8gmmKo/mwQi7ag7IBZ8cM3nJ2G86SajbjGP/HRpud6kMkPtcM2i0Tlw==",
-          "requires": {
-            "xtend": "^4.0.1"
-          }
-        },
-        "property-information": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/property-information/-/property-information-4.2.0.tgz",
-          "integrity": "sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==",
-          "requires": {
-            "xtend": "^4.0.1"
-          }
-        },
-        "rehype-react": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-3.1.0.tgz",
-          "integrity": "sha512-7SiLiqNudSGkvhrePkdKqdUvngZqzG+PJhdR5EeIFELz2j2ek4aO5DHbxUXYvaZfqUiBDO2Aeq1OROUmxmu+Vg==",
-          "requires": {
-            "@mapbox/hast-util-table-cell-style": "^0.1.3",
-            "has": "^1.0.1",
-            "hast-to-hyperscript": "^5.0.0"
-          }
-        },
-        "rehype-sanitize": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-2.0.3.tgz",
-          "integrity": "sha512-RZFLBV36yOWNbV4g2WJDfilAzV1Sin/InQHXA+5h9+GkxCFnTJCC7SPrAdVHEIrQ882eAD8/51jEYHD6xrewcw==",
-          "requires": {
-            "hast-util-sanitize": "^1.1.0"
-          }
-        },
-        "unist-util-is": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
-        }
-      }
-    },
     "@readme/oas-examples": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-3.6.0.tgz",
       "integrity": "sha512-8wAXHTKOEstiDO5tYxCdVXv9LOTU7xO5OWqcHTlVQwEZ8bXMxiVRgmGbYuAjLvC851J3jaajoNMVvsRxcQ7YMA==",
       "dev": true
-    },
-    "@readme/oas-extensions": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-8.0.0.tgz",
-      "integrity": "sha512-pDIFyXAMKgiGbt+BCvkbRuH9LBhm29YjB6mlAc7I5TDOG45O9pxEsTltnO0/0UzyyGSA2GjJp0J6ycTPQIgkzA=="
-    },
-    "@readme/oas-form": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-form/-/oas-form-8.0.0.tgz",
-      "integrity": "sha512-7AlhtVfsIjQrMb1Z3fWkTZ0m45f189p5IvLj7LLxeefBCuSOpSRTd5VZPHijP2TDeOkd07wwCLv9aocvGtfDWg==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.4.5",
-        "ajv": "^6.7.0",
-        "core-js": "^2.5.7",
-        "json-schema-merge-allof": "^0.6.0",
-        "jsonpointer": "^4.0.1",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.9.0",
-        "shortid": "^2.2.14"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
-      }
-    },
-    "@readme/oas-to-har": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-8.0.3.tgz",
-      "integrity": "sha512-/QNVHqYK3kIE29hE37/CkcTo/OlONVLNhUcB6RKcTenSbxRvP9FhiaDAHKTthfksatfswBpegWAKhOa22k+r9A==",
-      "requires": {
-        "@readme/oas-extensions": "^8.0.0",
-        "@readme/oas-tooling": "^3.6.1",
-        "parse-data-url": "^3.0.0"
-      }
-    },
-    "@readme/oas-to-snippet": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-8.0.3.tgz",
-      "integrity": "sha512-TA7Tu0PupB4cKfqvD9P7kO7V0tFaF9AarbsyS6+6lyl3hTmrmG3wYaBSROJSnCsjmY3C3gZSUx3XmfOsdX5HBQ==",
-      "requires": {
-        "@readme/httpsnippet": "^2.2.2",
-        "@readme/oas-extensions": "^8.0.0",
-        "@readme/oas-to-har": "^8.0.3",
-        "@readme/oas-tooling": "^3.6.1",
-        "@readme/syntax-highlighter": "^10.0.0",
-        "httpsnippet-client-api": "^2.4.0"
-      }
-    },
-    "@readme/oas-tooling": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.6.1.tgz",
-      "integrity": "sha512-hF0Iwh3DmsP3HHY9djVUI957HsHvlBw+H9GMjZJCy2pRFqjor1+l9uOYZl9L1AaajGJX5EXf8PqXfwD1Cr0V6Q==",
-      "requires": {
-        "jsonpointer": "^4.0.1",
-        "path-to-regexp": "^6.1.0"
-      }
     },
     "@readme/syntax-highlighter": {
       "version": "10.0.0",
@@ -2028,16 +1828,6 @@
             "react": "^16.4.2"
           }
         }
-      }
-    },
-    "@readme/variable": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-8.0.3.tgz",
-      "integrity": "sha512-ONuS5GB9Oz4mojEYNxu0/UYOJJ/hMPLjKPp4ScX9xoKPOrmhil78fO3Xz4YDX2suXZzI8qBVIBTBF5QT5sroug==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
       }
     },
     "@sinonjs/commons": {
@@ -2596,6 +2386,7 @@
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2606,12 +2397,14 @@
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
         }
       }
     },
@@ -3925,27 +3718,6 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
-    "compute-gcd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.0.tgz",
-      "integrity": "sha1-/B7eW2UAHpUCJlAvRlQ4Y+T+oQ4=",
-      "requires": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
-    "compute-lcm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.0.tgz",
-      "integrity": "sha1-q9ltBAtBsKFm+JlEtci3xRHiGtU=",
-      "requires": {
-        "compute-gcd": "^1.2.0",
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3991,11 +3763,6 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
-    },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -4509,11 +4276,6 @@
           "dev": true
         }
       }
-    },
-    "duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "duplexify": {
       "version": "3.7.1",
@@ -5387,20 +5149,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "event-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
-      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
-      "requires": {
-        "duplexer": "^0.1.1",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
-      }
-    },
     "events": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
@@ -6002,11 +5750,6 @@
         "map-cache": "^0.2.2"
       }
     },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
-    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -6053,7 +5796,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -6072,11 +5816,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
-    },
-    "get-own-enumerable-property-symbols": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
-      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -6263,6 +6002,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -6609,18 +6349,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
-    },
-    "httpsnippet-client-api": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.4.1.tgz",
-      "integrity": "sha512-mlvBZNM8ftSj4ErCmdcJ2gRvV8FpjpQ/TPF3OUaLRqoSn9GFdCpCwxUIQNPR67D2oGGg9Os5/0TJCAjOdO9OSw==",
-      "requires": {
-        "@readme/httpsnippet": "^2.2.2",
-        "content-type": "^1.0.4",
-        "oas": "^4.0.0",
-        "path-to-regexp": "^6.1.0",
-        "stringify-object": "^3.3.0"
-      }
     },
     "human-signals": {
       "version": "1.1.1",
@@ -6973,11 +6701,6 @@
         "kind-of": "^3.0.2"
       }
     },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-    },
     "is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -7014,11 +6737,6 @@
       "requires": {
         "has-symbols": "^1.0.1"
       }
-    },
-    "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -8329,24 +8047,6 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
-    "json-schema-compare": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
-      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
-      "requires": {
-        "lodash": "^4.17.4"
-      }
-    },
-    "json-schema-merge-allof": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
-      "integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
-      "requires": {
-        "compute-lcm": "^1.1.0",
-        "json-schema-compare": "^0.2.2",
-        "lodash": "^4.17.4"
-      }
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -8648,11 +8348,6 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
-    },
-    "map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -9023,11 +8718,6 @@
       "dev": true,
       "optional": true
     },
-    "nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -9278,9 +8968,9 @@
       "dev": true
     },
     "oas": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-4.1.0.tgz",
-      "integrity": "sha512-cHX+c6vwquLhemRfWj+APCz502y3RheQsoIKJbqFB0MdTRuIk9K7k3QObCMZ7tYyvy3luI3XiRfNcJDrZvn7nQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-5.0.0.tgz",
+      "integrity": "sha512-6H/U6fc1AhChfr/NuXaQRPnBh+PVTooDphFBgNS39CAqjmSVjjC+C0G4RuywU1wkNj7ir4uwg5f8EDjkz65j+Q==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -9770,14 +9460,6 @@
       "dev": true,
       "requires": {
         "pify": "^2.0.0"
-      }
-    },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "requires": {
-        "through": "~2.3"
       }
     },
     "pbkdf2": {
@@ -10389,7 +10071,8 @@
     "regenerator-runtime": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-      "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+      "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==",
+      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -11050,14 +10733,6 @@
       "dev": true,
       "optional": true
     },
-    "shortid": {
-      "version": "2.2.15",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
-      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
-      "requires": {
-        "nanoid": "^2.1.0"
-      }
-    },
     "should": {
       "version": "13.2.3",
       "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
@@ -11354,14 +11029,6 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "requires": {
-        "through": "2"
-      }
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -11464,15 +11131,6 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      }
-    },
-    "stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-      "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
       }
     },
     "stream-each": {
@@ -11647,16 +11305,6 @@
         "is-alphanumerical": "^1.0.0",
         "is-decimal": "^1.0.2",
         "is-hexadecimal": "^1.0.0"
-      }
-    },
-    "stringify-object": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-      "requires": {
-        "get-own-enumerable-property-symbols": "^3.0.0",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -12742,38 +12390,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "validate.io-array": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
-    },
-    "validate.io-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc="
-    },
-    "validate.io-integer": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
-      "requires": {
-        "validate.io-number": "^1.0.3"
-      }
-    },
-    "validate.io-integer-array": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
-      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
-      "requires": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-integer": "^1.0.4"
-      }
-    },
-    "validate.io-number": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
     },
     "validator": {
       "version": "12.2.0",

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -9278,10 +9278,11 @@
       "dev": true
     },
     "oas": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-4.0.0.tgz",
-      "integrity": "sha512-DGeXKXxs9xdCqI30IVLwIJ9IqkQssi+8N0DDfIokrxN70re3wSMYvieEDwFcu/KotzMuHXyjURqFQBDSfDNysw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-4.1.0.tgz",
+      "integrity": "sha512-cHX+c6vwquLhemRfWj+APCz502y3RheQsoIKJbqFB0MdTRuIk9K7k3QObCMZ7tYyvy3luI3XiRfNcJDrZvn7nQ==",
       "requires": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
         "colors": "^1.1.2",
         "figures": "^3.0.0",

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -943,6 +943,22 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs2": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.1.tgz",
+      "integrity": "sha512-5uSG1M64+OO+DL4U12qTqHDhc1vorwH6suCSPRH+77UVYzxO5TMyziWe/nQNPcPt9Wnl5G7dIYXuZ6MBuW/dFw==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+        }
+      }
+    },
     "@babel/runtime-corejs3": {
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
@@ -1736,6 +1752,29 @@
       "resolved": "https://registry.npmjs.org/@readme/http-status-codes/-/http-status-codes-7.1.0.tgz",
       "integrity": "sha512-sC94wCjHfHYt87j+pKnG6FaKMX0N6BLBINPokR3XXGv43lhT32qbFbWDzmBuiJOC4PRHg0M4kMsBToVH47V6mA=="
     },
+    "@readme/httpsnippet": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.2.2.tgz",
+      "integrity": "sha512-Ejhwekiii6EMcfBKCLsizzQtWf27ipVv0mCtra/0Qj8qBNYlr50OMDxkt56J6nf4C/rH9+AoMsfQUIl3bcXQlA==",
+      "requires": {
+        "event-stream": "4.0.1",
+        "form-data": "3.0.0",
+        "har-validator": "^5.0.0",
+        "stringify-object": "^3.3.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@readme/markdown": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@readme/markdown/-/markdown-6.21.0.tgz",
@@ -1799,11 +1838,172 @@
         }
       }
     },
+    "@readme/markdown-magic": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@readme/markdown-magic/-/markdown-magic-8.0.3.tgz",
+      "integrity": "sha512-FkdmhDOBE4TmvCa/7hIyBEDR3j6EaiyIr53AIetUzvmYas3Rnjw1yvPL+vVPhn2mHzdae09PCLtf+zy2XJ/b/g==",
+      "requires": {
+        "@readme/emojis": "1.0.0",
+        "@readme/syntax-highlighter": "^7.2.3",
+        "@readme/variable": "^8.0.3",
+        "hast-util-sanitize": "1.3.1",
+        "prop-types": "^15.7.2",
+        "react": "^16.4.2",
+        "rehype-raw": "4.0.2",
+        "rehype-react": "3.1.0",
+        "rehype-sanitize": "2.0.3",
+        "remark-breaks": "1.0.5",
+        "remark-parse": "7.0.2",
+        "remark-rehype": "7.0.0",
+        "unified": "8.4.2"
+      },
+      "dependencies": {
+        "@readme/syntax-highlighter": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-7.2.3.tgz",
+          "integrity": "sha512-BXwNDNLitBpoLqZQ7L7WCTw4/sf6QfkUA7EaeO/qOnE/PKhZC6oA6iTDFW6B0xq1nJy8r8qOK6K/2G1RnAWO4g==",
+          "requires": {
+            "@readme/variable": "^7.2.3",
+            "codemirror": "^5.48.2",
+            "react": "^16.4.2"
+          },
+          "dependencies": {
+            "@readme/variable": {
+              "version": "7.5.0",
+              "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-7.5.0.tgz",
+              "integrity": "sha512-GC0zZA7DD6jT691x5yROUFteJd7j1pkIEQz5tlNodjZcEVaGghU/h9sLyw5KJlj+v3OYuHci69x3SJwbyt/Rug==",
+              "requires": {
+                "classnames": "^2.2.6",
+                "prop-types": "^15.7.2",
+                "react": "^16.4.2"
+              }
+            }
+          }
+        },
+        "hast-to-hyperscript": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-5.0.0.tgz",
+          "integrity": "sha512-DLl3eYTz8uwwzEubDUdCChsR5t5b2ne+yvHrA2h58Suq/JnN3+Gsb9Tc4iZoCCsykmFUc6UUpwxTmQXs0akSeg==",
+          "requires": {
+            "comma-separated-tokens": "^1.0.0",
+            "property-information": "^4.0.0",
+            "space-separated-tokens": "^1.0.0",
+            "style-to-object": "^0.2.1",
+            "unist-util-is": "^2.0.0",
+            "web-namespaces": "^1.1.2"
+          }
+        },
+        "hast-util-sanitize": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz",
+          "integrity": "sha512-AIeKHuHx0Wk45nSkGVa2/ujQYTksnDl8gmmKo/mwQi7ag7IBZ8cM3nJ2G86SajbjGP/HRpud6kMkPtcM2i0Tlw==",
+          "requires": {
+            "xtend": "^4.0.1"
+          }
+        },
+        "property-information": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/property-information/-/property-information-4.2.0.tgz",
+          "integrity": "sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==",
+          "requires": {
+            "xtend": "^4.0.1"
+          }
+        },
+        "rehype-react": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-3.1.0.tgz",
+          "integrity": "sha512-7SiLiqNudSGkvhrePkdKqdUvngZqzG+PJhdR5EeIFELz2j2ek4aO5DHbxUXYvaZfqUiBDO2Aeq1OROUmxmu+Vg==",
+          "requires": {
+            "@mapbox/hast-util-table-cell-style": "^0.1.3",
+            "has": "^1.0.1",
+            "hast-to-hyperscript": "^5.0.0"
+          }
+        },
+        "rehype-sanitize": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-2.0.3.tgz",
+          "integrity": "sha512-RZFLBV36yOWNbV4g2WJDfilAzV1Sin/InQHXA+5h9+GkxCFnTJCC7SPrAdVHEIrQ882eAD8/51jEYHD6xrewcw==",
+          "requires": {
+            "hast-util-sanitize": "^1.1.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
+          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
+        }
+      }
+    },
     "@readme/oas-examples": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-3.6.0.tgz",
       "integrity": "sha512-8wAXHTKOEstiDO5tYxCdVXv9LOTU7xO5OWqcHTlVQwEZ8bXMxiVRgmGbYuAjLvC851J3jaajoNMVvsRxcQ7YMA==",
       "dev": true
+    },
+    "@readme/oas-extensions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-8.0.0.tgz",
+      "integrity": "sha512-pDIFyXAMKgiGbt+BCvkbRuH9LBhm29YjB6mlAc7I5TDOG45O9pxEsTltnO0/0UzyyGSA2GjJp0J6ycTPQIgkzA=="
+    },
+    "@readme/oas-form": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-form/-/oas-form-8.0.0.tgz",
+      "integrity": "sha512-7AlhtVfsIjQrMb1Z3fWkTZ0m45f189p5IvLj7LLxeefBCuSOpSRTd5VZPHijP2TDeOkd07wwCLv9aocvGtfDWg==",
+      "requires": {
+        "@babel/runtime-corejs2": "^7.4.5",
+        "ajv": "^6.7.0",
+        "core-js": "^2.5.7",
+        "json-schema-merge-allof": "^0.6.0",
+        "jsonpointer": "^4.0.1",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0",
+        "shortid": "^2.2.14"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
+    "@readme/oas-to-har": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-8.0.3.tgz",
+      "integrity": "sha512-/QNVHqYK3kIE29hE37/CkcTo/OlONVLNhUcB6RKcTenSbxRvP9FhiaDAHKTthfksatfswBpegWAKhOa22k+r9A==",
+      "requires": {
+        "@readme/oas-extensions": "^8.0.0",
+        "@readme/oas-tooling": "^3.6.1",
+        "parse-data-url": "^3.0.0"
+      }
+    },
+    "@readme/oas-to-snippet": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-8.0.3.tgz",
+      "integrity": "sha512-TA7Tu0PupB4cKfqvD9P7kO7V0tFaF9AarbsyS6+6lyl3hTmrmG3wYaBSROJSnCsjmY3C3gZSUx3XmfOsdX5HBQ==",
+      "requires": {
+        "@readme/httpsnippet": "^2.2.2",
+        "@readme/oas-extensions": "^8.0.0",
+        "@readme/oas-to-har": "^8.0.3",
+        "@readme/oas-tooling": "^3.6.1",
+        "@readme/syntax-highlighter": "^10.0.0",
+        "httpsnippet-client-api": "^2.4.0"
+      }
+    },
+    "@readme/oas-tooling": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.6.1.tgz",
+      "integrity": "sha512-hF0Iwh3DmsP3HHY9djVUI957HsHvlBw+H9GMjZJCy2pRFqjor1+l9uOYZl9L1AaajGJX5EXf8PqXfwD1Cr0V6Q==",
+      "requires": {
+        "jsonpointer": "^4.0.1",
+        "path-to-regexp": "^6.1.0"
+      }
     },
     "@readme/syntax-highlighter": {
       "version": "10.0.0",
@@ -1830,6 +2030,16 @@
         }
       }
     },
+    "@readme/variable": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-8.0.3.tgz",
+      "integrity": "sha512-ONuS5GB9Oz4mojEYNxu0/UYOJJ/hMPLjKPp4ScX9xoKPOrmhil78fO3Xz4YDX2suXZzI8qBVIBTBF5QT5sroug==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "prop-types": "^15.7.2",
+        "react": "^16.4.2"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -1847,6 +2057,87 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@testing-library/dom": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.26.3.tgz",
+      "integrity": "sha512-/1P6taENE/H12TofJaS3L1J28HnXx8ZFhc338+XPR5y1E3g5ttOgu86DsGnV9/n2iPrfJQVUZ8eiGYZGSxculw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.1",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^26.4.2"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.10",
@@ -2305,7 +2596,6 @@
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2316,14 +2606,12 @@
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         }
       }
     },
@@ -3637,6 +3925,27 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compute-gcd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.0.tgz",
+      "integrity": "sha1-/B7eW2UAHpUCJlAvRlQ4Y+T+oQ4=",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "compute-lcm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.0.tgz",
+      "integrity": "sha1-q9ltBAtBsKFm+JlEtci3xRHiGtU=",
+      "requires": {
+        "compute-gcd": "^1.2.0",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3682,6 +3991,11 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -4167,6 +4481,12 @@
         "isarray": "^1.0.0"
       }
     },
+    "dom-accessibility-api": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
+      "integrity": "sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==",
+      "dev": true
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -4189,6 +4509,11 @@
           "dev": true
         }
       }
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "duplexify": {
       "version": "3.7.1",
@@ -5062,6 +5387,20 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "requires": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "events": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
@@ -5663,6 +6002,11 @@
         "map-cache": "^0.2.2"
       }
     },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -5709,8 +6053,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -5729,6 +6072,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -5915,7 +6263,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -6262,6 +6609,18 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "httpsnippet-client-api": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.4.1.tgz",
+      "integrity": "sha512-mlvBZNM8ftSj4ErCmdcJ2gRvV8FpjpQ/TPF3OUaLRqoSn9GFdCpCwxUIQNPR67D2oGGg9Os5/0TJCAjOdO9OSw==",
+      "requires": {
+        "@readme/httpsnippet": "^2.2.2",
+        "content-type": "^1.0.4",
+        "oas": "^4.0.0",
+        "path-to-regexp": "^6.1.0",
+        "stringify-object": "^3.3.0"
+      }
     },
     "human-signals": {
       "version": "1.1.1",
@@ -6614,6 +6973,11 @@
         "kind-of": "^3.0.2"
       }
     },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
     "is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -6650,6 +7014,11 @@
       "requires": {
         "has-symbols": "^1.0.1"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -7960,6 +8329,24 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "json-schema-merge-allof": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
+      "integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
+      "requires": {
+        "compute-lcm": "^1.1.0",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -8216,6 +8603,12 @@
         }
       }
     },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
@@ -8255,6 +8648,11 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
+    },
+    "map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -8624,6 +9022,11 @@
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "dev": true,
       "optional": true
+    },
+    "nanoid": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -9368,6 +9771,14 @@
         "pify": "^2.0.0"
       }
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "~2.3"
+      }
+    },
     "pbkdf2": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
@@ -9977,8 +10388,7 @@
     "regenerator-runtime": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-      "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==",
-      "dev": true
+      "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -10639,6 +11049,14 @@
       "dev": true,
       "optional": true
     },
+    "shortid": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
+      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+      "requires": {
+        "nanoid": "^2.1.0"
+      }
+    },
     "should": {
       "version": "13.2.3",
       "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
@@ -10935,6 +11353,14 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -11037,6 +11463,15 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "stream-each": {
@@ -11211,6 +11646,16 @@
         "is-alphanumerical": "^1.0.0",
         "is-decimal": "^1.0.2",
         "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -12296,6 +12741,38 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
+    },
+    "validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc="
+    },
+    "validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "requires": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
     },
     "validator": {
       "version": "12.2.0",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -17,7 +17,7 @@
     "fetch-har": "^4.0.2",
     "js-cookie": "^2.1.4",
     "lodash.kebabcase": "^4.1.1",
-    "oas": "^4.0.0",
+    "oas": "^4.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.4.2",
     "react-copy-to-clipboard": "^5.0.1",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -17,7 +17,7 @@
     "fetch-har": "^4.0.2",
     "js-cookie": "^2.1.4",
     "lodash.kebabcase": "^4.1.1",
-    "oas": "^4.1.0",
+    "oas": "^5.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.4.2",
     "react-copy-to-clipboard": "^5.0.1",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@readme/eslint-config": "^3.2.0",
     "@readme/oas-examples": "^3.6.0",
+    "@testing-library/dom": "^7.26.3",
     "css-loader": "^4.3.0",
     "eslint": "^7.0.0",
     "jest": "^26.0.1",

--- a/packages/api-explorer/src/ResponseSchemaBody.jsx
+++ b/packages/api-explorer/src/ResponseSchemaBody.jsx
@@ -22,47 +22,73 @@ function getDescriptionMarkdown(useNewMarkdownEngine, description) {
   return markdownMagic(description);
 }
 
-function ResponseSchemaBody({ schema, oas, useNewMarkdownEngine }) {
-  const rows = flattenArray(flattenSchema(schema, oas)).map(row => (
-    <tr key={Math.random().toString(10)}>
-      <th
-        style={{
-          whiteSpace: 'nowrap',
-          width: '30%',
-          paddingRight: '5px',
-          textAlign: 'right',
-          overflow: 'hidden',
-        }}
-      >
-        {row.type}
-      </th>
-      <td
-        style={{
-          width: '70%',
-          overflow: 'hidden',
-          paddingLeft: '15px',
-          wordBreak: 'break-word',
-        }}
-      >
-        {row.name}
-        {row.description && getDescriptionMarkdown(useNewMarkdownEngine, row.description)}
-      </td>
-    </tr>
-  ));
+class ResponseSchemaBody extends React.Component {
+  constructor(props) {
+    super(props);
 
-  return (
-    <div>
-      {schema && schema.type && (
-        <p style={{ fontStyle: 'italic', margin: '0 0 10px 15px' }}>
-          {`Response schema type: `}
-          <span style={{ fontWeight: 'bold' }}>{getSchemaType(schema)}</span>
-        </p>
-      )}
-      <table style={{ tableLayout: 'fixed' }}>
-        <tbody>{rows}</tbody>
-      </table>
-    </div>
-  );
+    this.state = {
+      flattenedSchema: null,
+    };
+  }
+
+  componentDidMount() {
+    const { schema, oas } = this.props;
+
+    flattenSchema(schema, oas).then(flattened => {
+      this.setState({
+        flattenedSchema: flattenArray(flattened),
+      });
+    });
+  }
+
+  render() {
+    const { schema, useNewMarkdownEngine } = this.props;
+    const { flattenedSchema } = this.state;
+
+    let rows = [];
+    if (flattenedSchema) {
+      rows = flattenedSchema.map(row => (
+        <tr key={Math.random().toString(10)}>
+          <th
+            style={{
+              whiteSpace: 'nowrap',
+              width: '30%',
+              paddingRight: '5px',
+              textAlign: 'right',
+              overflow: 'hidden',
+            }}
+          >
+            {row.type}
+          </th>
+          <td
+            style={{
+              width: '70%',
+              overflow: 'hidden',
+              paddingLeft: '15px',
+              wordBreak: 'break-word',
+            }}
+          >
+            {row.name}
+            {row.description && getDescriptionMarkdown(useNewMarkdownEngine, row.description)}
+          </td>
+        </tr>
+      ));
+    }
+
+    return (
+      <div>
+        {schema && schema.type && (
+          <p style={{ fontStyle: 'italic', margin: '0 0 10px 15px' }}>
+            {`Response schema type: `}
+            <span style={{ fontWeight: 'bold' }}>{getSchemaType(schema)}</span>
+          </p>
+        )}
+        <table style={{ tableLayout: 'fixed' }}>
+          <tbody>{rows}</tbody>
+        </table>
+      </div>
+    );
+  }
 }
 
 ResponseSchemaBody.propTypes = {

--- a/packages/markdown-magic/package-lock.json
+++ b/packages/markdown-magic/package-lock.json
@@ -1353,16 +1353,6 @@
         }
       }
     },
-    "@readme/variable": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-8.0.0.tgz",
-      "integrity": "sha512-mzHktDOG4mSWGjswLCQQ51Zq/aENWaYm9y8vk+Q+9T6XHz7NIbsI8FBvf6yHH5boDSoKRwMG66Y45yTpRRubYg==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -6766,10 +6766,11 @@
       "dev": true
     },
     "oas": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-4.0.0.tgz",
-      "integrity": "sha512-DGeXKXxs9xdCqI30IVLwIJ9IqkQssi+8N0DDfIokrxN70re3wSMYvieEDwFcu/KotzMuHXyjURqFQBDSfDNysw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-4.1.0.tgz",
+      "integrity": "sha512-cHX+c6vwquLhemRfWj+APCz502y3RheQsoIKJbqFB0MdTRuIk9K7k3QObCMZ7tYyvy3luI3XiRfNcJDrZvn7nQ==",
       "requires": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
         "colors": "^1.1.2",
         "figures": "^3.0.0",

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -6766,9 +6766,9 @@
       "dev": true
     },
     "oas": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-4.1.0.tgz",
-      "integrity": "sha512-cHX+c6vwquLhemRfWj+APCz502y3RheQsoIKJbqFB0MdTRuIk9K7k3QObCMZ7tYyvy3luI3XiRfNcJDrZvn7nQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-5.0.0.tgz",
+      "integrity": "sha512-6H/U6fc1AhChfr/NuXaQRPnBh+PVTooDphFBgNS39CAqjmSVjjC+C0G4RuywU1wkNj7ir4uwg5f8EDjkz65j+Q==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^8.0.0",
-    "oas": "^4.0.0",
+    "oas": "^4.1.0",
     "parse-data-url": "^3.0.0"
   },
   "scripts": {

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@readme/oas-extensions": "^8.0.0",
-    "oas": "^4.1.0",
+    "oas": "^5.0.0",
     "parse-data-url": "^3.0.0"
   },
   "scripts": {

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -6673,10 +6673,11 @@
       "dev": true
     },
     "oas": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-4.0.0.tgz",
-      "integrity": "sha512-DGeXKXxs9xdCqI30IVLwIJ9IqkQssi+8N0DDfIokrxN70re3wSMYvieEDwFcu/KotzMuHXyjURqFQBDSfDNysw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-4.1.0.tgz",
+      "integrity": "sha512-cHX+c6vwquLhemRfWj+APCz502y3RheQsoIKJbqFB0MdTRuIk9K7k3QObCMZ7tYyvy3luI3XiRfNcJDrZvn7nQ==",
       "requires": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
         "colors": "^1.1.2",
         "figures": "^3.0.0",
@@ -6693,13 +6694,6 @@
         "path-to-regexp": "^6.2.0",
         "request": "^2.88.0",
         "swagger-inline": "3.2.2"
-      },
-      "dependencies": {
-        "path-to-regexp": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
-          "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
-        }
       }
     },
     "oas-normalize": {

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -4178,6 +4178,31 @@
         "oas": "^4.0.0",
         "path-to-regexp": "^6.1.0",
         "stringify-object": "^3.3.0"
+      },
+      "dependencies": {
+        "oas": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/oas/-/oas-4.0.0.tgz",
+          "integrity": "sha512-DGeXKXxs9xdCqI30IVLwIJ9IqkQssi+8N0DDfIokrxN70re3wSMYvieEDwFcu/KotzMuHXyjURqFQBDSfDNysw==",
+          "requires": {
+            "cardinal": "^2.1.1",
+            "colors": "^1.1.2",
+            "figures": "^3.0.0",
+            "glob": "^7.1.2",
+            "inquirer": "^7.0.1",
+            "json2yaml": "^1.1.0",
+            "jsonfile": "^6.0.0",
+            "jsonpointer": "^4.1.0",
+            "lodash": "^4.17.11",
+            "minimist": "^1.2.0",
+            "node-status": "^1.0.0",
+            "oas-normalize": "2.3.1",
+            "open": "^7.0.0",
+            "path-to-regexp": "^6.2.0",
+            "request": "^2.88.0",
+            "swagger-inline": "3.2.2"
+          }
+        }
       }
     },
     "human-signals": {
@@ -6673,9 +6698,9 @@
       "dev": true
     },
     "oas": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-4.1.0.tgz",
-      "integrity": "sha512-cHX+c6vwquLhemRfWj+APCz502y3RheQsoIKJbqFB0MdTRuIk9K7k3QObCMZ7tYyvy3luI3XiRfNcJDrZvn7nQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-5.0.0.tgz",
+      "integrity": "sha512-6H/U6fc1AhChfr/NuXaQRPnBh+PVTooDphFBgNS39CAqjmSVjjC+C0G4RuywU1wkNj7ir4uwg5f8EDjkz65j+Q==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -9,7 +9,7 @@
     "@readme/oas-to-har": "^8.0.3",
     "@readme/syntax-highlighter": "^10.0.0",
     "httpsnippet-client-api": "^2.4.1",
-    "oas": "^4.1.0"
+    "oas": "^5.0.0"
   },
   "scripts": {
     "lint": "eslint .",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -9,7 +9,7 @@
     "@readme/oas-to-har": "^8.0.3",
     "@readme/syntax-highlighter": "^10.0.0",
     "httpsnippet-client-api": "^2.4.1",
-    "oas": "^4.0.0"
+    "oas": "^4.1.0"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
## 🧰 What's being changed?

With https://github.com/readmeio/oas/pull/292, `oas/tooling/lib/flattenSchema` is now an async library to enable us to properly handle circular `$ref` pointers when flattening a response in the `ResponseSchemaBody` component.

This change updates the `ResponseSchemaBody` component to be compatible with the changes incoming in https://github.com/readmeio/oas/pull/292.

## 🧪 Testing

Here's an example of a circular ref'd schema that's currently failing when we're flattening the response schema: http://bin.readme.com/s/5f8f6eec31f4240024e73488