### PR TITLE
feat: hide "suggest edits" button if there's no body

### DIFF
--- a/packages/api-explorer/__tests__/Doc.test.jsx
+++ b/packages/api-explorer/__tests__/Doc.test.jsx
@@ -307,6 +307,17 @@ describe('suggest edits', () => {
     expect(doc.find('a.hub-reference-edit.pull-right')).toHaveLength(0);
   });
 
+  it('should not show if they have no markdown body', () => {
+    const doc = shallow(
+      <Doc
+        {...props}
+        doc={{ body: '', slug: 'slug', title: 'title', type: 'endpoint' }}
+        suggestedEdits
+      />
+    );
+    expect(doc.find('a.hub-reference-edit.pull-right')).toHaveLength(0);
+  });
+
   it('should show icon if suggested edits is true', () => {
     const doc = shallow(<Doc {...props} suggestedEdits />);
     expect(doc.find('a.hub-reference-edit.pull-right')).toHaveLength(1);

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -367,7 +367,7 @@ class Doc extends React.Component {
         <div className="hub-reference-section hub-reference-section-top">
           <div className="hub-reference-left">
             <header>
-              {this.props.suggestedEdits && (
+              {this.props.suggestedEdits && (doc.body || '').length > 0 && (
                 <a className="hub-reference-edit pull-right" href={`${this.props.baseUrl}/reference-edit/${doc.slug}`}>
                   <i className="icon icon-register" />
                   Suggest Edits


### PR DESCRIPTION
## 🧰 What's being changed?

Hide "suggest edits" button if there's no body

## 🧪 Testing

Check http://localhost:9966/