### PR TITLE
refactor: use nanoid instead of shortid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22059,9 +22059,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -27111,14 +27111,6 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "optional": true
-    },
-    "shortid": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
-      "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
-      "requires": {
-        "nanoid": "^2.1.0"
-      }
     },
     "should": {
       "version": "13.2.3",

--- a/packages/oas-form/package-lock.json
+++ b/packages/oas-form/package-lock.json
@@ -9992,9 +9992,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -13006,14 +13006,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
-    },
-    "shortid": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
-      "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
-      "requires": {
-        "nanoid": "^2.1.0"
-      }
     },
     "side-channel": {
       "version": "1.0.3",

--- a/packages/oas-form/package.json
+++ b/packages/oas-form/package.json
@@ -38,8 +38,8 @@
     "json-schema-merge-allof": "^0.6.0",
     "jsonpointer": "^4.0.1",
     "lodash": "^4.17.15",
-    "prop-types": "^15.7.2",
-    "shortid": "^2.2.14"
+    "nanoid": "^3.1.20",
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "16.x",

--- a/packages/oas-form/src/components/fields/ArrayField.js
+++ b/packages/oas-form/src/components/fields/ArrayField.js
@@ -17,7 +17,7 @@ import {
   toIdSchema,
   getDefaultRegistry,
 } from '../../utils';
-import shortid from 'shortid';
+import { nanoid } from 'nanoid';
 
 function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
   if (!title) {
@@ -156,7 +156,7 @@ function DefaultNormalArrayFieldTemplate(props) {
 }
 
 function generateRowId() {
-  return shortid.generate();
+  return nanoid();
 }
 
 function generateKeyedFormData(formData) {


### PR DESCRIPTION
## 🧰 What's being changed?
| 🎫 [Asana Task](https://app.asana.com/0/1199087650851461/1199553290437389/f) |
|--------------------------------------------------------------------------------------|

[shortid has been deprecated](https://www.npmjs.com/package/shortid). They recommend using `nanoid` — this just swaps `shortid` with `nanoid`.

## 🧪 Testing
 Click on the Add button for those params to make sure you can add rows. 

1. Open up the local environment
2. Open a Swagger file that has object and array type parameters. `types.json` is a good one cause it will have all different types of params!
3. Find any parameter that requires you to Add a row of input like `array of strings` or `array of objects`. 
4. Click Add! If you can add rows, it should be good to go 😄 