### PR TITLE
fix: regression in focus being lost when editing inputs in arrays

### DIFF
--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -27,7 +27,7 @@ const props = {
   operation,
 };
 
-const Params = createParams(oas);
+const Params = createParams(oas, operation);
 
 const jsonOperation = new Operation(oas, '/path', 'post', {
   requestBody: {
@@ -344,7 +344,7 @@ describe('schema handling', () => {
 
 describe('x-explorer-enabled', () => {
   const oasWithExplorerDisabled = { ...oas, [extensions.EXPLORER_ENABLED]: false };
-  const ParamsWithExplorerDisabled = createParams(oasWithExplorerDisabled);
+  const ParamsWithExplorerDisabled = createParams(oasWithExplorerDisabled, oas.operation('/pet', 'post'));
 
   it('array should still show add button, but sub-elements should not be editable', () => {
     const elem = mount(
@@ -419,14 +419,12 @@ describe('x-explorer-enabled', () => {
     const operationExplorerEnabled = oas.operation('/pet/{petId}/uploadImage', 'post');
     operationExplorerEnabled[extensions.EXPLORER_ENABLED] = true;
 
+    const Component = createParams(oasWithExplorerDisabled, operationExplorerEnabled);
+
     expect(
-      mount(
-        <ParamsWithExplorerDisabled
-          {...props}
-          oas={new Oas(oasWithExplorerDisabled)}
-          operation={operationExplorerEnabled}
-        />
-      ).find('input[type="file"]')
+      mount(<Component {...props} oas={new Oas(oasWithExplorerDisabled)} operation={operationExplorerEnabled} />).find(
+        'input[type="file"]'
+      )
     ).toHaveLength(1);
   });
 });

--- a/packages/api-explorer/src/Params.jsx
+++ b/packages/api-explorer/src/Params.jsx
@@ -150,20 +150,29 @@ Params.defaultProps = {
   useNewMarkdownEngine: false,
 };
 
-function createParams(oas) {
+function createParams(oas, operation) {
+  const explorerEnabled = extensions.getExtension(extensions.EXPLORER_ENABLED, oas, operation);
+
+  // These component creation methods should remain **outside** of the function that `createParams` returns because
+  // anytime data within the form is edited we don't want to recreate every form component at the same time as this
+  // introduces the possibility of the user input losing focus.
+  //
+  // This unfortunately can't be easily tested without introducing Puppeteer testing of the explorer as
+  // `document.activeElement` isn't exposed within Enzyme (and also Enzyme is deprecating the `.simulate()` method it
+  // provides which will make it even more difficult to determine which element is in focus).
+  //
+  // https://github.com/readmeio/api-explorer/commit/2313073711f3bb7b40df6e33eaf403e62caa22a3
+  // https://github.com/enzymejs/enzyme/issues/2173#issuecomment-505551552
+  const ArrayField = createArrayField(explorerEnabled);
+  const BaseInput = createBaseInput(explorerEnabled);
+  const FileWidget = createFileWidget(explorerEnabled);
+  const SchemaField = createSchemaField();
+  const SelectWidget = createSelectWidget(explorerEnabled);
+  const TextareaWidget = createTextareaWidget(explorerEnabled);
+  const URLWidget = createURLWidget(explorerEnabled);
+
   // eslint-disable-next-line react/display-name
   return props => {
-    // eslint-disable-next-line react/prop-types
-    const explorerEnabled = extensions.getExtension(extensions.EXPLORER_ENABLED, oas, props.operation);
-
-    const ArrayField = createArrayField(explorerEnabled);
-    const BaseInput = createBaseInput(explorerEnabled);
-    const FileWidget = createFileWidget(explorerEnabled);
-    const SchemaField = createSchemaField();
-    const SelectWidget = createSelectWidget(explorerEnabled);
-    const TextareaWidget = createTextareaWidget(explorerEnabled);
-    const URLWidget = createURLWidget(explorerEnabled);
-
     return (
       <Params
         {...props}

--- a/packages/oas-extensions/index.js
+++ b/packages/oas-extensions/index.js
@@ -20,9 +20,11 @@ module.exports.defaults = {
 
 // add these functions to OAS class on packages/tooling/src/oas.js
 module.exports.getExtension = (ext, oas, operation) => {
-  if (operation[ext] === undefined && oas[ext] === undefined) {
-    return module.exports.defaults[ext];
+  if (operation !== null && operation[ext] !== undefined) {
+    return operation[ext];
+  } else if (oas[ext] !== undefined) {
+    return oas[ext];
   }
 
-  return operation[ext] === undefined ? oas[ext] : operation[ext];
+  return module.exports.defaults[ext];
 };


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a regression that was introduced in https://github.com/readmeio/api-explorer/pull/940 where if you edited an input that was inside of an `ArrayField`, your browser would immediately lose focus. The reason for this happening is that since the form is dynamic we were recreating every form component and element anytime a state change would occur.

This bug was originally fixed in https://github.com/readmeio/api-explorer/commit/2313073711f3bb7b40df6e33eaf403e62caa22a3 by changing the way we create parameters for the form to be a stored component in `Doc`, but we accidentally undid this by moving those component creations back into the React function call that happens when the form reloads when we added support for operation-level extensions.

And to compound on that, we didn't know that this broke because we:

* Don't have tests for this focus loss
* Tests can't be written for it due to Enzyme not exposing the right document API
* We didn't manually test inputs inside of arrays

## 🧪 Testing

You can see the current focus loss happening in the latest version of the explorer on https://preview.readme.io/ by clicking on `photoUrls` and entering data in the form:

![5yBw0wkzZA](https://user-images.githubusercontent.com/33762/97374818-7995cc80-1876-11eb-8c6f-bff678f4afa5.gif)

With this fix in place:

![Aqkd6bNcFi](https://user-images.githubusercontent.com/33762/97374884-a1853000-1876-11eb-9fb5-7d9057b11f74.gif)