### PR TITLE
fix: enabling useObjectBody on js fetch snippets

### DIFF
--- a/packages/oas-to-snippet/src/supportedLanguages.js
+++ b/packages/oas-to-snippet/src/supportedLanguages.js
@@ -24,7 +24,7 @@ const supportedLanguages = {
     highlight: 'java',
   },
   javascript: {
-    httpsnippet: ['javascript', 'fetch'],
+    httpsnippet: ['javascript', 'fetch', { useObjectBody: true }],
     highlight: 'javascript',
   },
   kotlin: {
@@ -32,13 +32,7 @@ const supportedLanguages = {
     highlight: 'java',
   },
   node: {
-    httpsnippet: [
-      'node',
-      'fetch',
-      {
-        useObjectBody: true,
-      },
-    ],
+    httpsnippet: ['node', 'fetch', { useObjectBody: true }],
     highlight: 'javascript',
   },
   'node-simple': {


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

I did work in `@readme/httpsnippet` in https://github.com/readmeio/httpsnippet/pull/34 to extend the `useObjectBody` option we have for `node-fetch` snippets over to JS `fetch`, but failed to turn it on within `@readme/oas-to-snippet`.

## 🧬 Testing

https://preview.readme.io/

#### Before

![Screen Shot 2021-02-23 at 9 41 00 AM](https://user-images.githubusercontent.com/33762/108884291-43b1ec00-75bb-11eb-81e8-afc77a84711c.png)

#### After

![Screen Shot 2021-02-23 at 9 38 02 AM](https://user-images.githubusercontent.com/33762/108884223-3432a300-75bb-11eb-9a70-f46c5a2c6950.png)


[demo]: https://deployment_url
