### PR TITLE
style: making the response example section scrollable

### DIFF
--- a/packages/api-explorer/style/main.scss
+++ b/packages/api-explorer/style/main.scss
@@ -178,7 +178,7 @@ form.rjsf .field .form-group select {
 }
 
  /* For each nested object in an array, unset max-width for description. */
- .array-item fieldset .field-description {
+.array-item fieldset .field-description {
   max-width: unset;
   text-align: left;
 }
@@ -798,4 +798,10 @@ form.rjsf {
   > div + div {
     margin-left: 15px;
   }
+}
+
+// Make response examples/Try It results scrollable so they don't blow up the page.
+.hub-reference-results-examples .code-sample-body {
+  max-height: 80vh;
+  overflow: auto;
 }


### PR DESCRIPTION
## 🧰 What's being changed?

The new response example work in https://github.com/readmeio/api-explorer/pull/1027 introduced a new problem of large response schemas potentially blowing up the length of the page.

## 🧪 Testing

![ezgif com-gif-maker](https://user-images.githubusercontent.com/33762/98587849-99b68a00-227f-11eb-9e66-090dafec219a.gif)
