### PR TITLE
feat: set default javascript target to use fetch instead of xhr

### DIFF
--- a/packages/oas-to-snippet/src/index.js
+++ b/packages/oas-to-snippet/src/index.js
@@ -29,7 +29,7 @@ const supportedLanguages = {
     highlight: 'java',
   },
   javascript: {
-    httpsnippet: ['javascript', 'xhr', { cors: false }],
+    httpsnippet: ['javascript', 'fetch'],
     highlight: 'javascript',
   },
   kotlin: {


### PR DESCRIPTION
In the same vain as https://github.com/readmeio/api-explorer/commit/4bf746474d27e37059f5be777c9dcd9ff0ae5785

## 🧰 What's being changed?

Switching javascript target from xhr to fetch

## 🧪 Testing

Tested here against petstore: http://localhost:9966/
Tested here to make sure variables are passed through: http://localhost:9966/?selected=swagger-files%2Fauth-types.json

One thing I've not tested is cookies and the credentials option that can be passed in to fetch: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Sending_a_request_with_credentials_included

> fetch won’t send cookies, unless you set the credentials init option. (Since Aug 25, 2017. The spec changed the default credentials policy to same-origin. Firefox changed since 61.0b13.)

We used to say `cors: false` for the xhr config, which I think is the same thing: https://github.com/readmeio/api-explorer/blob/752c730ac475753c24d1ce197898a4d1c63c60f3/packages/oas-to-snippet/src/index.js#L32

I think if someone complains we can figure out what the correct value for this should be.

