### PR TITLE
fix: dont fetch logs for users who aren't logged in

### DIFF
--- a/packages/api-logs/__tests__/index.test.jsx
+++ b/packages/api-logs/__tests__/index.test.jsx
@@ -154,6 +154,13 @@ describe('Logs', () => {
     mock.done();
   });
 
+  it('should not fetch if no group is present', () => {
+    const comp = shallow(<Logs {...props} />);
+
+    comp.instance().getLogs = jest.fn();
+    expect(comp.instance().getLogs).not.toHaveBeenCalled();
+  });
+
   it('should render a "view more" button', () => {
     const comp = shallow(<LogTest {...props} />);
     expect(comp.find('a[target="_blank"]').prop('href')).toBe(

--- a/packages/api-logs/index.jsx
+++ b/packages/api-logs/index.jsx
@@ -83,7 +83,9 @@ class Logs extends React.Component {
   }
 
   componentDidMount() {
-    this.getLogs();
+    if (this.props.group) {
+      this.getLogs();
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -239,7 +241,7 @@ class Logs extends React.Component {
 
   render() {
     const { query, baseUrl, group, loginUrl } = this.props;
-    if (!group)
+    if (!group) {
       return (
         <div className="logs">
           <div>
@@ -256,6 +258,7 @@ class Logs extends React.Component {
           </div>
         </div>
       );
+    }
 
     const url = `${baseUrl}/logs?${querystring.stringify({ ...query, id: group })}`;
 


### PR DESCRIPTION
## 🧰 What's being changed?

This stops us from fetching logs for users who aren't logged in.

## 🧪 Testing

You can test this by loading up `example/src/Demo.jsx` and changing the `user` variables prop to be an empty object. Refresh the page and you shouldn't see any requests towards `/api/logs`. Revert the change to fake a logged in state and logs should be retrieved.