### PR TITLE
chore(oas-to-snippet): replace stringified request body with JSON.stringify and object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6699,9 +6699,9 @@
       "integrity": "sha512-sC94wCjHfHYt87j+pKnG6FaKMX0N6BLBINPokR3XXGv43lhT32qbFbWDzmBuiJOC4PRHg0M4kMsBToVH47V6mA=="
     },
     "@readme/httpsnippet": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.2.3.tgz",
-      "integrity": "sha512-HrcxlWpY/bkJq5RcDWQfo5RRD/slVIfXHk+sICO4p6UXcusItHBpee2rNaO9RAlXwmnl2IJswZNdHCQ21D15Dg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.3.1.tgz",
+      "integrity": "sha512-gnL3cXfY+sG03SL/Ua5bEeiDxk+nTMMJu7+aKNLGZguL9R67vXvqL+A6mYaGwwUo6b7g5dfUzv0Zs44tfFQD1w==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",

--- a/packages/oas-to-snippet/__tests__/index.test.js
+++ b/packages/oas-to-snippet/__tests__/index.test.js
@@ -67,7 +67,7 @@ test('should pass through json values to code snippet', () => {
     oasUrl
   );
 
-  expect(code).toMatch('body: \'{"id":"123"}\'');
+  expect(code).toMatch("body: JSON.stringify({id: '123'}");
 });
 
 test('should pass through form encoded values to code snippet', () => {

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -17,7 +17,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@readme/httpsnippet": "^2.2.3",
+    "@readme/httpsnippet": "^2.3.1",
     "@readme/oas-extensions": "^9.0.0",
     "@readme/oas-to-har": "^9.2.2",
     "@readme/syntax-highlighter": "^10.2.0",

--- a/packages/oas-to-snippet/src/index.js
+++ b/packages/oas-to-snippet/src/index.js
@@ -44,12 +44,6 @@ module.exports = (oas, operation, values, auth, lang, oasUrl) => {
     };
   }
 
-  if (lang === 'node') {
-    language.httpsnippet[2] = {
-      useObjectBody: true,
-    };
-  }
-
   return {
     code: snippet.convert(...language.httpsnippet),
     highlightMode: language.highlight,

--- a/packages/oas-to-snippet/src/index.js
+++ b/packages/oas-to-snippet/src/index.js
@@ -44,6 +44,12 @@ module.exports = (oas, operation, values, auth, lang, oasUrl) => {
     };
   }
 
+  if (lang === 'node') {
+    language.httpsnippet[2] = {
+      useObjectBody: true,
+    };
+  }
+
   return {
     code: snippet.convert(...language.httpsnippet),
     highlightMode: language.highlight,

--- a/packages/oas-to-snippet/src/supportedLanguages.js
+++ b/packages/oas-to-snippet/src/supportedLanguages.js
@@ -32,7 +32,13 @@ const supportedLanguages = {
     highlight: 'java',
   },
   node: {
-    httpsnippet: ['node', 'fetch'],
+    httpsnippet: [
+      'node',
+      'fetch',
+      {
+        useObjectBody: true,
+      },
+    ],
     highlight: 'javascript',
   },
   'node-simple': {


### PR DESCRIPTION
replace stringified request body with JSON.stringify and object

## 🧰 What's being changed?

The request body in the node example must be a string. Originally we were translating the JSON object to a string and including that. A JSON.stringified object is difficult to read, so this PR keeps the object literal and wraps it in a JSON.stringify call in the example.

See https://app.asana.com/0/1199087650851461/1198986894847661 for more discussion and example pictures.

## 🧪 Testing

Go to the petstore example, and the "add a new pet"  API call. Start typing in the "category" request body form below the example, and you should see the example automatically update with a request body that is an object literal wrapped in JSON.stringify.
