### PR TITLE
chore: remove unnecessary stringification from node-fetch snippets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6702,9 +6702,9 @@
       "integrity": "sha512-sC94wCjHfHYt87j+pKnG6FaKMX0N6BLBINPokR3XXGv43lhT32qbFbWDzmBuiJOC4PRHg0M4kMsBToVH47V6mA=="
     },
     "@readme/httpsnippet": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.2.2.tgz",
-      "integrity": "sha512-Ejhwekiii6EMcfBKCLsizzQtWf27ipVv0mCtra/0Qj8qBNYlr50OMDxkt56J6nf4C/rH9+AoMsfQUIl3bcXQlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.2.3.tgz",
+      "integrity": "sha512-HrcxlWpY/bkJq5RcDWQfo5RRD/slVIfXHk+sICO4p6UXcusItHBpee2rNaO9RAlXwmnl2IJswZNdHCQ21D15Dg==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "files": [
       {
         "path": "packages/api-explorer/dist/index.js",
-        "maxSize": "1.2mb"
+        "maxSize": "1.5mb"
       },
       {
         "path": "packages/api-logs/dist/index.js",

--- a/packages/oas-to-snippet/__tests__/index.test.js
+++ b/packages/oas-to-snippet/__tests__/index.test.js
@@ -98,7 +98,7 @@ test('should pass through form encoded values to code snippet', () => {
   );
 
   expect(code).toMatch("encodedParams.set('id', '123');");
-  expect(code).toMatch('body: encodedParams.toString()');
+  expect(code).toMatch('body: encodedParams');
 });
 
 test('should not contain proxy url', () => {

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -1434,9 +1434,9 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.2.2.tgz",
-      "integrity": "sha512-Ejhwekiii6EMcfBKCLsizzQtWf27ipVv0mCtra/0Qj8qBNYlr50OMDxkt56J6nf4C/rH9+AoMsfQUIl3bcXQlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.2.3.tgz",
+      "integrity": "sha512-HrcxlWpY/bkJq5RcDWQfo5RRD/slVIfXHk+sICO4p6UXcusItHBpee2rNaO9RAlXwmnl2IJswZNdHCQ21D15Dg==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -4,7 +4,7 @@
   "version": "8.0.3",
   "main": "src/index.js",
   "dependencies": {
-    "@readme/httpsnippet": "^2.2.2",
+    "@readme/httpsnippet": "^2.2.3",
     "@readme/oas-extensions": "^8.0.0",
     "@readme/oas-to-har": "^8.0.3",
     "@readme/syntax-highlighter": "^10.0.0",


### PR DESCRIPTION
## 🧰 What's being changed?

Upgrades `@readme/httpsnippet` to 2.2.3 to remove unnecessary `.toString()` calls when supplying `URLSearchParams` to `node-fetch` body` options.

`node-fetch` can accept both a string or the raw object, so since the snippet looks cleaner without the stringification we're removing it.