### PR TITLE
fix(api-explorer): fix legacy status ranges (4XX, etc)

### DIFF
--- a/packages/api-explorer/__tests__/lib/upgrade-legacy-responses.test.js
+++ b/packages/api-explorer/__tests__/lib/upgrade-legacy-responses.test.js
@@ -41,6 +41,38 @@ describe('upgradeLegacyResponses', () => {
     ]);
   });
 
+  it('should return codes array for the XX status codes', () => {
+    const encodedExample = {
+      meta: {
+        status_code: '4XX',
+        status: 'OK',
+      },
+      data: [],
+    };
+
+    const response = [
+      {
+        code: encodedExample,
+        language: 'json',
+        name: '',
+        status: '4XX',
+      },
+    ];
+
+    expect(upgradeLegacyResponses(response)).toStrictEqual([
+      {
+        languages: [
+          {
+            code: encodedExample,
+            language: 'json',
+            multipleExamples: false,
+          },
+        ],
+        status: '4XX',
+      },
+    ]);
+  });
+
   it('should return codes array for legacy response shape that has multiple examples', () => {
     const response = [
       {

--- a/packages/api-explorer/src/lib/upgrade-legacy-responses.js
+++ b/packages/api-explorer/src/lib/upgrade-legacy-responses.js
@@ -34,6 +34,17 @@ module.exports = responses => {
     });
   });
 
+  // Ensure we have a numeric status code, unless it's a range as defined in
+  // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#responsesObject
+  // (1XX, 2XX, 3XX, 4XX and 5XX)
+  function parseStatusCode(code) {
+    if (['1xx', '2xx', '3xx', '4xx', '5xx'].includes(code.toLowerCase())) {
+      return code;
+    }
+
+    return parseInt(code, 10);
+  }
+
   return Object.keys(codes)
     .map(status => {
       const data = codes[status];
@@ -65,7 +76,7 @@ module.exports = responses => {
       });
 
       return {
-        status: parseInt(status, 10),
+        status: parseStatusCode(status),
         languages,
       };
     })


### PR DESCRIPTION
## 🧰 What's being changed?

Before this PR, legacy apps that used status code ranges (1XX, 2XX, 3XX, 4XX and 5XX) in their responses failed to show those responses in the non-legacy API explorer.

## 🧪 Testing

- Create a legacy project by disabling the new api explorer in the project configuration
- Manually create an API call with a response status code of 4XX. Make sure to include an example response body.
- View the project in the legacy API explorer, and see the 4XX status code in the response examples
- Enable the new API explorer from the project configuration
- View the project in the new API explorer. Before this PR you would not see the 4XX status code. After this PR you should see it.