### PR TITLE
Style: fix padding and color on the demo reference page

### DIFF
--- a/example/reference/index.html
+++ b/example/reference/index.html
@@ -176,6 +176,10 @@
     #loading-screen.is-loaded {
       display: none;
     }
+
+    .hub-container {
+      display: flex;
+    }
   </style>
 </head>
 
@@ -232,17 +236,11 @@
           }
           section#hub-content {
             border-left: 1px solid #ddd;
-            margin-left: 246px;
             padding-left: 0px;
             width: unset;
           }
           section#hub-content.with-errors {
             border-left: none;
-          }
-          @media (max-width: 768px) {
-            section#hub-content {
-              margin-left: 0 !important;
-            }
           }
         </style>
         <div id="hub-sidebar-parent" class="hub-sidebar-sticky">

--- a/example/reference/index.html
+++ b/example/reference/index.html
@@ -234,6 +234,9 @@
             position: initial;
             padding-bottom: 0px;
           }
+          #hub-sidebar-content a.text-overflow {
+            background: #fff!important;
+          }
           section#hub-content {
             border-left: 1px solid #ddd;
             padding-left: 0px;


### PR DESCRIPTION
## 🧰 What's being changed?

Removing the giant space on [the demo reference page](https://preview.readme.io/reference/) and force the sidebar to be a more normal color.

**Before:**
<img width="1664" alt="Screen Shot 2020-11-20 at 10 22 08 AM" src="https://user-images.githubusercontent.com/7861044/99836101-719a1700-2b1a-11eb-86a3-3b3bd035046b.png">

**After:**
<img width="1459" alt="Screen Shot 2020-11-20 at 10 13 59 AM" src="https://user-images.githubusercontent.com/7861044/99836118-75c63480-2b1a-11eb-8196-e830c0066e59.png">


## 🧪 Testing

Provide as much information as you can on how to test what you've done.

[Asana link](https://app.asana.com/0/1199087650851461/1199187472127725)
