### PR TITLE
refactor: decoupling our ui library from the api explorer codebase

### DIFF
--- a/example/src/Demo.jsx
+++ b/example/src/Demo.jsx
@@ -1,7 +1,9 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 
-const { Button, Flex, Tabs, Toggle, TutorialModal, TutorialTile } = require('@readme/ui/.bundles/es/ui/components');
+const { Button, Flex, Tabs, Toggle } = require('@readme/ui/.bundles/es/ui/components');
+const { TutorialModal, TutorialTile } = require('@readme/ui/.bundles/es/ui/compositions');
+
 const { cmVariableContext: TutorialVariableContext } = require('@readme/ui/.bundles/es/views');
 const { DEFAULT_TUTORIAL } = require('@readme/ui/.bundles/es/ui/compositions/Tutorials/Modal/constants/stepDefaults');
 

--- a/example/src/Demo.jsx
+++ b/example/src/Demo.jsx
@@ -1,6 +1,9 @@
 const React = require('react');
 const PropTypes = require('prop-types');
-const { Flex, Toggle } = require('@readme/ui/.bundles/es/ui/components');
+
+const { Button, Flex, Tabs, Toggle, TutorialModal, TutorialTile } = require('@readme/ui/.bundles/es/ui/components');
+const { cmVariableContext: TutorialVariableContext } = require('@readme/ui/.bundles/es/views');
+const { DEFAULT_TUTORIAL } = require('@readme/ui/.bundles/es/ui/compositions/Tutorials/Modal/constants/stepDefaults');
 
 const extensions = require('../../packages/oas-extensions');
 
@@ -119,6 +122,18 @@ class Demo extends React.Component {
 
       suggestedEdits: true,
       useNewMarkdownEngine,
+
+      // API Explorer does not ship with our UI library so we need to give it the components it needs.
+      ui: {
+        Button,
+        Tabs,
+        tutorials: {
+          DEFAULT_TUTORIAL,
+          TutorialModal,
+          TutorialTile,
+          TutorialVariableContext,
+        },
+      },
 
       variables: {
         // Uncomment this to test without logs

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 88,
-      functions: 88,
+      functions: 85,
       lines: 90,
       statements: 90,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,118 +5,118 @@
   "requires": true,
   "dependencies": {
     "@algolia/cache-browser-local-storage": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.8.3.tgz",
-      "integrity": "sha512-Cwc03hikHSUI+xvgUdN+H+f6jFyoDsC9fegzXzJ2nPn1YSN9EXzDMBnbrgl0sbl9iLGXe0EIGMYqR2giCv1wMQ==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.8.5.tgz",
+      "integrity": "sha512-9rs/Yi82ilgifweJamOy4DlJ4xPGsCN/zg+RKy4vjytNhOrkEHLRQC8vPZ3OhD8KVlw9lRQIZTlgjgFl8iMeeA==",
       "requires": {
-        "@algolia/cache-common": "4.8.3"
+        "@algolia/cache-common": "4.8.5"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.8.3.tgz",
-      "integrity": "sha512-Cf7zZ2i6H+tLSBTkFePHhYvlgc9fnMPKsF9qTmiU38kFIGORy/TN2Fx5n1GBuRLIzaSXvcf+oHv1HvU0u1gE1g=="
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.8.5.tgz",
+      "integrity": "sha512-4SvRWnagKtwBFAy8Rsfmv0/Uk53fZL+6dy2idwdx6SjMGKSs0y1Qv+thb4h/k/H5MONisAoT9C2rgZ/mqwh5yw=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.8.3.tgz",
-      "integrity": "sha512-+N7tkvmijXiDy2E7u1mM73AGEgGPWFmEmPeJS96oT46I98KXAwVPNYbcAqBE79YlixdXpkYJk41cFcORzNh+Iw==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.8.5.tgz",
+      "integrity": "sha512-XBBfqs28FbjwLboY3sxvuzBgYsuXdFsj2mUvkgxfb0GVEzwW4I0NM7KzSPwT+iht55WS1PgIOnynjmhPsrubCw==",
       "requires": {
-        "@algolia/cache-common": "4.8.3"
+        "@algolia/cache-common": "4.8.5"
       }
     },
     "@algolia/client-account": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.8.3.tgz",
-      "integrity": "sha512-Uku8LqnXBwfDCtsTCDYTUOz2/2oqcAQCKgaO0uGdIR8DTQENBXFQvzziambHdn9KuFuY+6Et9k1+cjpTPBDTBg==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.8.5.tgz",
+      "integrity": "sha512-DjXMpeCdY4J4IDBfowiG6Xl9ec/FhG1NpPQM0Uv4xXsc/TeeZ1JgbgNDhWe9jW0jBEALy+a/RmPrZ0vsxcadsg==",
       "requires": {
-        "@algolia/client-common": "4.8.3",
-        "@algolia/client-search": "4.8.3",
-        "@algolia/transporter": "4.8.3"
+        "@algolia/client-common": "4.8.5",
+        "@algolia/client-search": "4.8.5",
+        "@algolia/transporter": "4.8.5"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.8.3.tgz",
-      "integrity": "sha512-9ensIWmjYJprZ+YjAVSZdWUG05xEnbytENXp508X59tf34IMIX8BR2xl0RjAQODtxBdAteGxuKt5THX6U9tQLA==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.8.5.tgz",
+      "integrity": "sha512-PQEY+chbHmZnRJdaWsvUYzDpEPr60az0EPUexdouvXGZId15/SnDaXjnf89F7tYmCzkHdUtG4bSvPzAupQ4AFA==",
       "requires": {
-        "@algolia/client-common": "4.8.3",
-        "@algolia/client-search": "4.8.3",
-        "@algolia/requester-common": "4.8.3",
-        "@algolia/transporter": "4.8.3"
+        "@algolia/client-common": "4.8.5",
+        "@algolia/client-search": "4.8.5",
+        "@algolia/requester-common": "4.8.5",
+        "@algolia/transporter": "4.8.5"
       }
     },
     "@algolia/client-common": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.8.3.tgz",
-      "integrity": "sha512-TU3623AEFAWUQlDTznkgAMSYo8lfS9pNs5QYDQzkvzWdqK0GBDWthwdRfo9iIsfxiR9qdCMHqwEu+AlZMVhNSA==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.8.5.tgz",
+      "integrity": "sha512-Dn8vog2VrGsJeOcBMcSAEIjBtPyogzUBGlh1DtVd0m8GN6q+cImCESl6DY846M2PTYWsLBKBksq37eUfSe9FxQ==",
       "requires": {
-        "@algolia/requester-common": "4.8.3",
-        "@algolia/transporter": "4.8.3"
+        "@algolia/requester-common": "4.8.5",
+        "@algolia/transporter": "4.8.5"
       }
     },
     "@algolia/client-recommendation": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-recommendation/-/client-recommendation-4.8.3.tgz",
-      "integrity": "sha512-qysGbmkcc6Agt29E38KWJq9JuxjGsyEYoKuX9K+P5HyQh08yR/BlRYrA8mB7vT/OIUHRGFToGO6Vq/rcg0NIOQ==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/client-recommendation/-/client-recommendation-4.8.5.tgz",
+      "integrity": "sha512-ffawCC1C25rCa8/JU2niRZgwr8aV9b2qsLVMo73GXFzi2lceXPAe9K68mt/BGHU+w7PFUwVHsV2VmB+G/HQRVw==",
       "requires": {
-        "@algolia/client-common": "4.8.3",
-        "@algolia/requester-common": "4.8.3",
-        "@algolia/transporter": "4.8.3"
+        "@algolia/client-common": "4.8.5",
+        "@algolia/requester-common": "4.8.5",
+        "@algolia/transporter": "4.8.5"
       }
     },
     "@algolia/client-search": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.8.3.tgz",
-      "integrity": "sha512-rAnvoy3GAhbzOQVniFcKVn1eM2NX77LearzYNCbtFrFYavG+hJI187bNVmajToiuGZ10FfJvK99X2OB1AzzezQ==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.8.5.tgz",
+      "integrity": "sha512-Ru2MljGZWrSQ0CVsDla11oGEPL/RinmVkLJfBtQ+/pk1868VfpAQFGKtOS/b8/xLrMA0Vm4EfC3Mgclk/p3KJA==",
       "requires": {
-        "@algolia/client-common": "4.8.3",
-        "@algolia/requester-common": "4.8.3",
-        "@algolia/transporter": "4.8.3"
+        "@algolia/client-common": "4.8.5",
+        "@algolia/requester-common": "4.8.5",
+        "@algolia/transporter": "4.8.5"
       }
     },
     "@algolia/logger-common": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.8.3.tgz",
-      "integrity": "sha512-03wksHRbhl2DouEKnqWuUb64s1lV6kDAAabMCQ2Du1fb8X/WhDmxHC4UXMzypeOGlH5BZBsgVwSB7vsZLP3MZg=="
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.8.5.tgz",
+      "integrity": "sha512-PS6NS6bpED0rAxgCPGhjZJg9why0PnoVEE7ZoCbPq6lsAOc6FPlQLri4OiLyU7wx8RWDoVtOadyzulqAAsfPSQ=="
     },
     "@algolia/logger-console": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.8.3.tgz",
-      "integrity": "sha512-Npt+hI4UF8t3TLMluL5utr9Gc11BjL5kDnGZOhDOAz5jYiSO2nrHMFmnpLT4Cy/u7a5t7EB5dlypuC4/AGStkA==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.8.5.tgz",
+      "integrity": "sha512-3+4gLSbwzuGmrb5go3IZNcFIYVMSbB4c8UMtWEJ/gDBtgGZIvT6f/KlvVSOHIhthSxaM3Y13V6Qile/SpGqc6A==",
       "requires": {
-        "@algolia/logger-common": "4.8.3"
+        "@algolia/logger-common": "4.8.5"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.8.3.tgz",
-      "integrity": "sha512-/LTTIpgEmEwkyhn8yXxDdBWqXqzlgw5w2PtTpIwkSlP2/jDwdR/9w1TkFzhNbJ81ki6LAEQM5mSwoTTnbIIecg==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.8.5.tgz",
+      "integrity": "sha512-M/Gf2vv/fU4+CqDW+wok7HPpEcLym3NtDzU9zaPzGYI/9X7o36581oyfnzt2pNfsXSQVj5a2pZVUWC3Z4SO27w==",
       "requires": {
-        "@algolia/requester-common": "4.8.3"
+        "@algolia/requester-common": "4.8.5"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.8.3.tgz",
-      "integrity": "sha512-+Yo9vBkofoKR1SCqqtMnmnfq9yt/BiaDewY/6bYSMNxSYCnu2Fw1JKSIaf/4zos09PMSsxGpLohZwGas3+0GDQ=="
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.8.5.tgz",
+      "integrity": "sha512-OIhsdwIrJVAlVlP7cwlt+RoR5AmxAoTGrFokOY9imVmgqXUUljdKO/DjhRL8vwYGFEidZ9efIjAIQ2B3XOhT9A=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.8.3.tgz",
-      "integrity": "sha512-k2fiKIeMIFqgC01FnzII6kqC2GQBAfbNaUX4k7QCPa6P8t4sp2xE6fImOUiztLnnL3C9X9ZX6Fw3L+cudi7jvQ==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.8.5.tgz",
+      "integrity": "sha512-viHAjfo53A3VSE7Bb/nzgpSMZ3prPp2qti7Wg8w7qxhntppKp3Fln6t4Vp+BoPOqruLsj139xXhheAKeRcYa0w==",
       "requires": {
-        "@algolia/requester-common": "4.8.3"
+        "@algolia/requester-common": "4.8.5"
       }
     },
     "@algolia/transporter": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.8.3.tgz",
-      "integrity": "sha512-nU7fy2iU8snxATlsks0MjMyv97QJWQmOVwTjDc+KZ4+nue8CLcgm4LA4dsTBqvxeCQIoEtt3n72GwXcaqiJSjQ==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.8.5.tgz",
+      "integrity": "sha512-Rb3cMlh/GoJK0+g+49GNA3IvR/EXsDEBwpyM+FOotSwxgiGt1wGBHM0K2v0GHwIEcuww02pl6KMDVlilA+qh0g==",
       "requires": {
-        "@algolia/cache-common": "4.8.3",
-        "@algolia/logger-common": "4.8.3",
-        "@algolia/requester-common": "4.8.3"
+        "@algolia/cache-common": "4.8.5",
+        "@algolia/logger-common": "4.8.5",
+        "@algolia/requester-common": "4.8.5"
       }
     },
     "@apidevtools/json-schema-ref-parser": {
@@ -1464,9 +1464,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@bem-react/classname": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@bem-react/classname/-/classname-1.5.8.tgz",
-      "integrity": "sha512-F+s5TVxOrznvnx7hYMq43RQ5ZNKk1fSMZX9PRObVco2bGYwNGEKTtvHTeY5wGVjkB7OJlq+/8QPDV2CJnbzaxg=="
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@bem-react/classname/-/classname-1.5.9.tgz",
+      "integrity": "sha512-I2uqyN+r1TdjSjOc7RiP8pmQVR1TBF0avIAXDHr7PcZVV828CXPFvoabkE+FTIFUnb2QjsgAXtvsGVsf/TU8SA=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
@@ -5574,18 +5574,6 @@
         "unist-util-flatmap": "^1.0.0",
         "unist-util-map": "^2.0.0",
         "unist-util-select": "^3.0.4"
-      },
-      "dependencies": {
-        "@readme/syntax-highlighter": {
-          "version": "10.4.4",
-          "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.4.4.tgz",
-          "integrity": "sha512-M0pKuFkdVpC8Lb2yDMat6CY7TDfdTuwuvbKEXM1RGR665ako+1zC4rLnObKeqjEzUF9+EDKwbpl/fc8D4qawJw==",
-          "requires": {
-            "codemirror": "^5.48.2",
-            "prop-types": "^15.7.2",
-            "react-codemirror2": "^7.2.1"
-          }
-        }
       }
     },
     "@readme/markdown-magic": {
@@ -5697,15 +5685,25 @@
       "integrity": "sha512-XBfLLUcPAoylw5xzan6viodcvn56W7ReTD1ZQxVfMgM8b0kr2AN9jynw0gfB/JrpaF2CghdoSgWrsrPcUypkYQ=="
     },
     "@readme/oas-to-har": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-10.1.0.tgz",
-      "integrity": "sha512-CXa11pAJC8SvHSIY7oUHU7R6r1q2eveSvYaFvpTnLTrcWpZy9gh6ey8aEW6+UDWitPYph+wvvpxM1jZaFnX1pQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-10.1.1.tgz",
+      "integrity": "sha512-b4VEQO+iqZN9GuTrn6wCxTJ5qoAdOWt6PrYasH1JpLAlup6hYEh4x4JxqMugZnaA7bl3qyuBKE+VmBhIoVLsNA==",
       "requires": {
         "@readme/oas-extensions": "^10.0.8",
         "oas": "^6.1.1",
         "parse-data-url": "^3.0.0"
       },
       "dependencies": {
+        "json-schema-merge-allof": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.7.0.tgz",
+          "integrity": "sha512-kvsuSVnl1n5xnNEu5ed4o8r8ujSA4/IgRtHmpgfMfa7FOMIRAzN4F9qbuklouTn5J8bi83y6MQ11n+ERMMTXZg==",
+          "requires": {
+            "compute-lcm": "^1.1.0",
+            "json-schema-compare": "^0.2.2",
+            "lodash": "^4.17.4"
+          }
+        },
         "oas": {
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/oas/-/oas-6.1.1.tgz",
@@ -5730,35 +5728,33 @@
             "path-to-regexp": "^6.2.0",
             "request": "^2.88.0",
             "swagger-inline": "3.2.2"
-          },
-          "dependencies": {
-            "json-schema-merge-allof": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.7.0.tgz",
-              "integrity": "sha512-kvsuSVnl1n5xnNEu5ed4o8r8ujSA4/IgRtHmpgfMfa7FOMIRAzN4F9qbuklouTn5J8bi83y6MQ11n+ERMMTXZg==",
-              "requires": {
-                "compute-lcm": "^1.1.0",
-                "json-schema-compare": "^0.2.2",
-                "lodash": "^4.17.4"
-              }
-            }
           }
         }
       }
     },
     "@readme/oas-to-snippet": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-10.1.0.tgz",
-      "integrity": "sha512-aAkbWKSlybhboJuGD38JlUxEOn61zmSaO39G2zKaV49LuC2C2KmOHpey/c8RxpLzizQ20TmGBHBJdBmOsLJqJA==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-10.1.1.tgz",
+      "integrity": "sha512-DqKPROFvBPhnsfnBK5lN3mqNCLwlCKM+dsjwcJiW5SxJjX+tsFYNpFAxdHXOe4K6RQtvszKHWnDpnpQlQht5SA==",
       "requires": {
         "@readme/httpsnippet": "^2.3.1",
         "@readme/oas-extensions": "^10.0.8",
-        "@readme/oas-to-har": "^10.1.0",
+        "@readme/oas-to-har": "^10.1.1",
         "@readme/syntax-highlighter": "^10.4.1",
         "httpsnippet-client-api": "^2.5.0",
         "oas": "^6.1.1"
       },
       "dependencies": {
+        "json-schema-merge-allof": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.7.0.tgz",
+          "integrity": "sha512-kvsuSVnl1n5xnNEu5ed4o8r8ujSA4/IgRtHmpgfMfa7FOMIRAzN4F9qbuklouTn5J8bi83y6MQ11n+ERMMTXZg==",
+          "requires": {
+            "compute-lcm": "^1.1.0",
+            "json-schema-compare": "^0.2.2",
+            "lodash": "^4.17.4"
+          }
+        },
         "oas": {
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/oas/-/oas-6.1.1.tgz",
@@ -5783,26 +5779,14 @@
             "path-to-regexp": "^6.2.0",
             "request": "^2.88.0",
             "swagger-inline": "3.2.2"
-          },
-          "dependencies": {
-            "json-schema-merge-allof": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.7.0.tgz",
-              "integrity": "sha512-kvsuSVnl1n5xnNEu5ed4o8r8ujSA4/IgRtHmpgfMfa7FOMIRAzN4F9qbuklouTn5J8bi83y6MQ11n+ERMMTXZg==",
-              "requires": {
-                "compute-lcm": "^1.1.0",
-                "json-schema-compare": "^0.2.2",
-                "lodash": "^4.17.4"
-              }
-            }
           }
         }
       }
     },
     "@readme/syntax-highlighter": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.4.1.tgz",
-      "integrity": "sha512-6TcJkxEs+Q+6t/tHYy8mNe8FQNQXiGUTE1llyVONyMfoFQ2gS/OQv0ld0V3NaR+kcq0Skcok/KJHr5l0F07DJg==",
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.4.4.tgz",
+      "integrity": "sha512-M0pKuFkdVpC8Lb2yDMat6CY7TDfdTuwuvbKEXM1RGR665ako+1zC4rLnObKeqjEzUF9+EDKwbpl/fc8D4qawJw==",
       "requires": {
         "codemirror": "^5.48.2",
         "prop-types": "^15.7.2",
@@ -5810,9 +5794,9 @@
       }
     },
     "@readme/ui": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@readme/ui/-/ui-1.17.7.tgz",
-      "integrity": "sha512-XPLuLAm2A9iPM2X30gkWvs+kVZ6ERN8XoVT49CBAPL7SGpK1suVnpc42LV2r8OdPLD//ukUMRYgS7e6E6jc1Rw==",
+      "version": "1.17.8",
+      "resolved": "https://registry.npmjs.org/@readme/ui/-/ui-1.17.8.tgz",
+      "integrity": "sha512-/Xu/qj18fRUgaVL/z8/jcQLvRM/Kf60G/hGCooA2nYXA9BL0ztLh7GG0Zr2D6kZyzSueJbkLFn2Glj2EUHIlMg==",
       "requires": {
         "@bem-react/classname": "^1.5.7",
         "@readme/emojis": "^3.0.0",
@@ -5826,13 +5810,6 @@
         "lodash": "^4.17.15",
         "modularscale-sass": "^3.0.10",
         "react-instantsearch-dom": "^6.4.0"
-      },
-      "dependencies": {
-        "@readme/emojis": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@readme/emojis/-/emojis-3.0.0.tgz",
-          "integrity": "sha512-qbuhp2lugNXl3evFqG7kd/+SMMMlm461dcr/vFputoU3S/fwY6W9J1HzFqsp2kH0otzKLS/6og/t3OxjLx7O0g=="
-        }
       }
     },
     "@readme/variable": {
@@ -6639,30 +6616,30 @@
       "dev": true
     },
     "algoliasearch": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.8.3.tgz",
-      "integrity": "sha512-pljX9jEE2TQ3i1JayhG8afNdE8UuJg3O9c7unW6QO67yRWCKr6b0t5aKC3hSVtjt7pA2TQXLKoAISb4SHx9ozQ==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.8.5.tgz",
+      "integrity": "sha512-GjKjpeevpePEJYinGokASNtIkl1t5EseNMlqDNAc+sXE8+iyyeqTyiJsN7bwlRG2BIremuslE/NlwdEfUuBLJw==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.8.3",
-        "@algolia/cache-common": "4.8.3",
-        "@algolia/cache-in-memory": "4.8.3",
-        "@algolia/client-account": "4.8.3",
-        "@algolia/client-analytics": "4.8.3",
-        "@algolia/client-common": "4.8.3",
-        "@algolia/client-recommendation": "4.8.3",
-        "@algolia/client-search": "4.8.3",
-        "@algolia/logger-common": "4.8.3",
-        "@algolia/logger-console": "4.8.3",
-        "@algolia/requester-browser-xhr": "4.8.3",
-        "@algolia/requester-common": "4.8.3",
-        "@algolia/requester-node-http": "4.8.3",
-        "@algolia/transporter": "4.8.3"
+        "@algolia/cache-browser-local-storage": "4.8.5",
+        "@algolia/cache-common": "4.8.5",
+        "@algolia/cache-in-memory": "4.8.5",
+        "@algolia/client-account": "4.8.5",
+        "@algolia/client-analytics": "4.8.5",
+        "@algolia/client-common": "4.8.5",
+        "@algolia/client-recommendation": "4.8.5",
+        "@algolia/client-search": "4.8.5",
+        "@algolia/logger-common": "4.8.5",
+        "@algolia/logger-console": "4.8.5",
+        "@algolia/requester-browser-xhr": "4.8.5",
+        "@algolia/requester-common": "4.8.5",
+        "@algolia/requester-node-http": "4.8.5",
+        "@algolia/transporter": "4.8.5"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.3.4.tgz",
-      "integrity": "sha512-1Ts2XcgGdjGlDrp3v6zbY8VW+X9+jJ5rBmtPBmXOQLd4b5t/LpJlaBdxoAnlMfVFjywP7KSAdmyFUNNYVHDyRQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.4.4.tgz",
+      "integrity": "sha512-OjyVLjykaYKCMxxRMZNiwLp8CS310E0qAeIY2NaublcmLAh8/SL19+zYHp7XCLtMem2ZXwl3ywMiA32O9jszuw==",
       "requires": {
         "events": "^1.1.1"
       }
@@ -8099,9 +8076,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "codemirror": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.59.1.tgz",
-      "integrity": "sha512-d0SSW/PCCD4LoSCBPdnP0BzmZB1v3emomCUtVlIWgZHJ06yVeBOvBtOH7vYz707pfAvEeWbO9aP6akh8vl1V3w=="
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.59.2.tgz",
+      "integrity": "sha512-/D5PcsKyzthtSy2NNKCyJi3b+htRkoKv3idswR/tR6UAvMNKA7SrmyZy6fOONJxSRs1JlUWEDAbxqfdArbK8iA=="
     },
     "collapse-white-space": {
       "version": "1.0.6",
@@ -13242,11 +13219,11 @@
       }
     },
     "httpsnippet-client-api": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.7.0.tgz",
-      "integrity": "sha512-8+PPy42R5TCnL9nC2zY+VCUdTsp9s81LluAgOZDGR6ztaTZnYsZDAg+5VrnnjbK21zm18C4MOvocqZS5kABENw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.7.1.tgz",
+      "integrity": "sha512-/cJxQWv+oJJl5SOac1jiKyUudIiMu6OoEv9kliL1s8qjiBuds6sm+NmknIWE6pBu0oTKGX9sNgQqp66XGeyeGQ==",
       "requires": {
-        "@readme/httpsnippet": "^2.4.0",
+        "@readme/httpsnippet": "^2.4.1",
         "content-type": "^1.0.4",
         "oas": "^10.0.0",
         "path-to-regexp": "^6.1.0",
@@ -18320,27 +18297,27 @@
       }
     },
     "react-instantsearch-core": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.8.2.tgz",
-      "integrity": "sha512-UdAjcNIXb2mSECEDS/2XuB4W6rcbnph1NjJBUpY5TLLzSCdKXNTzS2PxF5hkdeuY0L/m/hvDQX6YqxV28PqKLA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.9.0.tgz",
+      "integrity": "sha512-xLNyF0mUBq7MaLQgmosBnxac7YnLTuanu5TKZkH7RFEVC2T5mi4fINtG6vAkOkVjiH90abv2wdPY6UjE/Vt6kQ==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "algoliasearch-helper": "^3.1.0",
-        "prop-types": "^15.5.10",
+        "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0"
       }
     },
     "react-instantsearch-dom": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.8.2.tgz",
-      "integrity": "sha512-d6YBsjW/aF3qzul7qqUV/KuzEFPVxlAZm3QhREPqMvOyrPTnG5itZZBLe7sFm9OKJ/8shR4TyNp3hb94as7COg==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.9.0.tgz",
+      "integrity": "sha512-G8jSIC5QutdiK6QhZwyLcIONg2C6/6wRMkAM6uZ5ObSDvY+h/PkSohc8//A7LNOyedOCACd/UfdWlmexSYjl6Q==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "algoliasearch-helper": "^3.1.0",
         "classnames": "^2.2.5",
-        "prop-types": "^15.5.10",
+        "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0",
-        "react-instantsearch-core": "^6.8.2"
+        "react-instantsearch-core": "^6.9.0"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.1",
     "@readme/emojis": "^3.0.0",
-    "@readme/ui": "^1.17.6",
+    "@readme/ui": "^1.17.8",
     "babel-polyfill": "^6.26.0",
     "oas": "^10.1.1",
     "prop-types": "^15.7.2",

--- a/packages/api-explorer/__tests__/Doc.test.jsx
+++ b/packages/api-explorer/__tests__/Doc.test.jsx
@@ -2,6 +2,11 @@ const extensions = require('@readme/oas-extensions');
 const { Request, Response } = require('node-fetch');
 const Oas = require('oas/tooling');
 
+const { Button, Tabs } = require('@readme/ui/.bundles/es/ui/components');
+const { TutorialModal, TutorialTile } = require('@readme/ui/.bundles/es/ui/compositions');
+const { cmVariableContext: TutorialVariableContext } = require('@readme/ui/.bundles/es/views');
+const { DEFAULT_TUTORIAL } = require('@readme/ui/.bundles/es/ui/compositions/Tutorials/Modal/constants/stepDefaults');
+
 global.Request = Request;
 
 const React = require('react');
@@ -34,6 +39,16 @@ const props = {
   setLanguage: () => {},
   suggestedEdits: false,
   tryItMetrics: () => {},
+  ui: {
+    Button,
+    Tabs,
+    tutorials: {
+      DEFAULT_TUTORIAL,
+      TutorialModal,
+      TutorialTile,
+      TutorialVariableContext,
+    },
+  },
 };
 
 const petExample = {

--- a/packages/api-explorer/__tests__/Params.test.jsx
+++ b/packages/api-explorer/__tests__/Params.test.jsx
@@ -3,6 +3,7 @@ const { mount } = require('enzyme');
 const extensions = require('@readme/oas-extensions');
 const Oas = require('oas/tooling');
 const { ADDITIONAL_PROPERTY_FLAG } = require('@readme/oas-form/src/utils');
+const { Button, Tabs } = require('@readme/ui/.bundles/es/ui/components');
 
 const Description = require('../src/form-components/DescriptionField');
 const createParams = require('../src/Params');
@@ -27,6 +28,10 @@ const props = {
   onSubmit: () => {},
   operation,
   resetForm: () => {},
+  ui: {
+    Button,
+    Tabs,
+  },
 };
 
 const Params = createParams(oas, operation);

--- a/packages/api-explorer/__tests__/index.test.jsx
+++ b/packages/api-explorer/__tests__/index.test.jsx
@@ -5,6 +5,11 @@ const Cookie = require('js-cookie');
 const extensions = require('@readme/oas-extensions');
 const Oas = require('oas/tooling');
 
+const { Button, Tabs } = require('@readme/ui/.bundles/es/ui/components');
+const { TutorialModal, TutorialTile } = require('@readme/ui/.bundles/es/ui/compositions');
+const { cmVariableContext: TutorialVariableContext } = require('@readme/ui/.bundles/es/views');
+const { DEFAULT_TUTORIAL } = require('@readme/ui/.bundles/es/ui/compositions/Tutorials/Modal/constants/stepDefaults');
+
 const WrappedApiExplorer = require('../src');
 const AuthBox = require('../src/AuthBox');
 const ErrorBoundary = require('../src/ErrorBoundary');
@@ -40,6 +45,16 @@ const props = {
   },
   shouldDereferenceOas: false,
   suggestedEdits: false,
+  ui: {
+    Button,
+    Tabs,
+    tutorials: {
+      DEFAULT_TUTORIAL,
+      TutorialModal,
+      TutorialTile,
+      TutorialVariableContext,
+    },
+  },
   variables: { user: {}, defaults: [] },
 };
 

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -4,6 +4,135 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@algolia/cache-browser-local-storage": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.8.5.tgz",
+      "integrity": "sha512-9rs/Yi82ilgifweJamOy4DlJ4xPGsCN/zg+RKy4vjytNhOrkEHLRQC8vPZ3OhD8KVlw9lRQIZTlgjgFl8iMeeA==",
+      "dev": true,
+      "requires": {
+        "@algolia/cache-common": "4.8.5"
+      }
+    },
+    "@algolia/cache-common": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.8.5.tgz",
+      "integrity": "sha512-4SvRWnagKtwBFAy8Rsfmv0/Uk53fZL+6dy2idwdx6SjMGKSs0y1Qv+thb4h/k/H5MONisAoT9C2rgZ/mqwh5yw==",
+      "dev": true
+    },
+    "@algolia/cache-in-memory": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.8.5.tgz",
+      "integrity": "sha512-XBBfqs28FbjwLboY3sxvuzBgYsuXdFsj2mUvkgxfb0GVEzwW4I0NM7KzSPwT+iht55WS1PgIOnynjmhPsrubCw==",
+      "dev": true,
+      "requires": {
+        "@algolia/cache-common": "4.8.5"
+      }
+    },
+    "@algolia/client-account": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.8.5.tgz",
+      "integrity": "sha512-DjXMpeCdY4J4IDBfowiG6Xl9ec/FhG1NpPQM0Uv4xXsc/TeeZ1JgbgNDhWe9jW0jBEALy+a/RmPrZ0vsxcadsg==",
+      "dev": true,
+      "requires": {
+        "@algolia/client-common": "4.8.5",
+        "@algolia/client-search": "4.8.5",
+        "@algolia/transporter": "4.8.5"
+      }
+    },
+    "@algolia/client-analytics": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.8.5.tgz",
+      "integrity": "sha512-PQEY+chbHmZnRJdaWsvUYzDpEPr60az0EPUexdouvXGZId15/SnDaXjnf89F7tYmCzkHdUtG4bSvPzAupQ4AFA==",
+      "dev": true,
+      "requires": {
+        "@algolia/client-common": "4.8.5",
+        "@algolia/client-search": "4.8.5",
+        "@algolia/requester-common": "4.8.5",
+        "@algolia/transporter": "4.8.5"
+      }
+    },
+    "@algolia/client-common": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.8.5.tgz",
+      "integrity": "sha512-Dn8vog2VrGsJeOcBMcSAEIjBtPyogzUBGlh1DtVd0m8GN6q+cImCESl6DY846M2PTYWsLBKBksq37eUfSe9FxQ==",
+      "dev": true,
+      "requires": {
+        "@algolia/requester-common": "4.8.5",
+        "@algolia/transporter": "4.8.5"
+      }
+    },
+    "@algolia/client-recommendation": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/client-recommendation/-/client-recommendation-4.8.5.tgz",
+      "integrity": "sha512-ffawCC1C25rCa8/JU2niRZgwr8aV9b2qsLVMo73GXFzi2lceXPAe9K68mt/BGHU+w7PFUwVHsV2VmB+G/HQRVw==",
+      "dev": true,
+      "requires": {
+        "@algolia/client-common": "4.8.5",
+        "@algolia/requester-common": "4.8.5",
+        "@algolia/transporter": "4.8.5"
+      }
+    },
+    "@algolia/client-search": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.8.5.tgz",
+      "integrity": "sha512-Ru2MljGZWrSQ0CVsDla11oGEPL/RinmVkLJfBtQ+/pk1868VfpAQFGKtOS/b8/xLrMA0Vm4EfC3Mgclk/p3KJA==",
+      "dev": true,
+      "requires": {
+        "@algolia/client-common": "4.8.5",
+        "@algolia/requester-common": "4.8.5",
+        "@algolia/transporter": "4.8.5"
+      }
+    },
+    "@algolia/logger-common": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.8.5.tgz",
+      "integrity": "sha512-PS6NS6bpED0rAxgCPGhjZJg9why0PnoVEE7ZoCbPq6lsAOc6FPlQLri4OiLyU7wx8RWDoVtOadyzulqAAsfPSQ==",
+      "dev": true
+    },
+    "@algolia/logger-console": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.8.5.tgz",
+      "integrity": "sha512-3+4gLSbwzuGmrb5go3IZNcFIYVMSbB4c8UMtWEJ/gDBtgGZIvT6f/KlvVSOHIhthSxaM3Y13V6Qile/SpGqc6A==",
+      "dev": true,
+      "requires": {
+        "@algolia/logger-common": "4.8.5"
+      }
+    },
+    "@algolia/requester-browser-xhr": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.8.5.tgz",
+      "integrity": "sha512-M/Gf2vv/fU4+CqDW+wok7HPpEcLym3NtDzU9zaPzGYI/9X7o36581oyfnzt2pNfsXSQVj5a2pZVUWC3Z4SO27w==",
+      "dev": true,
+      "requires": {
+        "@algolia/requester-common": "4.8.5"
+      }
+    },
+    "@algolia/requester-common": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.8.5.tgz",
+      "integrity": "sha512-OIhsdwIrJVAlVlP7cwlt+RoR5AmxAoTGrFokOY9imVmgqXUUljdKO/DjhRL8vwYGFEidZ9efIjAIQ2B3XOhT9A==",
+      "dev": true
+    },
+    "@algolia/requester-node-http": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.8.5.tgz",
+      "integrity": "sha512-viHAjfo53A3VSE7Bb/nzgpSMZ3prPp2qti7Wg8w7qxhntppKp3Fln6t4Vp+BoPOqruLsj139xXhheAKeRcYa0w==",
+      "dev": true,
+      "requires": {
+        "@algolia/requester-common": "4.8.5"
+      }
+    },
+    "@algolia/transporter": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.8.5.tgz",
+      "integrity": "sha512-Rb3cMlh/GoJK0+g+49GNA3IvR/EXsDEBwpyM+FOotSwxgiGt1wGBHM0K2v0GHwIEcuww02pl6KMDVlilA+qh0g==",
+      "dev": true,
+      "requires": {
+        "@algolia/cache-common": "4.8.5",
+        "@algolia/logger-common": "4.8.5",
+        "@algolia/requester-common": "4.8.5"
+      }
+    },
     "@apidevtools/json-schema-ref-parser": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.7.tgz",
@@ -488,6 +617,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "@bem-react/classname": {
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@bem-react/classname/-/classname-1.5.9.tgz",
+      "integrity": "sha512-I2uqyN+r1TdjSjOc7RiP8pmQVR1TBF0avIAXDHr7PcZVV828CXPFvoabkE+FTIFUnb2QjsgAXtvsGVsf/TU8SA==",
       "dev": true
     },
     "@cnakazawa/watch": {
@@ -1256,6 +1391,108 @@
         }
       }
     },
+    "@readme/ui": {
+      "version": "1.17.8",
+      "resolved": "https://registry.npmjs.org/@readme/ui/-/ui-1.17.8.tgz",
+      "integrity": "sha512-/Xu/qj18fRUgaVL/z8/jcQLvRM/Kf60G/hGCooA2nYXA9BL0ztLh7GG0Zr2D6kZyzSueJbkLFn2Glj2EUHIlMg==",
+      "dev": true,
+      "requires": {
+        "@bem-react/classname": "^1.5.7",
+        "@readme/emojis": "^3.0.0",
+        "@readme/oas-to-snippet": "^10.0.4",
+        "@readme/syntax-highlighter": "^10.4.1",
+        "@readme/variable": "^10.0.0",
+        "algoliasearch": "^4.1.0",
+        "clipboard-copy": "^3.1.0",
+        "emoji-regex": "^9.0.0",
+        "js-cookie": "^2.2.1",
+        "lodash": "^4.17.15",
+        "modularscale-sass": "^3.0.10",
+        "react-instantsearch-dom": "^6.4.0"
+      },
+      "dependencies": {
+        "@readme/emojis": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@readme/emojis/-/emojis-3.0.0.tgz",
+          "integrity": "sha512-qbuhp2lugNXl3evFqG7kd/+SMMMlm461dcr/vFputoU3S/fwY6W9J1HzFqsp2kH0otzKLS/6og/t3OxjLx7O0g==",
+          "dev": true
+        },
+        "@readme/oas-extensions": {
+          "version": "10.0.8",
+          "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-10.0.8.tgz",
+          "integrity": "sha512-XBfLLUcPAoylw5xzan6viodcvn56W7ReTD1ZQxVfMgM8b0kr2AN9jynw0gfB/JrpaF2CghdoSgWrsrPcUypkYQ==",
+          "dev": true
+        },
+        "@readme/oas-to-har": {
+          "version": "10.1.1",
+          "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-10.1.1.tgz",
+          "integrity": "sha512-b4VEQO+iqZN9GuTrn6wCxTJ5qoAdOWt6PrYasH1JpLAlup6hYEh4x4JxqMugZnaA7bl3qyuBKE+VmBhIoVLsNA==",
+          "dev": true,
+          "requires": {
+            "@readme/oas-extensions": "^10.0.8",
+            "oas": "^6.1.1",
+            "parse-data-url": "^3.0.0"
+          }
+        },
+        "@readme/oas-to-snippet": {
+          "version": "10.1.1",
+          "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-10.1.1.tgz",
+          "integrity": "sha512-DqKPROFvBPhnsfnBK5lN3mqNCLwlCKM+dsjwcJiW5SxJjX+tsFYNpFAxdHXOe4K6RQtvszKHWnDpnpQlQht5SA==",
+          "dev": true,
+          "requires": {
+            "@readme/httpsnippet": "^2.3.1",
+            "@readme/oas-extensions": "^10.0.8",
+            "@readme/oas-to-har": "^10.1.1",
+            "@readme/syntax-highlighter": "^10.4.1",
+            "httpsnippet-client-api": "^2.5.0",
+            "oas": "^6.1.1"
+          }
+        },
+        "@readme/variable": {
+          "version": "10.0.9",
+          "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-10.0.9.tgz",
+          "integrity": "sha512-yRzAMeA+kjdSD+OXQpvyXWDcvBRjLfj7VSOduMF7pPgDU2xus/DoTd9CJMPvcbC6pAJhmbuPbrMBzIbtZz1mvA==",
+          "dev": true,
+          "requires": {
+            "classnames": "^2.2.6",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "emoji-regex": {
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.1.tgz",
+          "integrity": "sha512-117l1H6U4X3Krn+MrzYrL57d5H7siRHWraBs7s+LjRuFK7Fe7hJqnJ0skWlinqsycVLU5YAo6L8CsEYQ0V5prg==",
+          "dev": true
+        },
+        "oas": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/oas/-/oas-6.1.1.tgz",
+          "integrity": "sha512-qGiouvgeRa00gFW4EjkOke2ZvTZD/4Z/ElUBgTLO3hxim+bOtY3uElGSZjemZHgTmRSefE3j2WBb9xSZ0XebLQ==",
+          "dev": true,
+          "requires": {
+            "@apidevtools/json-schema-ref-parser": "^9.0.6",
+            "cardinal": "^2.1.1",
+            "colors": "^1.1.2",
+            "figures": "^3.0.0",
+            "glob": "^7.1.2",
+            "inquirer": "^7.0.1",
+            "json-schema-merge-allof": "^0.7.0",
+            "json2yaml": "^1.1.0",
+            "jsonfile": "^6.0.0",
+            "jsonpointer": "^4.1.0",
+            "lodash": "^4.17.11",
+            "lodash.kebabcase": "^4.1.1",
+            "minimist": "^1.2.0",
+            "node-status": "^1.0.0",
+            "oas-normalize": "2.3.1",
+            "open": "^7.0.0",
+            "path-to-regexp": "^6.2.0",
+            "request": "^2.88.0",
+            "swagger-inline": "3.2.2"
+          }
+        }
+      }
+    },
     "@readme/variable": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-12.0.0.tgz",
@@ -1788,6 +2025,37 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true
+    },
+    "algoliasearch": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.8.5.tgz",
+      "integrity": "sha512-GjKjpeevpePEJYinGokASNtIkl1t5EseNMlqDNAc+sXE8+iyyeqTyiJsN7bwlRG2BIremuslE/NlwdEfUuBLJw==",
+      "dev": true,
+      "requires": {
+        "@algolia/cache-browser-local-storage": "4.8.5",
+        "@algolia/cache-common": "4.8.5",
+        "@algolia/cache-in-memory": "4.8.5",
+        "@algolia/client-account": "4.8.5",
+        "@algolia/client-analytics": "4.8.5",
+        "@algolia/client-common": "4.8.5",
+        "@algolia/client-recommendation": "4.8.5",
+        "@algolia/client-search": "4.8.5",
+        "@algolia/logger-common": "4.8.5",
+        "@algolia/logger-console": "4.8.5",
+        "@algolia/requester-browser-xhr": "4.8.5",
+        "@algolia/requester-common": "4.8.5",
+        "@algolia/requester-node-http": "4.8.5",
+        "@algolia/transporter": "4.8.5"
+      }
+    },
+    "algoliasearch-helper": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.4.4.tgz",
+      "integrity": "sha512-OjyVLjykaYKCMxxRMZNiwLp8CS310E0qAeIY2NaublcmLAh8/SL19+zYHp7XCLtMem2ZXwl3ywMiA32O9jszuw==",
+      "dev": true,
+      "requires": {
+        "events": "^1.1.1"
+      }
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -2672,6 +2940,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
+    },
+    "clipboard-copy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-3.2.0.tgz",
+      "integrity": "sha512-vooFaGFL6ulEP1liiaWFBmmfuPm3cY3y7T9eB83ZTnYc/oFeAKsq3NcDrOkBC8XaauEE8zHQwI7k0+JSYiVQSQ==",
+      "dev": true
     },
     "cliui": {
       "version": "4.1.0",
@@ -4378,6 +4652,12 @@
         "stream-combiner": "^0.2.2",
         "through": "^2.3.8"
       }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -7896,6 +8176,12 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
+    "modularscale-sass": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/modularscale-sass/-/modularscale-sass-3.0.10.tgz",
+      "integrity": "sha512-ppbMfcXC+ESpqk1s8BfqsuY85DTAJdoPLxrYFohAUjg3r9eh2CBm2Wn7+JAh26DbRpAHynRt3a8ma2FOfk7JGA==",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -9115,6 +9401,38 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
+      "dev": true
+    },
+    "react-instantsearch-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.9.0.tgz",
+      "integrity": "sha512-xLNyF0mUBq7MaLQgmosBnxac7YnLTuanu5TKZkH7RFEVC2T5mi4fINtG6vAkOkVjiH90abv2wdPY6UjE/Vt6kQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "algoliasearch-helper": "^3.1.0",
+        "prop-types": "^15.6.2",
+        "react-fast-compare": "^3.0.0"
+      }
+    },
+    "react-instantsearch-dom": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.9.0.tgz",
+      "integrity": "sha512-G8jSIC5QutdiK6QhZwyLcIONg2C6/6wRMkAM6uZ5ObSDvY+h/PkSohc8//A7LNOyedOCACd/UfdWlmexSYjl6Q==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "algoliasearch-helper": "^3.1.0",
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.2",
+        "react-fast-compare": "^3.0.0",
+        "react-instantsearch-core": "^6.9.0"
       }
     },
     "react-is": {

--- a/packages/api-explorer/package-lock.json
+++ b/packages/api-explorer/package-lock.json
@@ -4,135 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@algolia/cache-browser-local-storage": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.8.5.tgz",
-      "integrity": "sha512-9rs/Yi82ilgifweJamOy4DlJ4xPGsCN/zg+RKy4vjytNhOrkEHLRQC8vPZ3OhD8KVlw9lRQIZTlgjgFl8iMeeA==",
-      "dev": true,
-      "requires": {
-        "@algolia/cache-common": "4.8.5"
-      }
-    },
-    "@algolia/cache-common": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.8.5.tgz",
-      "integrity": "sha512-4SvRWnagKtwBFAy8Rsfmv0/Uk53fZL+6dy2idwdx6SjMGKSs0y1Qv+thb4h/k/H5MONisAoT9C2rgZ/mqwh5yw==",
-      "dev": true
-    },
-    "@algolia/cache-in-memory": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.8.5.tgz",
-      "integrity": "sha512-XBBfqs28FbjwLboY3sxvuzBgYsuXdFsj2mUvkgxfb0GVEzwW4I0NM7KzSPwT+iht55WS1PgIOnynjmhPsrubCw==",
-      "dev": true,
-      "requires": {
-        "@algolia/cache-common": "4.8.5"
-      }
-    },
-    "@algolia/client-account": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.8.5.tgz",
-      "integrity": "sha512-DjXMpeCdY4J4IDBfowiG6Xl9ec/FhG1NpPQM0Uv4xXsc/TeeZ1JgbgNDhWe9jW0jBEALy+a/RmPrZ0vsxcadsg==",
-      "dev": true,
-      "requires": {
-        "@algolia/client-common": "4.8.5",
-        "@algolia/client-search": "4.8.5",
-        "@algolia/transporter": "4.8.5"
-      }
-    },
-    "@algolia/client-analytics": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.8.5.tgz",
-      "integrity": "sha512-PQEY+chbHmZnRJdaWsvUYzDpEPr60az0EPUexdouvXGZId15/SnDaXjnf89F7tYmCzkHdUtG4bSvPzAupQ4AFA==",
-      "dev": true,
-      "requires": {
-        "@algolia/client-common": "4.8.5",
-        "@algolia/client-search": "4.8.5",
-        "@algolia/requester-common": "4.8.5",
-        "@algolia/transporter": "4.8.5"
-      }
-    },
-    "@algolia/client-common": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.8.5.tgz",
-      "integrity": "sha512-Dn8vog2VrGsJeOcBMcSAEIjBtPyogzUBGlh1DtVd0m8GN6q+cImCESl6DY846M2PTYWsLBKBksq37eUfSe9FxQ==",
-      "dev": true,
-      "requires": {
-        "@algolia/requester-common": "4.8.5",
-        "@algolia/transporter": "4.8.5"
-      }
-    },
-    "@algolia/client-recommendation": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-recommendation/-/client-recommendation-4.8.5.tgz",
-      "integrity": "sha512-ffawCC1C25rCa8/JU2niRZgwr8aV9b2qsLVMo73GXFzi2lceXPAe9K68mt/BGHU+w7PFUwVHsV2VmB+G/HQRVw==",
-      "dev": true,
-      "requires": {
-        "@algolia/client-common": "4.8.5",
-        "@algolia/requester-common": "4.8.5",
-        "@algolia/transporter": "4.8.5"
-      }
-    },
-    "@algolia/client-search": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.8.5.tgz",
-      "integrity": "sha512-Ru2MljGZWrSQ0CVsDla11oGEPL/RinmVkLJfBtQ+/pk1868VfpAQFGKtOS/b8/xLrMA0Vm4EfC3Mgclk/p3KJA==",
-      "dev": true,
-      "requires": {
-        "@algolia/client-common": "4.8.5",
-        "@algolia/requester-common": "4.8.5",
-        "@algolia/transporter": "4.8.5"
-      }
-    },
-    "@algolia/logger-common": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.8.5.tgz",
-      "integrity": "sha512-PS6NS6bpED0rAxgCPGhjZJg9why0PnoVEE7ZoCbPq6lsAOc6FPlQLri4OiLyU7wx8RWDoVtOadyzulqAAsfPSQ==",
-      "dev": true
-    },
-    "@algolia/logger-console": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.8.5.tgz",
-      "integrity": "sha512-3+4gLSbwzuGmrb5go3IZNcFIYVMSbB4c8UMtWEJ/gDBtgGZIvT6f/KlvVSOHIhthSxaM3Y13V6Qile/SpGqc6A==",
-      "dev": true,
-      "requires": {
-        "@algolia/logger-common": "4.8.5"
-      }
-    },
-    "@algolia/requester-browser-xhr": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.8.5.tgz",
-      "integrity": "sha512-M/Gf2vv/fU4+CqDW+wok7HPpEcLym3NtDzU9zaPzGYI/9X7o36581oyfnzt2pNfsXSQVj5a2pZVUWC3Z4SO27w==",
-      "dev": true,
-      "requires": {
-        "@algolia/requester-common": "4.8.5"
-      }
-    },
-    "@algolia/requester-common": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.8.5.tgz",
-      "integrity": "sha512-OIhsdwIrJVAlVlP7cwlt+RoR5AmxAoTGrFokOY9imVmgqXUUljdKO/DjhRL8vwYGFEidZ9efIjAIQ2B3XOhT9A==",
-      "dev": true
-    },
-    "@algolia/requester-node-http": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.8.5.tgz",
-      "integrity": "sha512-viHAjfo53A3VSE7Bb/nzgpSMZ3prPp2qti7Wg8w7qxhntppKp3Fln6t4Vp+BoPOqruLsj139xXhheAKeRcYa0w==",
-      "dev": true,
-      "requires": {
-        "@algolia/requester-common": "4.8.5"
-      }
-    },
-    "@algolia/transporter": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.8.5.tgz",
-      "integrity": "sha512-Rb3cMlh/GoJK0+g+49GNA3IvR/EXsDEBwpyM+FOotSwxgiGt1wGBHM0K2v0GHwIEcuww02pl6KMDVlilA+qh0g==",
-      "dev": true,
-      "requires": {
-        "@algolia/cache-common": "4.8.5",
-        "@algolia/logger-common": "4.8.5",
-        "@algolia/requester-common": "4.8.5"
-      }
-    },
     "@apidevtools/json-schema-ref-parser": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.7.tgz",
@@ -539,9 +410,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.13.tgz",
-      "integrity": "sha512-BPjEhhHe12QsV4k2iRNvP95yB1Gpjj6/NMmVP++5Yw295Se/ZVXPePV8cC5cZ6nrZBmmsQ9n0JmeUobM8TbskA==",
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.18.tgz",
+      "integrity": "sha512-1wlWco+J/wbzdblk2oxThE7PhN8hZDK9fFnEG77Z1TJ+1dwt7UJ5soH5JPqrBTazlVTXTIwCcFGXsH/7m9WdYQ==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -617,12 +488,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true
-    },
-    "@bem-react/classname": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/@bem-react/classname/-/classname-1.5.9.tgz",
-      "integrity": "sha512-I2uqyN+r1TdjSjOc7RiP8pmQVR1TBF0avIAXDHr7PcZVV828CXPFvoabkE+FTIFUnb2QjsgAXtvsGVsf/TU8SA==",
       "dev": true
     },
     "@cnakazawa/watch": {
@@ -1265,14 +1130,14 @@
       "dev": true
     },
     "@readme/oas-extensions": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-11.0.0.tgz",
-      "integrity": "sha512-klQNY548hCRPbcfufO62xXC3JDbpeMkbT+6FCOHz+9pF0AlAAGQLxbPtjYKRNJ5w9UG1kBgdBq4F9TusqDmrHQ=="
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-12.0.0.tgz",
+      "integrity": "sha512-gBCJFep7WqiI+jDj0dKdxAjvJxIDu3aZON0OMneuETB5dMjKPoKzuOk/KzY6rIZ5AOlbCJn8VIBdKDlsLho1Jg=="
     },
     "@readme/oas-form": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-form/-/oas-form-11.2.0.tgz",
-      "integrity": "sha512-iONhc9Yq9a1v/uA3rVvMon6AjUBT52mPSOi6gLTNXjyrXo03ByX0p1mLMOcoU2wMdE3FWXSmSEuWvape39jqtw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-form/-/oas-form-12.0.0.tgz",
+      "integrity": "sha512-R6fdO9qwWP2MtUZAtFnJQuDGz0IIHBDO5Kpz9q88Vp/oU19a63lwuSE4BsEI/GqL0s6sCIwv59OVC3L/uIWnpw==",
       "requires": {
         "@babel/runtime-corejs2": "^7.4.5",
         "ajv": "^6.7.0",
@@ -1318,26 +1183,26 @@
       }
     },
     "@readme/oas-to-har": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-11.2.0.tgz",
-      "integrity": "sha512-rNsa/nUDrNo+mxTe+9pz+eehGyh8flV5JYcb+UlYomjzG6Wtnd0ZcxxD8mRosOJHRJR4jLNcDgTEtun/96VjBg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-12.0.0.tgz",
+      "integrity": "sha512-Ty3Tx8KBzgWMhUaTmbsfiItZq49+sl96vqca6LV8ohMTdVnwNvYAmj1WPb+if32ykuziARwdD8CqZgGXknWbZA==",
       "requires": {
-        "@readme/oas-extensions": "^11.0.0",
-        "oas": "^10.0.4",
+        "@readme/oas-extensions": "^12.0.0",
+        "oas": "^10.1.1",
         "parse-data-url": "^3.0.0"
       }
     },
     "@readme/oas-to-snippet": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-11.2.2.tgz",
-      "integrity": "sha512-qeyofXmE/UbafmOA/+e/cEvfXsQfGjjjDMBnuQMTcRNG4V1F7Vh/lteKflOzFkRdmedcox+pAqnVoJ6pO0cM/w==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-12.0.0.tgz",
+      "integrity": "sha512-pjbFfXkgi3Z9OH/fSQu02SZkyegZQNe5q/GKBKxq0GfeIvyv1Po6Pcg6HNFwZ7vCE8YlSOTx+aR7Bs42sVBGWA==",
       "requires": {
         "@readme/httpsnippet": "^2.4.3",
-        "@readme/oas-extensions": "^11.0.0",
-        "@readme/oas-to-har": "^11.2.0",
+        "@readme/oas-extensions": "^12.0.0",
+        "@readme/oas-to-har": "^12.0.0",
         "@readme/syntax-highlighter": "^10.4.1",
         "httpsnippet-client-api": "^2.7.0",
-        "oas": "^10.0.4"
+        "oas": "^10.1.1"
       },
       "dependencies": {
         "@readme/httpsnippet": {
@@ -1391,112 +1256,10 @@
         }
       }
     },
-    "@readme/ui": {
-      "version": "1.17.8",
-      "resolved": "https://registry.npmjs.org/@readme/ui/-/ui-1.17.8.tgz",
-      "integrity": "sha512-/Xu/qj18fRUgaVL/z8/jcQLvRM/Kf60G/hGCooA2nYXA9BL0ztLh7GG0Zr2D6kZyzSueJbkLFn2Glj2EUHIlMg==",
-      "dev": true,
-      "requires": {
-        "@bem-react/classname": "^1.5.7",
-        "@readme/emojis": "^3.0.0",
-        "@readme/oas-to-snippet": "^10.0.4",
-        "@readme/syntax-highlighter": "^10.4.1",
-        "@readme/variable": "^10.0.0",
-        "algoliasearch": "^4.1.0",
-        "clipboard-copy": "^3.1.0",
-        "emoji-regex": "^9.0.0",
-        "js-cookie": "^2.2.1",
-        "lodash": "^4.17.15",
-        "modularscale-sass": "^3.0.10",
-        "react-instantsearch-dom": "^6.4.0"
-      },
-      "dependencies": {
-        "@readme/emojis": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@readme/emojis/-/emojis-3.0.0.tgz",
-          "integrity": "sha512-qbuhp2lugNXl3evFqG7kd/+SMMMlm461dcr/vFputoU3S/fwY6W9J1HzFqsp2kH0otzKLS/6og/t3OxjLx7O0g==",
-          "dev": true
-        },
-        "@readme/oas-extensions": {
-          "version": "10.0.8",
-          "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-10.0.8.tgz",
-          "integrity": "sha512-XBfLLUcPAoylw5xzan6viodcvn56W7ReTD1ZQxVfMgM8b0kr2AN9jynw0gfB/JrpaF2CghdoSgWrsrPcUypkYQ==",
-          "dev": true
-        },
-        "@readme/oas-to-har": {
-          "version": "10.1.1",
-          "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-10.1.1.tgz",
-          "integrity": "sha512-b4VEQO+iqZN9GuTrn6wCxTJ5qoAdOWt6PrYasH1JpLAlup6hYEh4x4JxqMugZnaA7bl3qyuBKE+VmBhIoVLsNA==",
-          "dev": true,
-          "requires": {
-            "@readme/oas-extensions": "^10.0.8",
-            "oas": "^6.1.1",
-            "parse-data-url": "^3.0.0"
-          }
-        },
-        "@readme/oas-to-snippet": {
-          "version": "10.1.1",
-          "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-10.1.1.tgz",
-          "integrity": "sha512-DqKPROFvBPhnsfnBK5lN3mqNCLwlCKM+dsjwcJiW5SxJjX+tsFYNpFAxdHXOe4K6RQtvszKHWnDpnpQlQht5SA==",
-          "dev": true,
-          "requires": {
-            "@readme/httpsnippet": "^2.3.1",
-            "@readme/oas-extensions": "^10.0.8",
-            "@readme/oas-to-har": "^10.1.1",
-            "@readme/syntax-highlighter": "^10.4.1",
-            "httpsnippet-client-api": "^2.5.0",
-            "oas": "^6.1.1"
-          }
-        },
-        "@readme/variable": {
-          "version": "10.0.9",
-          "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-10.0.9.tgz",
-          "integrity": "sha512-yRzAMeA+kjdSD+OXQpvyXWDcvBRjLfj7VSOduMF7pPgDU2xus/DoTd9CJMPvcbC6pAJhmbuPbrMBzIbtZz1mvA==",
-          "dev": true,
-          "requires": {
-            "classnames": "^2.2.6",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "emoji-regex": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.1.tgz",
-          "integrity": "sha512-117l1H6U4X3Krn+MrzYrL57d5H7siRHWraBs7s+LjRuFK7Fe7hJqnJ0skWlinqsycVLU5YAo6L8CsEYQ0V5prg==",
-          "dev": true
-        },
-        "oas": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/oas/-/oas-6.1.1.tgz",
-          "integrity": "sha512-qGiouvgeRa00gFW4EjkOke2ZvTZD/4Z/ElUBgTLO3hxim+bOtY3uElGSZjemZHgTmRSefE3j2WBb9xSZ0XebLQ==",
-          "dev": true,
-          "requires": {
-            "@apidevtools/json-schema-ref-parser": "^9.0.6",
-            "cardinal": "^2.1.1",
-            "colors": "^1.1.2",
-            "figures": "^3.0.0",
-            "glob": "^7.1.2",
-            "inquirer": "^7.0.1",
-            "json-schema-merge-allof": "^0.7.0",
-            "json2yaml": "^1.1.0",
-            "jsonfile": "^6.0.0",
-            "jsonpointer": "^4.1.0",
-            "lodash": "^4.17.11",
-            "lodash.kebabcase": "^4.1.1",
-            "minimist": "^1.2.0",
-            "node-status": "^1.0.0",
-            "oas-normalize": "2.3.1",
-            "open": "^7.0.0",
-            "path-to-regexp": "^6.2.0",
-            "request": "^2.88.0",
-            "swagger-inline": "3.2.2"
-          }
-        }
-      }
-    },
     "@readme/variable": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-11.0.0.tgz",
-      "integrity": "sha512-J6gIW/UeH7GD5j4agykjhiWDlsndQS/6NBix3A0FF69ho3RKeiYUnXJ1RJQbeOkPE8a+iFIRKCZWaefR0E8N8A==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-12.0.0.tgz",
+      "integrity": "sha512-enjjazM+viUGyrDFQrAkm8WingNreMZHZJEwNlxBtPyYUs7u7+/JV+sj8p7qkeD6mTJmJ537MHtbYfqY7d7BrA==",
       "dev": true,
       "requires": {
         "classnames": "^2.2.6",
@@ -2025,37 +1788,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true
-    },
-    "algoliasearch": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.8.5.tgz",
-      "integrity": "sha512-GjKjpeevpePEJYinGokASNtIkl1t5EseNMlqDNAc+sXE8+iyyeqTyiJsN7bwlRG2BIremuslE/NlwdEfUuBLJw==",
-      "dev": true,
-      "requires": {
-        "@algolia/cache-browser-local-storage": "4.8.5",
-        "@algolia/cache-common": "4.8.5",
-        "@algolia/cache-in-memory": "4.8.5",
-        "@algolia/client-account": "4.8.5",
-        "@algolia/client-analytics": "4.8.5",
-        "@algolia/client-common": "4.8.5",
-        "@algolia/client-recommendation": "4.8.5",
-        "@algolia/client-search": "4.8.5",
-        "@algolia/logger-common": "4.8.5",
-        "@algolia/logger-console": "4.8.5",
-        "@algolia/requester-browser-xhr": "4.8.5",
-        "@algolia/requester-common": "4.8.5",
-        "@algolia/requester-node-http": "4.8.5",
-        "@algolia/transporter": "4.8.5"
-      }
-    },
-    "algoliasearch-helper": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.4.2.tgz",
-      "integrity": "sha512-xuNY+xfyMmrTyD6c8vdYdsBkWqsFGmBM/uxZs4lWgjWxeNb2Jsi2ZaMR51aBn4DeCK4NRdp4LOLvdFEOCoeBkQ==",
-      "dev": true,
-      "requires": {
-        "events": "^1.1.1"
-      }
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -2940,12 +2672,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
-    },
-    "clipboard-copy": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-3.2.0.tgz",
-      "integrity": "sha512-vooFaGFL6ulEP1liiaWFBmmfuPm3cY3y7T9eB83ZTnYc/oFeAKsq3NcDrOkBC8XaauEE8zHQwI7k0+JSYiVQSQ==",
-      "dev": true
     },
     "cliui": {
       "version": "4.1.0",
@@ -4652,12 +4378,6 @@
         "stream-combiner": "^0.2.2",
         "through": "^2.3.8"
       }
-    },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -8176,12 +7896,6 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
-    "modularscale-sass": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/modularscale-sass/-/modularscale-sass-3.0.10.tgz",
-      "integrity": "sha512-ppbMfcXC+ESpqk1s8BfqsuY85DTAJdoPLxrYFohAUjg3r9eh2CBm2Wn7+JAh26DbRpAHynRt3a8ma2FOfk7JGA==",
-      "dev": true
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -9401,38 +9115,6 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
-      }
-    },
-    "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
-      "dev": true
-    },
-    "react-instantsearch-core": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.9.0.tgz",
-      "integrity": "sha512-xLNyF0mUBq7MaLQgmosBnxac7YnLTuanu5TKZkH7RFEVC2T5mi4fINtG6vAkOkVjiH90abv2wdPY6UjE/Vt6kQ==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "^3.1.0",
-        "prop-types": "^15.6.2",
-        "react-fast-compare": "^3.0.0"
-      }
-    },
-    "react-instantsearch-dom": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.9.0.tgz",
-      "integrity": "sha512-G8jSIC5QutdiK6QhZwyLcIONg2C6/6wRMkAM6uZ5ObSDvY+h/PkSohc8//A7LNOyedOCACd/UfdWlmexSYjl6Q==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "^3.1.0",
-        "classnames": "^2.2.5",
-        "prop-types": "^15.6.2",
-        "react-fast-compare": "^3.0.0",
-        "react-instantsearch-core": "^6.9.0"
       }
     },
     "react-is": {

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -49,6 +49,7 @@
     "@readme/eslint-config": "^4.0.0",
     "@readme/markdown": "^6.21.0",
     "@readme/oas-examples": "^4.0.0",
+    "@readme/ui": "^1.17.8",
     "@readme/variable": "^12.0.0",
     "@testing-library/react": "^11.2.2",
     "css-loader": "^4.3.0",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -41,7 +41,6 @@
   },
   "peerDependencies": {
     "@readme/markdown": "^6.21.0",
-    "@readme/ui": "^1.17.0",
     "@readme/variable": "^11.0.0",
     "react": "16.x",
     "react-dom": "16.x"
@@ -50,7 +49,6 @@
     "@readme/eslint-config": "^4.0.0",
     "@readme/markdown": "^6.21.0",
     "@readme/oas-examples": "^4.0.0",
-    "@readme/ui": "^1.17.6",
     "@readme/variable": "^12.0.0",
     "@testing-library/react": "^11.2.2",
     "css-loader": "^4.3.0",

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -9,8 +9,6 @@ const oasToHar = require('@readme/oas-to-har');
 const Oas = require('oas/tooling');
 const { getPath, matchesMimeType } = require('oas/tooling/utils');
 
-const { TutorialTile } = require('@readme/ui/.bundles/es/ui/compositions');
-
 const isAuthReady = require('./lib/is-auth-ready');
 
 const PathUrl = require('./PathUrl');
@@ -482,6 +480,7 @@ class Doc extends React.Component {
         onSubmit={this.onSubmit}
         operation={this.getOperation()}
         resetForm={this.resetForm}
+        ui={this.props.ui}
         validationErrors={validationErrors}
       />
     );
@@ -513,6 +512,7 @@ class Doc extends React.Component {
 
   render() {
     const { doc, lazy, oas, useNewMarkdownEngine } = this.props;
+    const { TutorialTile } = this.props.ui.tutorials;
 
     const renderEndpoint = () => {
       if (this.props.appearance.splitReferenceDocs) return this.renderEndpoint();
@@ -631,6 +631,16 @@ Doc.propTypes = {
   setLanguage: PropTypes.func.isRequired,
   suggestedEdits: PropTypes.bool.isRequired,
   tryItMetrics: PropTypes.func.isRequired,
+  ui: PropTypes.shape({
+    Button: PropTypes.func,
+    Tabs: PropTypes.func,
+    tutorials: PropTypes.shape({
+      DEFAULT_TUTORIAL: PropTypes.object,
+      TutorialModal: PropTypes.func,
+      TutorialTile: PropTypes.func,
+      TutorialVariableContext: PropTypes.object,
+    }),
+  }),
   useNewMarkdownEngine: PropTypes.bool,
   user: PropTypes.shape({}),
 };
@@ -654,6 +664,16 @@ Doc.defaultProps = {
   onDereferenceCompletion: () => {},
   onError: () => {},
   openTutorialModal: () => {},
+  ui: {
+    Button: () => {},
+    Tabs: () => {},
+    tutorials: {
+      DEFAULT_TUTORIAL: {},
+      TutorialModal: () => {},
+      TutorialTile: () => {},
+      TutorialVariableContext: {},
+    },
+  },
   useNewMarkdownEngine: false,
   user: {},
 };

--- a/packages/api-explorer/src/Params.jsx
+++ b/packages/api-explorer/src/Params.jsx
@@ -5,7 +5,6 @@ const extensions = require('@readme/oas-extensions');
 const Oas = require('oas/tooling');
 
 const { PasswordWidget, TextWidget, UpDownWidget } = require('@readme/oas-form/src/components/widgets').default;
-const { Button, Tabs } = require('@readme/ui/.bundles/es/ui/components');
 
 const createArrayField = require('./form-components/ArrayField');
 const createBaseInput = require('./form-components/BaseInput');
@@ -123,6 +122,7 @@ class Params extends React.Component {
 
   render() {
     const { CodeEditor, enableJsonEditor, formDataJsonRaw, onJsonChange, resetForm, validationErrors } = this.props;
+    const { Button, Tabs } = this.props.ui;
 
     return (
       <div
@@ -199,6 +199,10 @@ Params.propTypes = {
   SchemaField: PropTypes.func.isRequired,
   SelectWidget: PropTypes.func.isRequired,
   TextareaWidget: PropTypes.func.isRequired,
+  ui: PropTypes.shape({
+    Button: PropTypes.func,
+    Tabs: PropTypes.func,
+  }),
   URLWidget: PropTypes.func.isRequired,
   useNewMarkdownEngine: PropTypes.bool,
   validationErrors: PropTypes.shape({
@@ -211,6 +215,10 @@ Params.defaultProps = {
   enableJsonEditor: false,
   formData: {},
   formDataJsonRaw: '{}',
+  ui: {
+    Button: () => {},
+    Tabs: () => {},
+  },
   useNewMarkdownEngine: false,
   validationErrors: {
     form: false,

--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -7,15 +7,12 @@ const Oas = require('oas/tooling');
 
 const OauthContext = require('@readme/variable/contexts/Oauth');
 const SelectedAppContext = require('@readme/variable/contexts/SelectedApp');
-const { cmVariableContext: TutorialVariableContext } = require('@readme/ui/.bundles/es/views');
 
 const ErrorBoundary = require('./ErrorBoundary');
 const Doc = require('./Doc');
 const DocAsync = require('./DocAsync');
-const { TutorialModal } = require('@readme/ui/.bundles/es/ui/compositions');
 
 const getAuth = require('./lib/get-auth');
-const { DEFAULT_TUTORIAL } = require('@readme/ui/.bundles/es/ui/compositions/Tutorials/Modal/constants/stepDefaults');
 
 const supportedHttpMethods = ['connect', 'delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'trace'];
 
@@ -41,7 +38,7 @@ class ApiExplorer extends React.Component {
         selected: '',
         changeSelected: this.changeSelected,
       },
-      selectedTutorial: DEFAULT_TUTORIAL,
+      selectedTutorial: this.props.ui.tutorials.DEFAULT_TUTORIAL,
       showTutorialModal: false,
     };
 
@@ -240,11 +237,14 @@ class ApiExplorer extends React.Component {
   }
 
   closeTutorialModal() {
+    const { DEFAULT_TUTORIAL } = this.props.ui.tutorials;
+
     this.setState(() => ({ showTutorialModal: false, selectedTutorial: DEFAULT_TUTORIAL }));
   }
 
   renderTutorialModal() {
     const { selectedTutorial, showTutorialModal } = this.state;
+    const { TutorialModal } = this.props.ui.tutorials;
 
     return (
       <TutorialModal
@@ -260,6 +260,8 @@ class ApiExplorer extends React.Component {
   }
 
   render() {
+    const { TutorialVariableContext } = this.props.ui.tutorials;
+
     const docs = this.props.docs.filter(doc => {
       // If the HTTP method is something we don't support, then we shouldn't attempt to render it as a normal API
       // operation.
@@ -334,6 +336,7 @@ class ApiExplorer extends React.Component {
                                 setLanguage={this.setLanguage}
                                 suggestedEdits={this.props.suggestedEdits}
                                 tryItMetrics={this.props.tryItMetrics}
+                                ui={this.props.ui}
                                 useNewMarkdownEngine={this.props.useNewMarkdownEngine}
                                 user={this.props.variables.user}
                               />
@@ -383,6 +386,16 @@ ApiExplorer.propTypes = {
   shouldDereferenceOas: PropTypes.bool,
   suggestedEdits: PropTypes.bool.isRequired,
   tryItMetrics: PropTypes.func,
+  ui: PropTypes.shape({
+    Button: PropTypes.func,
+    Tabs: PropTypes.func,
+    tutorials: PropTypes.shape({
+      DEFAULT_TUTORIAL: PropTypes.object,
+      TutorialModal: PropTypes.func,
+      TutorialTile: PropTypes.func,
+      TutorialVariableContext: PropTypes.object,
+    }),
+  }),
   useNewMarkdownEngine: PropTypes.bool,
   variables: PropTypes.shape({
     defaults: PropTypes.arrayOf(
@@ -413,6 +426,16 @@ ApiExplorer.defaultProps = {
   onError: () => {},
   shouldDereferenceOas: true,
   tryItMetrics: () => {},
+  ui: {
+    Button: () => {},
+    Tabs: () => {},
+    tutorials: {
+      DEFAULT_TUTORIAL: {},
+      TutorialModal: () => {},
+      TutorialTile: () => {},
+      TutorialVariableContext: {},
+    },
+  },
   useNewMarkdownEngine: false,
 };
 


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

Last month we deprecated `@readme/ui`, but unfortunately our API Explorer still ships with it. This work fully decouples that library from this codebase, which'll allow to keep the components that we use here up to date with while also allowing us to shave a nice chunk off the bundle size.

Now when we instantiate the `APIExplorer` component in ReadMe we'll need to pass it a `ui` prop containing the following:

```js
{
  // @readme/ui/.bundles/es/ui/components/Button
  Button, 

  // @readme/ui/.bundles/es/ui/components/Tabs
  Tabs,

  tutorials: {
    // @readme/ui/.bundles/es/ui/compositions/Tutorials/Modal/constants/stepDefaults.DEFAULT_TUTORIAL
    DEFAULT_TUTORIAL, 
    
    // @readme/ui/.bundles/es/ui/compositions/TutorialModal
    TutorialModal,
    
    // @readme/ui/.bundles/es/ui/compositions/TutorialTile
    TutorialTile, 

    // @readme/ui/.bundles/es/views/cmVariableContext
    TutorialVariableContext 
  }
}
```

However since we still have unit tests that need to do determinations based on these components, and https://preview.readme.io still has to work `@readme/ui` will remain as a dev dependency here -- it just won't be shipped with our bundle.

## 🧹 Bundle size changes

> The file sizes here are what Webpack outputs to the console when running `npm run build`. They do not take gzipping into account.

| Branch | `@readme/api-explorer` |
| :--- | :--- |
| Before (`next`) | 2.65 MiB |
| After  | 2.24MiB |

## 🧬 Testing

* [ ] Does the JSON editor still work?
* [ ] Do the recipe tiles and modals still work?

[demo]: https://explorer-pr-1193.herokuapp.com/
