### PR TITLE
fix: issue where changing response schemas wouldn't always update the component

### DIFF
--- a/packages/api-explorer/src/ResponseSchema.jsx
+++ b/packages/api-explorer/src/ResponseSchema.jsx
@@ -78,13 +78,14 @@ class ResponseSchema extends React.Component {
 
   render() {
     const { operation, oas, useNewMarkdownEngine } = this.props;
+    const { selectedStatus } = this.state;
     if (!operation.schema || !operation.schema.responses || Object.keys(operation.schema.responses).length === 0) {
       return null;
     }
 
     const schema = this.getSchema(operation);
 
-    let response = operation.getResponseByStatusCode(this.state.selectedStatus);
+    let response = operation.getResponseByStatusCode(selectedStatus);
 
     // @todo This should really be called higher up when the OAS is processed within the Doc component.
     if (response.$ref) {
@@ -108,7 +109,14 @@ class ResponseSchema extends React.Component {
               <div className="desc">{markdownMagic(response.description)}</div>
             ))}
 
-          {schema && <ResponseSchemaBody oas={oas} schema={schema} useNewMarkdownEngine={useNewMarkdownEngine} />}
+          {schema && (
+            <ResponseSchemaBody
+              key={`statusCode-${selectedStatus}`}
+              oas={oas}
+              schema={schema}
+              useNewMarkdownEngine={useNewMarkdownEngine}
+            />
+          )}
         </div>
       </div>
     );


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a bug where sometimes switching what response schema you were looking at wouldn't update the component.

Resolves #1042

## 🧪 Testing

You can see this bug in action on the preview site here: http://bin.readme.com/s/5fc975f4a698920024f1aa95

![uula9jibja](https://user-images.githubusercontent.com/33762/101101370-3f0e0680-357d-11eb-804d-256aa67652ca.gif)

Despite `200` and `2XX` having different responses, moving between them doesn't update the component, but if I move from `2XX` to `400` and then to `200` I'll see all three states.

Here's what this behavior looks like now with this fix:

![pIRBpmiQ4M](https://user-images.githubusercontent.com/33762/101101778-9ad88f80-357d-11eb-990a-3fa2c2d45b9c.gif)

<details>
<summary>API definition to test with</summary>

```json
{
  "openapi": "3.0.3",
  "info": {
    "version": "1",
    "title": "Bug Example API"
  },
  "servers": [
    {
      "url": "https://example.com"
    }
  ],
  "paths": {
    "/example": {
      "get": {
        "responses": {
          "200": {
            "description": "200 response",
            "content": {
              "x-www-form-urlencoded": {
                "schema": {
                  "type": "object",
                  "properties": {
                    "id": {
                      "description": "id description",
                      "type": "string",
                      "format": "uuid"
                    },
                    "quantity": {
                      "description": "quantity description",
                      "type": "integer"
                    }
                  }
                }
              }
            }
          },
          "2XX": {
            "description": "2XX response",
            "content": {
              "x-www-form-urlencoded": {
                "schema": {
                  "type": "object",
                  "properties": {
                    "name": {
                      "description": "name description",
                      "type": "string"
                    },
                    "gift": {
                      "description": "gift description",
                      "type": "string"
                    }
                  }
                }
              }
            }
          },
          "400": {
            "description": "400 response"
          }
        }
      }
    }
  }
}
```

</details>