### PR TITLE
fix: ignore styling definitions on oas-reserved headers

### DIFF
--- a/packages/oas-to-har/src/lib/style-formatting/index.js
+++ b/packages/oas-to-har/src/lib/style-formatting/index.js
@@ -5,6 +5,10 @@ function shouldNotStyleEmptyValues(parameter) {
   return ['simple', 'spaceDelimited', 'pipeDelimited', 'deepObject'].includes(parameter.style);
 }
 
+function shouldNotStyleReservedHeader(parameter) {
+  return ['accept', 'authorization', 'content-type'].includes(parameter.name.toLowerCase());
+}
+
 // Note: This isn't necessarily part of the spec. Behavior for the value 'undefined' is, well, undefined.
 //   This code makes our system look better. If we wanted to be more accurate, we might want to remove this,
 //   restore the un-fixed behavior for undefined and have our UI pass in empty string instead of undefined.
@@ -48,6 +52,17 @@ function stylizeValue(value, parameter) {
   // Every style that adds their style to empty values should use emptystring for path parameters instead of undefined to avoid the string 'undefined'
   if (parameter.in === 'path') {
     finalValue = removeUndefinedForPath(finalValue);
+  }
+
+  // Eventhough `Accept`, `Authorization`, and `Content-Type` headers can be defined as parameters, they should be
+  // completely ignored when it comes to serialization.
+  //
+  //  > If in is "header" and the name field is "Accept", "Content-Type" or "Authorization", the parameter definition
+  //  > SHALL be ignored.
+  //
+  // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#fixed-fields-10
+  if (parameter.in === 'header' && shouldNotStyleReservedHeader(parameter)) {
+    return value;
   }
 
   return stylize({

--- a/packages/oas-to-har/src/lib/style-formatting/style-serializer.js
+++ b/packages/oas-to-har/src/lib/style-formatting/style-serializer.js
@@ -10,7 +10,7 @@
 const { Buffer } = require('buffer');
 
 const isRfc3986Reserved = char => ":/?#[]@!$&'()*+,;=".indexOf(char) > -1;
-const isRrc3986Unreserved = char => /^[a-z0-9\-._~]+$/i.test(char);
+const isRfc3986Unreserved = char => /^[a-z0-9\-._~]+$/i.test(char);
 
 module.exports = function stylize(config) {
   const { value } = config;
@@ -46,7 +46,7 @@ module.exports.encodeDisallowedCharacters = function encodeDisallowedCharacters(
   // code points rather than UCS-2/UTF-16 code units.
   return [...str]
     .map(char => {
-      if (isRrc3986Unreserved(char)) {
+      if (isRfc3986Unreserved(char)) {
         return char;
       }
 


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

* [x] Fixes a regression introduced in our #1128 support that was serializing OAS-reserved headers: `accept`, `authorization`, `content-type`. Fixes RM-188

![Screen Shot 2021-01-29 at 1 57 22 PM](https://user-images.githubusercontent.com/33762/106331517-ecc62a80-6239-11eb-853a-a44e43676aaa.png)

## 🧬 Testing

See unit test for examples.

![Screen Shot 2021-01-29 at 1 57 52 PM](https://user-images.githubusercontent.com/33762/106331567-04051800-623a-11eb-9a74-896fcb50c2ea.png)

[demo]: https://deployment_url