### PR TITLE
fix(examples): fix examples button type

### DIFF
--- a/packages/api-explorer/src/ResponseTabs.jsx
+++ b/packages/api-explorer/src/ResponseTabs.jsx
@@ -65,7 +65,8 @@ class ResponseTabs extends React.Component {
               hideResults();
             }}
           >
-            <span className="fa fa-chevron-circle-left"> to examples </span>
+            <i className="fa fa-chevron-circle-left" />
+            Examples
           </a>
         )}
       </ul>


### PR DESCRIPTION
Before (Firefox and chrome only):
![Screen Shot 2020-11-24 at 5 12 32 PM](https://user-images.githubusercontent.com/5341618/100171926-12bb0180-2e7c-11eb-8785-e52ee497c6fe.png)

After:
<img width="389" alt="Screen Shot 2020-11-24 at 5 39 11 PM" src="https://user-images.githubusercontent.com/5341618/100171931-16e71f00-2e7c-11eb-9de1-5bc342c63bea.png">
