### PR TITLE
fix(ui components): remove a stylesheet import that's now redundant

### DIFF
--- a/example/src/Demo.jsx
+++ b/example/src/Demo.jsx
@@ -156,7 +156,7 @@ class Demo extends React.Component {
     if (enableTutorials) {
       docs.forEach((doc, i) => {
         // Only add our mock tutorials if we don't have them present.
-        if (!('tutorials' in doc)) {
+        if ('tutorials' in doc) {
           docs[i].tutorials = [
             {
               title: 'Test Recipe',
@@ -195,9 +195,7 @@ class Demo extends React.Component {
       });
     } else {
       docs.forEach((doc, i) => {
-        if (!('tutorials' in doc)) {
-          docs[i].tutorials = [];
-        }
+        docs[i].tutorials = [];
       });
     }
 

--- a/example/src/Demo.jsx
+++ b/example/src/Demo.jsx
@@ -42,8 +42,8 @@ class Demo extends React.Component {
         description: 'Enable our request body JSON editor.',
         stateProp: 'enableJsonEditor',
       },
-      'Enable tutorials (beta)': {
-        description: 'Enable our tutorials beta.',
+      'Enable recipes (beta)': {
+        description: 'Enable our recipes beta.',
         stateProp: 'enableTutorials',
       },
     };
@@ -159,9 +159,9 @@ class Demo extends React.Component {
         if (!('tutorials' in doc)) {
           docs[i].tutorials = [
             {
-              title: 'Test Tutorial',
-              description: 'Tutorial description',
-              slug: 'test-tutorial',
+              title: 'Test Recipe',
+              description: 'Recipe description',
+              slug: 'test-recipe',
               backgroundColor: '#018FF4',
               emoji: '🦉',
               _id: '123',

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -10,7 +10,6 @@ const Oas = require('oas/tooling');
 const { getPath, matchesMimeType } = require('oas/tooling/utils');
 
 const { TutorialTile } = require('@readme/ui/.bundles/es/ui/compositions');
-require('@readme/ui/.bundles/umd/main.css');
 
 const isAuthReady = require('./lib/is-auth-ready');
 


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

Now that we've migrated our full component library to the ReadMe repo, we need to remove a stylesheet import from the API Explorer repo since it's being applied twice. See https://github.com/readmeio/readme/pull/3552 for more info!

I verified that this doesn't break any of the styling in the demo app because of [`bundle-hub2.css`](https://github.com/readmeio/api-explorer/blob/0b3fbebdaefd2306e6fe393a1c05dc781f9ffa7e/example/bundle-hub2.css).

This also does a bit of recipes-specific housekeeping:
- [x] Updates the copy in the demo app so it's now "recipes" d90dc65
- [x] Fixes some of the logic so the "Enable recipes" toggle is now working again in the demo app. **Feel free to revert this if the toggle was intentionally disabled!** 0b3fbeb

## 🧬 Testing

Verify that the "Enable recipes" toggle in the demo app is working, and that none of the styling appears to be broken.

[demo]: https://deployment_url
