### PR TITLE
fix(api-explorer): stop x-readme-api-explorer header from breaking unproxied cors requests

### DIFF
--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -25,8 +25,6 @@ const { Operation } = Oas;
 const parseResponse = require('./lib/parse-response');
 const Content = require('./block-types/Content');
 
-const { version: packageVersion } = require('../package.json');
-
 const stringifyPretty = data => JSON.stringify(data, undefined, 2);
 
 class Doc extends React.Component {
@@ -213,13 +211,6 @@ class Doc extends React.Component {
     });
 
     const request = constructRequest(har);
-
-    // There's a bug in Firefox and Chrome where they don't respect setting a custom User-Agent on fetch() requests,
-    // so instead to let API metrics know that this request came from the Explorer, we're setting a vendor header
-    // instead.
-    //
-    // https://stackoverflow.com/questions/42815087/sending-a-custom-user-agent-string-along-with-my-headers-fetch
-    request.headers.append('x-readme-api-explorer', packageVersion);
 
     return fetch(request).then(async res => {
       this.props.tryItMetrics(har, res);


### PR DESCRIPTION
## 🧰 What's being changed?

`x-readme-api-explorer` header is causing issues for some customers due to cors: https://app.intercom.com/a/apps/m6855w1q/inbox/inbox/conversation/7278100009838. We could just remove this for people not using the proxy, but it sounds like we're not using this header at all, so we chose to remove it entirely (https://readmeio.slack.com/archives/C5B798RFZ/p1610669718031200)

## 🧪 Testing

Test any API request from the explorer with the network tab open, and you shouldn't see the `x-readme-api-explorer` header being sent.
