### PR TITLE
chore(deps): upgrading oas to 5.2.1

### DIFF
--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -1201,8 +1201,7 @@
     "@readme/oas-extensions": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-9.0.0.tgz",
-      "integrity": "sha512-IYGh/ijZrDAeVxuc1/2YccZgdI7yWmh2HRE15BbD1GH174igvQlyndCaruXrzDdQ3r+V88NsEMRDfM2LFULJfA==",
-      "dev": true
+      "integrity": "sha512-IYGh/ijZrDAeVxuc1/2YccZgdI7yWmh2HRE15BbD1GH174igvQlyndCaruXrzDdQ3r+V88NsEMRDfM2LFULJfA=="
     },
     "@readme/oas-to-har": {
       "version": "9.2.0",
@@ -2943,6 +2942,27 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
+    },
+    "compute-gcd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.0.tgz",
+      "integrity": "sha1-/B7eW2UAHpUCJlAvRlQ4Y+T+oQ4=",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "compute-lcm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.0.tgz",
+      "integrity": "sha1-q9ltBAtBsKFm+JlEtci3xRHiGtU=",
+      "requires": {
+        "compute-gcd": "^1.2.0",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -7118,6 +7138,24 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "json-schema-merge-allof": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.7.0.tgz",
+      "integrity": "sha512-kvsuSVnl1n5xnNEu5ed4o8r8ujSA4/IgRtHmpgfMfa7FOMIRAzN4F9qbuklouTn5J8bi83y6MQ11n+ERMMTXZg==",
+      "requires": {
+        "compute-lcm": "^1.1.0",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -8008,9 +8046,9 @@
       "dev": true
     },
     "oas": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-5.2.0.tgz",
-      "integrity": "sha512-Dd5JELlCeAy45ZQuRnozW9SiT/devRyv8df4bcAm+kP/0uVlJku6p4bHNWFS+E+JNTqzj+Xx637ogAikQ2O8Hw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-5.2.1.tgz",
+      "integrity": "sha512-8cVCAVbKb9YCmWTKr3sClZzD2QyUHPTnh8CXQ4m4N0yA4FSIZuaZIryxl8L03hKsjdGE/B5PtAjPRWmqwWEQgw==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -8018,6 +8056,7 @@
         "figures": "^3.0.0",
         "glob": "^7.1.2",
         "inquirer": "^7.0.1",
+        "json-schema-merge-allof": "^0.7.0",
         "json2yaml": "^1.1.0",
         "jsonfile": "^6.0.0",
         "jsonpointer": "^4.1.0",
@@ -11319,6 +11358,38 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
+    },
+    "validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc="
+    },
+    "validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "requires": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
     },
     "validator": {
       "version": "12.2.0",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -32,7 +32,7 @@
     "fetch-har": "^4.0.2",
     "js-cookie": "^2.1.4",
     "lodash.kebabcase": "^4.1.1",
-    "oas": "^5.2.0",
+    "oas": "^5.2.1",
     "prop-types": "^15.7.2",
     "react-copy-to-clipboard": "^5.0.1",
     "react-debounce-input": "^3.2.0",

--- a/packages/api-explorer/src/lib/content-type-is-json.js
+++ b/packages/api-explorer/src/lib/content-type-is-json.js
@@ -1,5 +1,5 @@
 function contentTypeIsJson(contentType) {
-  const jsonContentTypes = ['application/json', '+json'];
+  const jsonContentTypes = ['application/json', 'application/x-json', 'text/json', 'text/x-json', '+json', '*/*'];
   return jsonContentTypes.some(ct => contentType.includes(ct));
 }
 

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -2105,6 +2105,27 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compute-gcd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.0.tgz",
+      "integrity": "sha1-/B7eW2UAHpUCJlAvRlQ4Y+T+oQ4=",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "compute-lcm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.0.tgz",
+      "integrity": "sha1-q9ltBAtBsKFm+JlEtci3xRHiGtU=",
+      "requires": {
+        "compute-gcd": "^1.2.0",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6045,6 +6066,24 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "json-schema-merge-allof": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.7.0.tgz",
+      "integrity": "sha512-kvsuSVnl1n5xnNEu5ed4o8r8ujSA4/IgRtHmpgfMfa7FOMIRAzN4F9qbuklouTn5J8bi83y6MQ11n+ERMMTXZg==",
+      "requires": {
+        "compute-lcm": "^1.1.0",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -6580,9 +6619,9 @@
       "dev": true
     },
     "oas": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-5.2.0.tgz",
-      "integrity": "sha512-Dd5JELlCeAy45ZQuRnozW9SiT/devRyv8df4bcAm+kP/0uVlJku6p4bHNWFS+E+JNTqzj+Xx637ogAikQ2O8Hw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-5.2.1.tgz",
+      "integrity": "sha512-8cVCAVbKb9YCmWTKr3sClZzD2QyUHPTnh8CXQ4m4N0yA4FSIZuaZIryxl8L03hKsjdGE/B5PtAjPRWmqwWEQgw==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -6590,6 +6629,7 @@
         "figures": "^3.0.0",
         "glob": "^7.1.2",
         "inquirer": "^7.0.1",
+        "json-schema-merge-allof": "^0.7.0",
         "json2yaml": "^1.1.0",
         "jsonfile": "^6.0.0",
         "jsonpointer": "^4.1.0",
@@ -8563,6 +8603,38 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
+    },
+    "validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc="
+    },
+    "validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "requires": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
     },
     "validator": {
       "version": "12.2.0",

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@readme/oas-extensions": "^9.0.0",
-    "oas": "^5.2.0",
+    "oas": "^5.2.1",
     "parse-data-url": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -2529,6 +2529,27 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compute-gcd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.0.tgz",
+      "integrity": "sha1-/B7eW2UAHpUCJlAvRlQ4Y+T+oQ4=",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "compute-lcm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.0.tgz",
+      "integrity": "sha1-q9ltBAtBsKFm+JlEtci3xRHiGtU=",
+      "requires": {
+        "compute-gcd": "^1.2.0",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6169,6 +6190,24 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "json-schema-merge-allof": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.7.0.tgz",
+      "integrity": "sha512-kvsuSVnl1n5xnNEu5ed4o8r8ujSA4/IgRtHmpgfMfa7FOMIRAzN4F9qbuklouTn5J8bi83y6MQ11n+ERMMTXZg==",
+      "requires": {
+        "compute-lcm": "^1.1.0",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6698,9 +6737,9 @@
       "dev": true
     },
     "oas": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-5.2.0.tgz",
-      "integrity": "sha512-Dd5JELlCeAy45ZQuRnozW9SiT/devRyv8df4bcAm+kP/0uVlJku6p4bHNWFS+E+JNTqzj+Xx637ogAikQ2O8Hw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-5.2.1.tgz",
+      "integrity": "sha512-8cVCAVbKb9YCmWTKr3sClZzD2QyUHPTnh8CXQ4m4N0yA4FSIZuaZIryxl8L03hKsjdGE/B5PtAjPRWmqwWEQgw==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -6708,6 +6747,7 @@
         "figures": "^3.0.0",
         "glob": "^7.1.2",
         "inquirer": "^7.0.1",
+        "json-schema-merge-allof": "^0.7.0",
         "json2yaml": "^1.1.0",
         "jsonfile": "^6.0.0",
         "jsonpointer": "^4.1.0",
@@ -8871,6 +8911,38 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
+    },
+    "validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc="
+    },
+    "validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "requires": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
     },
     "validator": {
       "version": "12.2.0",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -22,7 +22,7 @@
     "@readme/oas-to-har": "^9.2.1",
     "@readme/syntax-highlighter": "^10.2.0",
     "httpsnippet-client-api": "^2.4.4",
-    "oas": "^5.2.0"
+    "oas": "^5.2.1"
   },
   "devDependencies": {
     "@readme/eslint-config": "^3.2.0",


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] Upgrades `oas` to 5.2.1 to fix a bug in generated examples where `allOf` wasn't recognized.
* [x] Updates our JSON matching regex to support a few more mimetypes, including `*/*`.