### PR TITLE
fix(oas-to-har): fix validation failures when using multiple json formats

### DIFF
--- a/packages/oas-to-har/__tests__/index.test.js
+++ b/packages/oas-to-har/__tests__/index.test.js
@@ -1153,6 +1153,72 @@ describe('requestBody', () => {
         ).toBe(JSON.stringify({ a: JSON.parse('{ "b": "valid json" }') }));
       });
 
+      it('should parse one valid JSON format even if another is invalid', () => {
+        expect(
+          oasToHar(
+            oas,
+            {
+              path: '/body',
+              method: 'post',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      required: ['a'],
+                      properties: {
+                        a: {
+                          type: 'string',
+                          format: 'json',
+                        },
+                        b: {
+                          type: 'string',
+                          format: 'json',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            { body: { a: '{ "z": "valid json" }', b: 'invalid json' } }
+          ).log.entries[0].request.postData.text
+        ).toBe(JSON.stringify({ a: { z: 'valid json' }, b: 'invalid json' }));
+      });
+
+      it('should parse one valid JSON format even if another is left empty', () => {
+        expect(
+          oasToHar(
+            oas,
+            {
+              path: '/body',
+              method: 'post',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      required: ['a'],
+                      properties: {
+                        a: {
+                          type: 'string',
+                          format: 'json',
+                        },
+                        b: {
+                          type: 'string',
+                          format: 'json',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            { body: { a: '{ "z": "valid json" }', b: undefined } }
+          ).log.entries[0].request.postData.text
+        ).toBe(JSON.stringify({ a: { z: 'valid json' }, b: undefined }));
+      });
+
       it('should leave user specified empty object JSON alone', () => {
         expect(
           oasToHar(

--- a/packages/oas-to-har/src/index.js
+++ b/packages/oas-to-har/src/index.js
@@ -316,7 +316,7 @@ module.exports = (
                   try {
                     cleanBody[prop] = JSON.parse(cleanBody[prop]);
                   } catch (e) {
-                    // console.log('leave the prop as a string value')
+                    // leave the prop as a string value
                   }
                 });
 

--- a/packages/oas-to-har/src/index.js
+++ b/packages/oas-to-har/src/index.js
@@ -305,16 +305,19 @@ module.exports = (
 
             // Find all `{ type: string, format: json }` properties in the schema because we need to manually JSON.parse
             // them before submit, otherwise they'll be escaped instead of actual objects.
+            // We also only want values that the user has entered, so we drop any undefined cleanBody keys
             const jsonTypes = Object.keys(requestBody.schema.properties).filter(
-              key => requestBody.schema.properties[key].format === 'json'
+              key => requestBody.schema.properties[key].format === 'json' && cleanBody[key] !== undefined
             );
 
             if (jsonTypes.length) {
               try {
                 jsonTypes.forEach(prop => {
-                  // Attempt to parse each of the JSON properties, but if it fails for the data being invalid JSON,
-                  // instead we'll catch the exception and handle it as raw text.
-                  cleanBody[prop] = JSON.parse(cleanBody[prop]);
+                  try {
+                    cleanBody[prop] = JSON.parse(cleanBody[prop]);
+                  } catch (e) {
+                    // console.log('leave the prop as a string value')
+                  }
                 });
 
                 if (typeof cleanBody.RAW_BODY !== 'undefined') {


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

Our expected behavior with parameters set to `format=json` is that the resulting example is parsed into a JSON object. If it's valid JSON, it would appear as is in the example (`{"example": "code"}`). If invalid, it would show up as a string (`"{\"example\":\"code"`)

Before this PR, if you had two parameters in the same operation that were `format=json` and one was valid, but the other was not (or was left empty), neither parameter would be considered valid and they both would be turned into strings.

After this PR, any valid parameter should be properly formatted in the example.

## 🧬 Testing

Message me for a example OAS file, or find it in our internal ticketing, or create an OAS file with a single path, a single operation, and two parameters, each with `format=json`.

Test it in production by entering valid JSON in one field, and ignore the second field (or enter invalid JSON). The valid JSON should remain as a string.

Test it in this branch and the valid JSON should be turned into a JSON object, even if the second parameter is invalid.
