### PR TITLE
feat: flipping the order of data in the response schema component

### DIFF
--- a/packages/api-explorer/__tests__/ResponseSchemaBody.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseSchemaBody.test.jsx
@@ -22,8 +22,8 @@ test('display object properties in the table', () => {
   return waitFor(() => {
     comp.update();
 
-    expect(comp.find('th').text()).toContain('String');
-    expect(comp.find('td').text()).toBe('a');
+    expect(comp.find('th').text()).toContain('a');
+    expect(comp.find('td').text()).toBe('String');
   });
 });
 
@@ -48,7 +48,7 @@ test('display object properties inside another object in the table', () => {
 
     expect(
       comp
-        .find('td')
+        .find('th')
         .map(a => a.text())
         .filter(a => a === 'a.a')
     ).toHaveLength(1);
@@ -98,13 +98,13 @@ test('not render more than 3 level deep object', () => {
 
     expect(
       comp
-        .find('td')
+        .find('th')
         .map(a => a.text())
         .filter(a => a === 'a.a.a')
     ).toHaveLength(1);
     expect(
       comp
-        .find('td')
+        .find('th')
         .map(a => a.text())
         .filter(a => a === 'a.a.a.a')
     ).toHaveLength(0);
@@ -130,13 +130,13 @@ test('render top level array of objects', () => {
 
     expect(
       comp
-        .find('td')
+        .find('th')
         .map(a => a.text())
         .filter(a => a === 'name')
     ).toHaveLength(1);
     expect(
       comp
-        .find('th')
+        .find('td')
         .map(a => a.text())
         .filter(a => a === 'String')
     ).toHaveLength(1);
@@ -232,7 +232,7 @@ describe('$ref handling', () => {
 
       expect(
         comp
-          .find('td')
+          .find('th')
           .map(a => a.text())
           .filter(a => a === 'category.name')
       ).toHaveLength(1);
@@ -280,13 +280,14 @@ describe('$ref handling', () => {
         comp
           .find('th')
           .map(a => a.text())
-          .filter(a => a === '[Object]')
+          .filter(a => a === 'a.pets[].index')
       ).toHaveLength(1);
+
       expect(
         comp
           .find('td')
           .map(a => a.text())
-          .filter(a => a === 'a.pets[].index')
+          .filter(a => a === '[Object]')
       ).toHaveLength(1);
     });
   });
@@ -320,13 +321,13 @@ describe('$ref handling', () => {
 
       expect(
         comp
-          .find('td')
+          .find('th')
           .map(a => a.text())
           .filter(a => a === 'name')
       ).toHaveLength(1);
       expect(
         comp
-          .find('th')
+          .find('td')
           .map(a => a.text())
           .filter(a => a === 'String')
       ).toHaveLength(1);
@@ -384,11 +385,11 @@ describe('$ref handling', () => {
 
         expect(comp.find('tr')).toHaveLength(2);
 
-        expect(comp.find('tr').at(0).find('th').text()).toBe('Number');
-        expect(comp.find('tr').at(0).find('td').text()).toBe('id');
+        expect(comp.find('tr').at(0).find('th').text()).toBe('id');
+        expect(comp.find('tr').at(0).find('td').text()).toBe('Number');
 
-        expect(comp.find('tr').at(1).find('th').text()).toBe('Circular');
-        expect(comp.find('tr').at(1).find('td').text()).toBe('fields');
+        expect(comp.find('tr').at(1).find('th').text()).toBe('fields');
+        expect(comp.find('tr').at(1).find('td').text()).toBe('Circular');
       });
     });
   });

--- a/packages/api-explorer/src/ResponseSchemaBody.jsx
+++ b/packages/api-explorer/src/ResponseSchemaBody.jsx
@@ -55,6 +55,8 @@ class ResponseSchemaBody extends React.Component {
               textAlign: 'right',
               overflow: 'visible',
               wordBreak: 'break-all',
+              // eslint-disable-next-line no-dupe-keys
+              wordBreak: 'break-word',
             }}
           >
             {row.name}

--- a/packages/api-explorer/src/ResponseSchemaBody.jsx
+++ b/packages/api-explorer/src/ResponseSchemaBody.jsx
@@ -51,24 +51,23 @@ class ResponseSchemaBody extends React.Component {
         <tr key={Math.random().toString(10)}>
           <th
             style={{
-              whiteSpace: 'nowrap',
-              width: '30%',
               paddingRight: '5px',
               textAlign: 'right',
-              overflow: 'hidden',
-            }}
-          >
-            {row.type}
-          </th>
-          <td
-            style={{
-              width: '70%',
-              overflow: 'hidden',
-              paddingLeft: '15px',
-              wordBreak: 'break-word',
+              overflow: 'visible',
+              wordBreak: 'break-all',
             }}
           >
             {row.name}
+          </th>
+          <td
+            style={{
+              overflow: 'hidden',
+              paddingLeft: '15px',
+              wordBreak: 'break-word',
+              verticalAlign: 'top',
+            }}
+          >
+            {row.type}
             {row.description && getDescriptionMarkdown(useNewMarkdownEngine, row.description)}
           </td>
         </tr>


### PR DESCRIPTION
## 🧰 What's being changed?

This flips the order of data we're showing in the response schema component on operations from `type` → `property` to `property` → `type`.

## 🧪 Testing

You can test this out on the petstore example under the "Finds Pets by status" operation. Some examples:

<img width="369" alt="Screen Shot 2020-11-24 at 10 51 56 AM" src="https://user-images.githubusercontent.com/33762/100126395-81c83400-2e43-11eb-9706-cd39b752352e.png">

<img width="362" alt="Screen Shot 2020-11-24 at 10 53 31 AM" src="https://user-images.githubusercontent.com/33762/100126412-8856ab80-2e43-11eb-9728-b3bff51fec1b.png">
