### PR TITLE
chore: add missing test for the wildcard response type branch

### DIFF
--- a/packages/api-explorer/__tests__/lib/parse-response.test.js
+++ b/packages/api-explorer/__tests__/lib/parse-response.test.js
@@ -218,3 +218,13 @@ test('should default to JSON with wildcard content-type', async () => {
 
   expect((await parseResponse(har, wildcardResponse)).responseBody).toStrictEqual(JSON.parse(responseBody));
 });
+
+test('should return with empty string if there is no response', async () => {
+  const emptyResponse = new Response(null, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  expect((await parseResponse(har, emptyResponse)).responseBody).toStrictEqual('');
+});

--- a/packages/api-explorer/__tests__/lib/parse-response.test.js
+++ b/packages/api-explorer/__tests__/lib/parse-response.test.js
@@ -208,3 +208,13 @@ test('should not error if invalid json is returned', async () => {
 
   expect((await parseResponse(har, invalidJsonResponse)).responseBody).toBe('plain text');
 });
+
+test('should default to JSON with wildcard content-type', async () => {
+  const wildcardResponse = new Response(responseBody, {
+    headers: {
+      'Content-Type': '*/*',
+    },
+  });
+
+  expect((await parseResponse(har, wildcardResponse)).responseBody).toStrictEqual(JSON.parse(responseBody));
+});


### PR DESCRIPTION
## 🧰 What's being changed?

The condition at the end of this line didn't have a test:
https://github.com/readmeio/api-explorer/blob/77b90ebed4673f168354cdcd730e34b7ee016360/packages/api-explorer/src/lib/parse-response.js#L15

## 🧬 Testing
If the build passes 🤷‍♂️