### PR TITLE
fix: prevent code snippets from double encoding querystrings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5486,9 +5486,9 @@
       "integrity": "sha512-sC94wCjHfHYt87j+pKnG6FaKMX0N6BLBINPokR3XXGv43lhT32qbFbWDzmBuiJOC4PRHg0M4kMsBToVH47V6mA=="
     },
     "@readme/httpsnippet": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.3.1.tgz",
-      "integrity": "sha512-gnL3cXfY+sG03SL/Ua5bEeiDxk+nTMMJu7+aKNLGZguL9R67vXvqL+A6mYaGwwUo6b7g5dfUzv0Zs44tfFQD1w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.4.0.tgz",
+      "integrity": "sha512-YvzKSRMp/6WHA8U+MR6tnsYXAgA8j1tH4mMQHUGJjZOnD/zA8kWuotZkIeraptgKHaSKBFXMWp0zQYjWlNjCgQ==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12951,55 +12951,15 @@
       }
     },
     "httpsnippet-client-api": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.5.0.tgz",
-      "integrity": "sha512-0d6502HC7Y/6dVKa4tnJzCTeR4yV3XrIuNgRB1Z9rRrvCNRhJlQXZMp/1X/AXWZtvJSBXdqw4VvYcp5b91ERJg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.7.0.tgz",
+      "integrity": "sha512-8+PPy42R5TCnL9nC2zY+VCUdTsp9s81LluAgOZDGR6ztaTZnYsZDAg+5VrnnjbK21zm18C4MOvocqZS5kABENw==",
       "requires": {
-        "@readme/httpsnippet": "^2.2.2",
+        "@readme/httpsnippet": "^2.4.0",
         "content-type": "^1.0.4",
-        "oas": "^6.1.0",
+        "oas": "^10.0.0",
         "path-to-regexp": "^6.1.0",
         "stringify-object": "^3.3.0"
-      },
-      "dependencies": {
-        "oas": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/oas/-/oas-6.1.1.tgz",
-          "integrity": "sha512-qGiouvgeRa00gFW4EjkOke2ZvTZD/4Z/ElUBgTLO3hxim+bOtY3uElGSZjemZHgTmRSefE3j2WBb9xSZ0XebLQ==",
-          "requires": {
-            "@apidevtools/json-schema-ref-parser": "^9.0.6",
-            "cardinal": "^2.1.1",
-            "colors": "^1.1.2",
-            "figures": "^3.0.0",
-            "glob": "^7.1.2",
-            "inquirer": "^7.0.1",
-            "json-schema-merge-allof": "^0.7.0",
-            "json2yaml": "^1.1.0",
-            "jsonfile": "^6.0.0",
-            "jsonpointer": "^4.1.0",
-            "lodash": "^4.17.11",
-            "lodash.kebabcase": "^4.1.1",
-            "minimist": "^1.2.0",
-            "node-status": "^1.0.0",
-            "oas-normalize": "2.3.1",
-            "open": "^7.0.0",
-            "path-to-regexp": "^6.2.0",
-            "request": "^2.88.0",
-            "swagger-inline": "3.2.2"
-          },
-          "dependencies": {
-            "json-schema-merge-allof": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.7.0.tgz",
-              "integrity": "sha512-kvsuSVnl1n5xnNEu5ed4o8r8ujSA4/IgRtHmpgfMfa7FOMIRAzN4F9qbuklouTn5J8bi83y6MQ11n+ERMMTXZg==",
-              "requires": {
-                "compute-lcm": "^1.1.0",
-                "json-schema-compare": "^0.2.2",
-                "lodash": "^4.17.4"
-              }
-            }
-          }
-        }
       }
     },
     "human-signals": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5486,14 +5486,22 @@
       "integrity": "sha512-sC94wCjHfHYt87j+pKnG6FaKMX0N6BLBINPokR3XXGv43lhT32qbFbWDzmBuiJOC4PRHg0M4kMsBToVH47V6mA=="
     },
     "@readme/httpsnippet": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.4.0.tgz",
-      "integrity": "sha512-YvzKSRMp/6WHA8U+MR6tnsYXAgA8j1tH4mMQHUGJjZOnD/zA8kWuotZkIeraptgKHaSKBFXMWp0zQYjWlNjCgQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.4.1.tgz",
+      "integrity": "sha512-u/PSMvzqZ0m9KRJpKMy1dJfFq+xcTq0DpwIw9itXMxQTUekFC72N0donKEg9tI1SwLjxmhHOfn+Q0anMckFA8w==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",
         "har-validator": "^5.0.0",
+        "qs": "^6.9.6",
         "stringify-object": "^3.3.0"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.9.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+        }
       }
     },
     "@readme/markdown": {

--- a/packages/oas-to-snippet/__tests__/index.test.js
+++ b/packages/oas-to-snippet/__tests__/index.test.js
@@ -126,29 +126,6 @@ test('should return with unhighlighted code', () => {
   expect(code).not.toMatch(/cm-s-tomorrow-night/);
 });
 
-test('should not double-encode query strings', () => {
-  const woofEncoded = encodeURIComponent('woof:woof');
-  const barkEncoded = encodeURIComponent('bark:bark');
-
-  const petstoreOas = new Oas(petstore);
-  const snippet = generateCodeSnippet(
-    petstoreOas,
-    petstoreOas.operation('/user/login', 'get'),
-    {
-      query: {
-        username: woofEncoded,
-        password: barkEncoded,
-      },
-    },
-    {},
-    'javascript',
-    oasUrl
-  );
-
-  expect(snippet.code).not.toContain(encodeURIComponent(woofEncoded));
-  expect(snippet.code).not.toContain(encodeURIComponent(barkEncoded));
-});
-
 test('should support node-simple', () => {
   const petstoreOas = new Oas(petstore);
   const snippet = generateCodeSnippet(
@@ -247,6 +224,48 @@ describe('multipart/form-data handlings', () => {
 
     expect(snippet).toMatchSnapshot();
   });
+});
+
+test('should not double-encode query strings', () => {
+  const startTime = '2019-06-13T19:08:25.455Z';
+  const endTime = '2015-09-15T14:00:12-04:00';
+
+  const snippet = generateCodeSnippet(
+    oas,
+    {
+      path: '/',
+      method: 'get',
+      parameters: [
+        {
+          explode: true,
+          in: 'query',
+          name: 'startTime',
+          schema: {
+            type: 'string',
+          },
+          style: 'form',
+        },
+        {
+          explode: true,
+          in: 'query',
+          name: 'endTime',
+          schema: {
+            type: 'string',
+          },
+          style: 'form',
+        },
+      ],
+    },
+    { query: { startTime, endTime } },
+    {},
+    'javascript',
+    oasUrl
+  );
+
+  expect(snippet.code).toContain(encodeURIComponent(startTime));
+  expect(snippet.code).toContain(encodeURIComponent(endTime));
+  expect(snippet.code).not.toContain(encodeURIComponent(encodeURIComponent(startTime)));
+  expect(snippet.code).not.toContain(encodeURIComponent(encodeURIComponent(endTime)));
 });
 
 describe('#getLangName()', () => {

--- a/packages/oas-to-snippet/__tests__/index.test.js
+++ b/packages/oas-to-snippet/__tests__/index.test.js
@@ -126,6 +126,29 @@ test('should return with unhighlighted code', () => {
   expect(code).not.toMatch(/cm-s-tomorrow-night/);
 });
 
+test('should not double-encode query strings', () => {
+  const woofEncoded = encodeURIComponent('woof:woof');
+  const barkEncoded = encodeURIComponent('bark:bark');
+
+  const petstoreOas = new Oas(petstore);
+  const snippet = generateCodeSnippet(
+    petstoreOas,
+    petstoreOas.operation('/user/login', 'get'),
+    {
+      query: {
+        username: woofEncoded,
+        password: barkEncoded,
+      },
+    },
+    {},
+    'javascript',
+    oasUrl
+  );
+
+  expect(snippet.code).not.toContain(encodeURIComponent(woofEncoded));
+  expect(snippet.code).not.toContain(encodeURIComponent(barkEncoded));
+});
+
 test('should support node-simple', () => {
   const petstoreOas = new Oas(petstore);
   const snippet = generateCodeSnippet(

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -5507,64 +5507,15 @@
       }
     },
     "httpsnippet-client-api": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.5.0.tgz",
-      "integrity": "sha512-0d6502HC7Y/6dVKa4tnJzCTeR4yV3XrIuNgRB1Z9rRrvCNRhJlQXZMp/1X/AXWZtvJSBXdqw4VvYcp5b91ERJg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.7.0.tgz",
+      "integrity": "sha512-8+PPy42R5TCnL9nC2zY+VCUdTsp9s81LluAgOZDGR6ztaTZnYsZDAg+5VrnnjbK21zm18C4MOvocqZS5kABENw==",
       "requires": {
-        "@readme/httpsnippet": "^2.2.2",
+        "@readme/httpsnippet": "^2.4.0",
         "content-type": "^1.0.4",
-        "oas": "^6.1.0",
+        "oas": "^10.0.0",
         "path-to-regexp": "^6.1.0",
         "stringify-object": "^3.3.0"
-      },
-      "dependencies": {
-        "@readme/httpsnippet": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.3.1.tgz",
-          "integrity": "sha512-gnL3cXfY+sG03SL/Ua5bEeiDxk+nTMMJu7+aKNLGZguL9R67vXvqL+A6mYaGwwUo6b7g5dfUzv0Zs44tfFQD1w==",
-          "requires": {
-            "event-stream": "4.0.1",
-            "form-data": "3.0.0",
-            "har-validator": "^5.0.0",
-            "stringify-object": "^3.3.0"
-          }
-        },
-        "form-data": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "oas": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/oas/-/oas-6.1.1.tgz",
-          "integrity": "sha512-qGiouvgeRa00gFW4EjkOke2ZvTZD/4Z/ElUBgTLO3hxim+bOtY3uElGSZjemZHgTmRSefE3j2WBb9xSZ0XebLQ==",
-          "requires": {
-            "@apidevtools/json-schema-ref-parser": "^9.0.6",
-            "cardinal": "^2.1.1",
-            "colors": "^1.1.2",
-            "figures": "^3.0.0",
-            "glob": "^7.1.2",
-            "inquirer": "^7.0.1",
-            "json-schema-merge-allof": "^0.7.0",
-            "json2yaml": "^1.1.0",
-            "jsonfile": "^6.0.0",
-            "jsonpointer": "^4.1.0",
-            "lodash": "^4.17.11",
-            "lodash.kebabcase": "^4.1.1",
-            "minimist": "^1.2.0",
-            "node-status": "^1.0.0",
-            "oas-normalize": "2.3.1",
-            "open": "^7.0.0",
-            "path-to-regexp": "^6.2.0",
-            "request": "^2.88.0",
-            "swagger-inline": "3.2.2"
-          }
-        }
       }
     },
     "human-signals": {

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -2440,13 +2440,14 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.4.0.tgz",
-      "integrity": "sha512-YvzKSRMp/6WHA8U+MR6tnsYXAgA8j1tH4mMQHUGJjZOnD/zA8kWuotZkIeraptgKHaSKBFXMWp0zQYjWlNjCgQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.4.1.tgz",
+      "integrity": "sha512-u/PSMvzqZ0m9KRJpKMy1dJfFq+xcTq0DpwIw9itXMxQTUekFC72N0donKEg9tI1SwLjxmhHOfn+Q0anMckFA8w==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",
         "har-validator": "^5.0.0",
+        "qs": "^6.9.6",
         "stringify-object": "^3.3.0"
       },
       "dependencies": {
@@ -2459,6 +2460,11 @@
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
+        },
+        "qs": {
+          "version": "6.9.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
         }
       }
     },

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -2440,9 +2440,9 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.3.1.tgz",
-      "integrity": "sha512-gnL3cXfY+sG03SL/Ua5bEeiDxk+nTMMJu7+aKNLGZguL9R67vXvqL+A6mYaGwwUo6b7g5dfUzv0Zs44tfFQD1w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.4.0.tgz",
+      "integrity": "sha512-YvzKSRMp/6WHA8U+MR6tnsYXAgA8j1tH4mMQHUGJjZOnD/zA8kWuotZkIeraptgKHaSKBFXMWp0zQYjWlNjCgQ==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -17,7 +17,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@readme/httpsnippet": "^2.3.1",
+    "@readme/httpsnippet": "^2.4.0",
     "@readme/oas-extensions": "^11.0.0",
     "@readme/oas-to-har": "^11.1.2",
     "@readme/syntax-highlighter": "^10.4.1",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -21,7 +21,7 @@
     "@readme/oas-extensions": "^11.0.0",
     "@readme/oas-to-har": "^11.1.2",
     "@readme/syntax-highlighter": "^10.4.1",
-    "httpsnippet-client-api": "^2.5.0",
+    "httpsnippet-client-api": "^2.7.0",
     "oas": "^10.0.1"
   },
   "devDependencies": {

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -17,7 +17,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@readme/httpsnippet": "^2.4.0",
+    "@readme/httpsnippet": "^2.4.1",
     "@readme/oas-extensions": "^11.0.0",
     "@readme/oas-to-har": "^11.1.2",
     "@readme/syntax-highlighter": "^10.4.1",

--- a/packages/oas-to-snippet/src/index.js
+++ b/packages/oas-to-snippet/src/index.js
@@ -27,7 +27,7 @@ module.exports = (oas, operation, values, auth, lang, oasUrl) => {
     }
   }
 
-  const snippet = new HTTPSnippet(har);
+  const snippet = new HTTPSnippet(har, { escapeQueryStrings: false });
 
   const language = supportedLanguages[lang];
 


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

Fixes a bug where if a query string had a `style` attribute to specify an encoding, it would end up getting doubly encoded between `@readme/oas-to-har` and `@readme/httpsnippet`.

Fixes RM-216

## 🧬 Testing

Check out the attached unit test. `2019-06-13T19:08:25.455Z` and `2015-09-15T14:00:12-04:00` was entered by the user and according to the API definition should be encoded with `form` styling. This data gets saved as `2019-06-13T19%3A08%3A25.455Z` into the HAR and fed into `@readme/oas-to-snippet` and `@readme/httpsnippet`.

`@readme/httpsnippet` should not encode this data again into `2019-06-13T19%253A08%253A25.455Z`.

[demo]: https://readme-api-e-fix-querys-rdllnu.herokuapp.com/
