### PR TITLE
feat(api explorer): adding optional handler for auth group change

### DIFF
--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -114,6 +114,10 @@ class ApiExplorer extends React.Component {
    * @param {string} group
    */
   onAuthGroupChange(group) {
+    // Invoke supplementary handler (if available)
+    if (this.props.onAuthGroupChange && typeof this.props.onAuthGroupChange === 'function') {
+      this.props.onAuthGroupChange(group);
+    }
     const { user } = this.props.variables;
     let groupName = false;
     if (user.keys) {
@@ -291,6 +295,7 @@ ApiExplorer.propTypes = {
   oasFiles: PropTypes.shape({}).isRequired,
   oasUrls: PropTypes.shape({}).isRequired,
   oauth: PropTypes.bool,
+  onAuthGroupChange: PropTypes.func,
   onError: PropTypes.func,
   suggestedEdits: PropTypes.bool.isRequired,
   tryItMetrics: PropTypes.func,

--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -115,9 +115,8 @@ class ApiExplorer extends React.Component {
    */
   onAuthGroupChange(group) {
     // Invoke supplementary handler (if available)
-    if (this.props.onAuthGroupChange && typeof this.props.onAuthGroupChange === 'function') {
-      this.props.onAuthGroupChange(group);
-    }
+    this.props.onAuthGroupChange(group);
+
     const { user } = this.props.variables;
     let groupName = false;
     if (user.keys) {
@@ -324,6 +323,7 @@ ApiExplorer.defaultProps = {
   Logs: undefined,
   maskErrorMessages: true,
   oauth: false,
+  onAuthGroupChange: () => {},
   onError: () => {},
   tryItMetrics: () => {},
   useNewMarkdownEngine: false,


### PR DESCRIPTION
## 🧰 What's being changed?
* Adding support for passing an optional function to handle group change via props (which is called in addition to existing, built-in behavior).
* This function would receive the new group member id whenever onAuthGroupChange() is invoked.

🧪 Testing
* Manually verified