### PR TITLE
fix(api-explorer): prevent nulls from breaking operations

### DIFF
--- a/packages/oas-to-har/__tests__/index.test.js
+++ b/packages/oas-to-har/__tests__/index.test.js
@@ -182,6 +182,49 @@ describe('parameters', () => {
         { query: { id: 0 } },
         [{ name: 'id', value: '0' }],
       ],
+      [
+        'should handle null array values',
+        {
+          parameters: [{ name: 'id', in: 'query' }],
+        },
+        { query: { id: [null, null] } },
+        [
+          { name: 'id', value: 'null' },
+          { name: 'id', value: 'null' },
+        ],
+      ],
+      [
+        'should handle null values',
+        {
+          parameters: [{ name: 'id', in: 'query' }],
+        },
+        { query: { id: null } },
+        [{ name: 'id', value: 'null' }],
+      ],
+      [
+        'should handle null default values',
+        {
+          parameters: [
+            {
+              name: 'id',
+              in: 'query',
+              required: true,
+              schema: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+                default: [null, null],
+              },
+            },
+          ],
+        },
+        { query: {} },
+        [
+          { name: 'id', value: 'null' },
+          { name: 'id', value: 'null' },
+        ],
+      ],
     ])('%s', async (testCase, operation = {}, values = {}, expectedQueryString = []) => {
       const har = oasToHar(
         oas,

--- a/packages/oas-to-har/src/index.js
+++ b/packages/oas-to-har/src/index.js
@@ -67,7 +67,7 @@ function appendHarValue(harParam, name, value) {
     value.forEach(singleValue => {
       appendHarValue(harParam, name, singleValue);
     });
-  } else if (typeof value === 'object') {
+  } else if (typeof value === 'object' && value !== null) {
     // If the formatter gives us an object, we're expected to add each property value as a new parameter item, each with the name of the property
     Object.keys(value).forEach(key => {
       appendHarValue(harParam, key, value[key]);


### PR DESCRIPTION
## 🧰 What's being changed?

Null values or defaults had the potential of throwing an error when rendering a non-body operation. This fixes that.

## 🧪 Testing

Message me for an example json file and put it in your `examples/swagger-files` folder, run `npm start`, and test the `manual-api-keeptrucking.json` file. Look for the endpoint named `driver_utilization`. Before this change you would see an error. After it you should see a rendered operation.