### PR TITLE
fix: missing operation schema exceptions

### DIFF
--- a/example/swagger-files/manual-api-missingInOas.json
+++ b/example/swagger-files/manual-api-missingInOas.json
@@ -1,0 +1,54 @@
+{
+  "readmeManual": true,
+  "docs": [
+    {
+      "_id": "7333016a-a191-4722-ba46-be45a19ddf6c",
+      "swagger": {
+        "path": "/",
+        "definition": "{\"tags\":[\"assets\"],\"description\":\"\",\"operationId\":\"removeAssets\",\"consumes\":[\"application/json\"],\"produces\":[\"application/json\"],\"parameters\":[{\"in\":\"body\",\"name\":\"body\",\"required\":false,\"schema\":{\"$ref\":\"#/definitions/BatchDeleteRequest\"}}],\"responses\":{\"200\":{\"description\":\"Operation finished with list of responses specific for particular asset.\",\"schema\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/BatchOperationApiResponse\"}}}},\"_path\":\"/assets\",\"_method\":\"delete\"}"
+      },
+      "api": {
+        "apiSetting": "5c2b025e-16ea-4a07-9c6c-87e0aae7e4fd",
+        "auth": "required",
+        "params": [],
+        "url": "",
+        "method": "delete",
+        "results": { "codes": [] }
+      },
+      "body": "",
+      "excerpt": "",
+      "slug": "removelistofassets",
+      "type": "endpoint",
+      "title": "Bulk delete operation for set of assets."
+    }
+  ],
+  "oasFiles": {
+    "5c2b025e-16ea-4a07-9c6c-87e0aae7e4fd": {
+      "openapi": "3.0.0",
+      "info": {
+        "description": "This is a sample server Petstore server.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,\n`special-key` to test the authorization filters.",
+        "version": "1.0.0",
+        "title": "Swagger Petstore"
+      },
+      "servers": [
+        {
+          "url": "http://petstore.swagger.io/v2"
+        }
+      ],
+      "paths": {
+        "/": {
+          "get": {
+            "responses": {
+              "200": {
+                "description": "OK"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "oasUrls": {
+    "5c2b025e-16ea-4a07-9c6c-87e0aae7e4fd": "https://example.com/5c2b025e-16ea-4a07-9c6c-87e0aae7e4fd"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6175,9 +6175,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.6.tgz",
-      "integrity": "sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.0.tgz",
+      "integrity": "sha512-O3SQC6+6AySHwrspYn2UvC6tjo6jCTMMmylxZUFhE1CulVu5l3AxU6ca9lrJDTQDVllF62LIxVSx5fuYL6LiZg=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -18062,9 +18062,9 @@
       }
     },
     "oas": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-10.0.2.tgz",
-      "integrity": "sha512-odR0z9aP+qo4UFqf620Y7AbBuFer+F0NvDtOiCOaIVwiVFloTQCT4ww9ZbFiJiGWfWj86TIhL0jaw3p19xmjLg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-10.0.3.tgz",
+      "integrity": "sha512-BbJBdzU3tGOyN6Ok20diq63Vh5orfk1j5ak9DmjtNiuH0uiBlxvEi5k3iWJkJz0fA9Esap/WEgHANYpmm9964Q==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -19576,9 +19576,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-json-view": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.21.0.tgz",
-      "integrity": "sha512-qdN4XepZhjjgIDVsLE2d78u7gcqcq4lQV5puoDGo+js+SBMahkVXc+xI/GhLC0/SwYHwiiQXg8LQXfvBTryQlQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.21.1.tgz",
+      "integrity": "sha512-AonvGea4nWlsnNXCbnSdUHsetyNS8rUMhbFHS9eFaDB1oeaxgHcVsqo5LhGRMvWybfDdjVUo0xzDoMQP7jbrXw==",
       "requires": {
         "flux": "^4.0.1",
         "react-base16-styling": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@readme/emojis": "^3.0.0",
     "@readme/ui": "^1.17.6",
     "babel-polyfill": "^6.26.0",
-    "oas": "^10.0.2",
+    "oas": "^10.0.3",
     "prop-types": "^15.7.2",
     "react-hot-loader": "^4.12.16",
     "swagger2openapi": "^7.0.0",

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -697,9 +697,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.5.tgz",
-      "integrity": "sha512-kBBSQbz2K0Nyn+31j/w36fUfxkBW9/gfwRWdUY1ULReH3iokVJgddZAFcD1D0xlgTmFxJCbUkUclAlc6/IDJkw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "optional": true
     },
     "har-schema": {
@@ -1163,9 +1163,9 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oas": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-10.0.2.tgz",
-      "integrity": "sha512-odR0z9aP+qo4UFqf620Y7AbBuFer+F0NvDtOiCOaIVwiVFloTQCT4ww9ZbFiJiGWfWj86TIhL0jaw3p19xmjLg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-10.0.3.tgz",
+      "integrity": "sha512-BbJBdzU3tGOyN6Ok20diq63Vh5orfk1j5ak9DmjtNiuH0uiBlxvEi5k3iWJkJz0fA9Esap/WEgHANYpmm9964Q==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -31,7 +31,7 @@
     "js-cookie": "^2.1.4",
     "lodash.clonedeep": "^4.5.0",
     "lodash.kebabcase": "^4.1.1",
-    "oas": "^10.0.2",
+    "oas": "^10.0.3",
     "prop-types": "^15.7.2",
     "react-copy-to-clipboard": "^5.0.1",
     "react-debounce-input": "^3.2.0",

--- a/packages/oas-to-har/package-lock.json
+++ b/packages/oas-to-har/package-lock.json
@@ -6954,9 +6954,9 @@
       "dev": true
     },
     "oas": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-10.0.2.tgz",
-      "integrity": "sha512-odR0z9aP+qo4UFqf620Y7AbBuFer+F0NvDtOiCOaIVwiVFloTQCT4ww9ZbFiJiGWfWj86TIhL0jaw3p19xmjLg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-10.0.3.tgz",
+      "integrity": "sha512-BbJBdzU3tGOyN6Ok20diq63Vh5orfk1j5ak9DmjtNiuH0uiBlxvEi5k3iWJkJz0fA9Esap/WEgHANYpmm9964Q==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@readme/oas-extensions": "^11.0.0",
-    "oas": "^10.0.2",
+    "oas": "^10.0.3",
     "parse-data-url": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -8038,9 +8038,9 @@
       "dev": true
     },
     "oas": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-10.0.2.tgz",
-      "integrity": "sha512-odR0z9aP+qo4UFqf620Y7AbBuFer+F0NvDtOiCOaIVwiVFloTQCT4ww9ZbFiJiGWfWj86TIhL0jaw3p19xmjLg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-10.0.3.tgz",
+      "integrity": "sha512-BbJBdzU3tGOyN6Ok20diq63Vh5orfk1j5ak9DmjtNiuH0uiBlxvEi5k3iWJkJz0fA9Esap/WEgHANYpmm9964Q==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -22,7 +22,7 @@
     "@readme/oas-to-har": "^11.1.5",
     "@readme/syntax-highlighter": "^10.4.1",
     "httpsnippet-client-api": "^2.7.0",
-    "oas": "^10.0.2"
+    "oas": "^10.0.3"
   },
   "devDependencies": {
     "@readme/eslint-config": "^4.0.0",


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

* [x] Updates our `oas` dependency to fix a bug where if a supplied path+method combination didn't exist in an OAS it was being searched for in though we'd still return an instance of the `Operation` class, we'd return it with an `undefined` `schema` property. This error would then cascase and throw failures on any accessor of that class. Check out https://github.com/readmeio/oas/pull/371 for tests.

## 🧬 Testing

Check out the attached `manual-api-missingInOas.json` example definition.

Against `next`, this is what it currently looks like:

![Screen Shot 2021-02-09 at 6 56 39 PM](https://user-images.githubusercontent.com/33762/107458254-8e862b00-6b08-11eb-96de-05f3988048ad.png)

And with this fix:

![Screen Shot 2021-02-09 at 6 58 14 PM](https://user-images.githubusercontent.com/33762/107458355-c7be9b00-6b08-11eb-8582-ca82c6462920.png)

[demo]: https://deployment_url