### PR TITLE
chore(deps): bump ui to 1.17.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7105,31 +7105,31 @@
       }
     },
     "@readme/oas-extensions": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-10.0.4.tgz",
-      "integrity": "sha512-naHj01oxKU04+Wws+5uOtAHFjfxfM2JWLjsdoKWcmoSDCi4bOBzOzTxJLknVI/BlWQ1VlxIUkjQgr0Z/uxPdUg=="
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-10.0.8.tgz",
+      "integrity": "sha512-XBfLLUcPAoylw5xzan6viodcvn56W7ReTD1ZQxVfMgM8b0kr2AN9jynw0gfB/JrpaF2CghdoSgWrsrPcUypkYQ=="
     },
     "@readme/oas-to-har": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-10.0.5.tgz",
-      "integrity": "sha512-5VrbkIdfqGR+xyNmWnSHU3MlqRyLVSwMSDwOyYaSniJ1g5hFvZCquYI/TaKeIYt4Fg8+Gb/ELqejv3F94dgQmg==",
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-10.0.9.tgz",
+      "integrity": "sha512-355JQFNWShiq5pkktTHhKYbFVlE36evyN2kp+ZK+7m+ebsqqGt4X8EiOUl4I06z2WQWrQwd6oasKG0mI5awTkg==",
       "requires": {
-        "@readme/oas-extensions": "^10.0.4",
-        "oas": "^6.1.0",
+        "@readme/oas-extensions": "^10.0.8",
+        "oas": "^6.1.1",
         "parse-data-url": "^3.0.0"
       }
     },
     "@readme/oas-to-snippet": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-10.0.5.tgz",
-      "integrity": "sha512-lirYqfifmthT4JOT29AlPmZGt8IgZxM5DP+Ted4KKQzPHeqivkSMFlI1jr3Tag7kz9cLEOG5cCMG3dc8suabtg==",
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-10.0.9.tgz",
+      "integrity": "sha512-Ei68fzVI69e4PpTIflpa6SY3YCwbW2NossnQfeKBd73oZ7LM3LUvxjohLUQpLGTas/sKPEaRCssdwzmdf28cZA==",
       "requires": {
         "@readme/httpsnippet": "^2.3.1",
-        "@readme/oas-extensions": "^10.0.4",
-        "@readme/oas-to-har": "^10.0.5",
+        "@readme/oas-extensions": "^10.0.8",
+        "@readme/oas-to-har": "^10.0.9",
         "@readme/syntax-highlighter": "^10.4.1",
         "httpsnippet-client-api": "^2.5.0",
-        "oas": "^6.1.0"
+        "oas": "^6.1.1"
       }
     },
     "@readme/syntax-highlighter": {
@@ -7143,9 +7143,9 @@
       }
     },
     "@readme/ui": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@readme/ui/-/ui-1.17.3.tgz",
-      "integrity": "sha512-oYxndyoLf83JsMZ5KyCTnvH0U5KAcvJ0z5rbKKwJwchdpGFdSBsfbqq+T2y+a9bnNMiAzOi0kwEMdeSd5zpXPw==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/@readme/ui/-/ui-1.17.6.tgz",
+      "integrity": "sha512-BpBRD6+miuvofV9aInmAN90j2H7NSVoWv5dSLuVLBynjv+MdLsy+xdJF8DwIE2bgnGHxdn5e4lqZfHfsAmCMuw==",
       "requires": {
         "@bem-react/classname": "^1.5.7",
         "@readme/emojis": "^3.0.0",
@@ -7166,20 +7166,20 @@
           "resolved": "https://registry.npmjs.org/@readme/emojis/-/emojis-3.0.0.tgz",
           "integrity": "sha512-qbuhp2lugNXl3evFqG7kd/+SMMMlm461dcr/vFputoU3S/fwY6W9J1HzFqsp2kH0otzKLS/6og/t3OxjLx7O0g=="
         },
-        "@readme/variable": {
-          "version": "10.0.7",
-          "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-10.0.7.tgz",
-          "integrity": "sha512-IcWm8lgUTZj4WVsMkQWDPnqTDNg25kx/QksrkhAbBvwBsXw5UJvygrHFhgm/17CEqgjuEy8Wd0WIuV+D5Qjlww==",
-          "requires": {
-            "classnames": "^2.2.6",
-            "prop-types": "^15.7.2"
-          }
-        },
         "emoji-regex": {
           "version": "9.2.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.0.tgz",
           "integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug=="
         }
+      }
+    },
+    "@readme/variable": {
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-10.0.9.tgz",
+      "integrity": "sha512-yRzAMeA+kjdSD+OXQpvyXWDcvBRjLfj7VSOduMF7pPgDU2xus/DoTd9CJMPvcbC6pAJhmbuPbrMBzIbtZz1mvA==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "prop-types": "^15.7.2"
       }
     },
     "@testing-library/dom": {
@@ -10518,9 +10518,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "codemirror": {
-      "version": "5.58.3",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.58.3.tgz",
-      "integrity": "sha512-KBhB+juiyOOgn0AqtRmWyAT3yoElkuvWTI6hsHa9E6GQrl6bk/fdAYcvuqW1/upO9T9rtEtapWdw4XYcNiVDEA=="
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.59.1.tgz",
+      "integrity": "sha512-d0SSW/PCCD4LoSCBPdnP0BzmZB1v3emomCUtVlIWgZHJ06yVeBOvBtOH7vYz707pfAvEeWbO9aP6akh8vl1V3w=="
     },
     "collection-visit": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.1",
     "@readme/emojis": "^2.1.0",
-    "@readme/ui": "^1.17.3",
+    "@readme/ui": "^1.17.6",
     "babel-polyfill": "^6.26.0",
     "oas": "^6.1.1",
     "prop-types": "^15.7.2",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -50,7 +50,7 @@
     "@readme/eslint-config": "^4.0.0",
     "@readme/markdown": "^6.21.0",
     "@readme/oas-examples": "^4.0.0",
-    "@readme/ui": "^1.17.0",
+    "@readme/ui": "^1.17.6",
     "@readme/variable": "^10.0.9",
     "@testing-library/react": "^11.2.2",
     "css-loader": "^4.3.0",


### PR DESCRIPTION
Bumps ui for updated tutorial tile component (it'll now say, "open recipe"):

![Safari - API Explorer - 2021-01-05 at 05 50 11 PM](https://user-images.githubusercontent.com/5341618/103719800-b10fac00-4f7e-11eb-9d15-90a811734e6e.png)
