### PR TITLE
fix: only access the proxy-enabled extension if we need to

### DIFF
--- a/packages/oas-to-har/src/index.js
+++ b/packages/oas-to-har/src/index.js
@@ -81,10 +81,10 @@ module.exports = (
     httpVersion: 'HTTP/1.1',
   };
 
-  const proxyEnabled = extensions.getExtension(extensions.PROXY_ENABLED, oas, operation);
-  // TODO look to move this to Oas class as well
-  if (proxyEnabled && opts.proxyUrl) {
-    har.url = `https://try.readme.io/${har.url}`;
+  if (opts.proxyUrl) {
+    if (extensions.getExtension(extensions.PROXY_ENABLED, oas, operation)) {
+      har.url = `https://try.readme.io/${har.url}`;
+    }
   }
 
   // Does this operation have any parameters?


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] Changes `@readme/oas-to-har` to only look for the `x-proxy-enabled` OAS extension if the option to do so has been passed into the library.