### PR TITLE
fix: update the prop type on `placeholder` to accept numbers

### DIFF
--- a/packages/oas-form/src/components/widgets/BaseInput.js
+++ b/packages/oas-form/src/components/widgets/BaseInput.js
@@ -112,7 +112,7 @@ if (process.env.NODE_ENV !== 'production') {
     onBlur: PropTypes.func,
     onChange: PropTypes.func,
     onFocus: PropTypes.func,
-    placeholder: PropTypes.string,
+    placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     readonly: PropTypes.bool,
     required: PropTypes.bool,
     value: PropTypes.any,


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

This updates the prop type on the `placeholder` prop in `BaseInput` to accept strings **and** numbers.

## 🧬 Testing

With this fix, this React error goes away:

```
Warning: Failed prop type: Invalid prop `placeholder` of type `number` supplied to `BaseInput`, expected `string`.
    in BaseInput (created by UpDownWidget)
    in UpDownWidget (created by Component)
    in Component (created by StringField)
    in StringField (created by NumberField)
    in NumberField (created by SchemaField)
    in div (created by CustomTemplate)
    in div (created by CustomTemplate)
    in CustomTemplate (created by SchemaField)
    in SchemaField (created by SchemaField)
    in SchemaField (created by ObjectField)
    in fieldset (created by DefaultObjectFieldTemplate)
    in DefaultObjectFieldTemplate (created by ObjectField)
    in ObjectField (created by SchemaField)
    in div (created by WrapIfAdditional)
    in WrapIfAdditional (created by DefaultTemplate)
    in DefaultTemplate (created by SchemaField)
    in SchemaField (created by SchemaField)
    in SchemaField (created by Form)
    in form (created by Form)
    in Form (created by Params)
    in div (created by Tabs)
    in Tabs (created by Params)
    in div (created by Params)
    in div (created by Params)
    in Params (created by Component)
    in Component (created by Doc)
    in div (created by Doc)
    in div (created by Doc)
    in div (created by Doc)
    in ErrorBoundary (created by Doc)
    in div (created by Doc)
    in Doc (created by DocAsync)
    in DocAsync (created by Component)
    in Component (created by ApiExplorer)
    in div (created by ApiExplorer)
    in div (created by ApiExplorer)
    in ApiExplorer (created by Component)
    in ErrorBoundary (created by Component)
    in Component (created by Demo)
    in div (created by Demo)
    in div (created by Demo)
    in Demo (created by SpecFetcher)
    in SpecFetcher
    in AppContainer
```

[demo]: https://deployment_url
