### PR TITLE
revert: "feat: flipping the order of data in the response schema component"

### DIFF
--- a/packages/api-explorer/__tests__/ResponseSchemaBody.test.jsx
+++ b/packages/api-explorer/__tests__/ResponseSchemaBody.test.jsx
@@ -22,8 +22,8 @@ test('display object properties in the table', () => {
   return waitFor(() => {
     comp.update();
 
-    expect(comp.find('th').text()).toContain('a');
-    expect(comp.find('td').text()).toBe('String');
+    expect(comp.find('th').text()).toContain('String');
+    expect(comp.find('td').text()).toBe('a');
   });
 });
 
@@ -48,7 +48,7 @@ test('display object properties inside another object in the table', () => {
 
     expect(
       comp
-        .find('th')
+        .find('td')
         .map(a => a.text())
         .filter(a => a === 'a.a')
     ).toHaveLength(1);
@@ -98,13 +98,13 @@ test('not render more than 3 level deep object', () => {
 
     expect(
       comp
-        .find('th')
+        .find('td')
         .map(a => a.text())
         .filter(a => a === 'a.a.a')
     ).toHaveLength(1);
     expect(
       comp
-        .find('th')
+        .find('td')
         .map(a => a.text())
         .filter(a => a === 'a.a.a.a')
     ).toHaveLength(0);
@@ -130,13 +130,13 @@ test('render top level array of objects', () => {
 
     expect(
       comp
-        .find('th')
+        .find('td')
         .map(a => a.text())
         .filter(a => a === 'name')
     ).toHaveLength(1);
     expect(
       comp
-        .find('td')
+        .find('th')
         .map(a => a.text())
         .filter(a => a === 'String')
     ).toHaveLength(1);
@@ -232,7 +232,7 @@ describe('$ref handling', () => {
 
       expect(
         comp
-          .find('th')
+          .find('td')
           .map(a => a.text())
           .filter(a => a === 'category.name')
       ).toHaveLength(1);
@@ -280,14 +280,13 @@ describe('$ref handling', () => {
         comp
           .find('th')
           .map(a => a.text())
-          .filter(a => a === 'a.pets[].index')
+          .filter(a => a === '[Object]')
       ).toHaveLength(1);
-
       expect(
         comp
           .find('td')
           .map(a => a.text())
-          .filter(a => a === '[Object]')
+          .filter(a => a === 'a.pets[].index')
       ).toHaveLength(1);
     });
   });
@@ -321,13 +320,13 @@ describe('$ref handling', () => {
 
       expect(
         comp
-          .find('th')
+          .find('td')
           .map(a => a.text())
           .filter(a => a === 'name')
       ).toHaveLength(1);
       expect(
         comp
-          .find('td')
+          .find('th')
           .map(a => a.text())
           .filter(a => a === 'String')
       ).toHaveLength(1);
@@ -385,11 +384,11 @@ describe('$ref handling', () => {
 
         expect(comp.find('tr')).toHaveLength(2);
 
-        expect(comp.find('tr').at(0).find('th').text()).toBe('id');
-        expect(comp.find('tr').at(0).find('td').text()).toBe('Number');
+        expect(comp.find('tr').at(0).find('th').text()).toBe('Number');
+        expect(comp.find('tr').at(0).find('td').text()).toBe('id');
 
-        expect(comp.find('tr').at(1).find('th').text()).toBe('fields');
-        expect(comp.find('tr').at(1).find('td').text()).toBe('Circular');
+        expect(comp.find('tr').at(1).find('th').text()).toBe('Circular');
+        expect(comp.find('tr').at(1).find('td').text()).toBe('fields');
       });
     });
   });

--- a/packages/api-explorer/src/ResponseSchemaBody.jsx
+++ b/packages/api-explorer/src/ResponseSchemaBody.jsx
@@ -51,25 +51,24 @@ class ResponseSchemaBody extends React.Component {
         <tr key={Math.random().toString(10)}>
           <th
             style={{
+              whiteSpace: 'nowrap',
+              width: '30%',
               paddingRight: '5px',
               textAlign: 'right',
-              overflow: 'visible',
-              wordBreak: 'break-all',
-              // eslint-disable-next-line no-dupe-keys
+              overflow: 'hidden',
+            }}
+          >
+            {row.type}
+          </th>
+          <td
+            style={{
+              width: '70%',
+              overflow: 'hidden',
+              paddingLeft: '15px',
               wordBreak: 'break-word',
             }}
           >
             {row.name}
-          </th>
-          <td
-            style={{
-              overflow: 'hidden',
-              paddingLeft: '15px',
-              wordBreak: 'break-word',
-              verticalAlign: 'top',
-            }}
-          >
-            {row.type}
             {row.description && getDescriptionMarkdown(useNewMarkdownEngine, row.description)}
           </td>
         </tr>


### PR DESCRIPTION
There's some problems with readmeio/api-explorer#1065 on some customer sites where the change makes property names look like crap:

![Screen Shot 2020-12-08 at 4 24 37 PM](https://user-images.githubusercontent.com/33762/101557872-b7583b80-3972-11eb-822b-7f3dcb65c147.png)

Reverting this and we'll just handle the flip with the upcoming redesign.