### PR TITLE
fix(api-explorer): fix style encoding

### DIFF
--- a/packages/oas-to-har/src/lib/style-formatting/index.js
+++ b/packages/oas-to-har/src/lib/style-formatting/index.js
@@ -55,11 +55,9 @@ function stylizeValue(value, parameter) {
     key: parameter.name,
     style: parameter.style,
     explode: parameter.explode,
-    /*
-      TODO: this parameter is optional to stylize. It defaults to false, and can accept falsy, truthy, or "unsafe".
-      I do not know if it is correct for query to use this. See style-serializer for more info
-    */
-    escape: true,
+    // We do not want to encode query parameters, cookies or headers because our httpsnippet library does that for us.
+    // We do want to encode path parameters because the httpsnippet library does not handle any encoding there
+    escape: parameter.in === 'path',
   });
 }
 


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?
Ticket: https://linear.app/readme-io/issue/RM-216/serialized-data-being-double-serialized-in-some-httpsnippet-targets

When developing the style library, it was unclear how we wanted to handle encoding. After some feedback from users and additional research and discussion, I believe we only want the style library to encode values on the path because the httpsnippet library will encode everything else once for us before the end users see it.

## 🧬 Testing

Compare the example style oas files in production, and against this PR. You will notice that typing a value like `;` in production leads to `%253B` and in this PR leads to `%3B`
