### PR TITLE
fix(oas-to-har): clean up formatting of raw json bodies

### DIFF
--- a/packages/oas-to-har/__tests__/index.test.js
+++ b/packages/oas-to-har/__tests__/index.test.js
@@ -1124,6 +1124,30 @@ describe('requestBody', () => {
         ).toBe(JSON.stringify({ a: '{ "b": invalid json' }));
       });
 
+      // TODO: Why do I have to json encode the resulting string? website doesn't seem to need that....
+      it('should parse valid arbitrary JSON request bodies', () => {
+        expect(
+          oasToHar(
+            oas,
+            {
+              path: '/body',
+              method: 'post',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                      format: 'json',
+                    },
+                  },
+                },
+              },
+            },
+            { body: '{ "a": { "b": "valid json" } }' }
+          ).log.entries[0].request.postData.text
+        ).toBe('{"a":{"b":"valid json"}}');
+      });
+
       it('should parse valid JSON as an object', () => {
         expect(
           oasToHar(

--- a/packages/oas-to-har/src/index.js
+++ b/packages/oas-to-har/src/index.js
@@ -303,33 +303,43 @@ module.exports = (
           } else {
             har.postData.mimeType = contentType;
 
-            // Find all `{ type: string, format: json }` properties in the schema because we need to manually JSON.parse
-            // them before submit, otherwise they'll be escaped instead of actual objects.
-            // We also only want values that the user has entered, so we drop any undefined cleanBody keys
-            const jsonTypes = Object.keys(requestBody.schema.properties).filter(
-              key => requestBody.schema.properties[key].format === 'json' && cleanBody[key] !== undefined
-            );
+            // Handle arbitraty JSON input via a string.
+            // In OAS you usually find this in an application/json content type.
+            //   with a schema type=string, format=json.
+            // In the UI this is represented by an arbitrary text input
+            // This ensures we remove any newlines or tabs and use a clean json block in the example
+            if (requestBody.schema.type === 'string') {
+              har.postData.text = JSON.stringify(JSON.parse(cleanBody));
+            } else {
+              // Handle formatted JSON objects that have properties that accept arbitrary JSON
+              // Find all `{ type: string, format: json }` properties in the schema because we need to manually JSON.parse
+              // them before submit, otherwise they'll be escaped instead of actual objects.
+              // We also only want values that the user has entered, so we drop any undefined cleanBody keys
+              const jsonTypes = Object.keys(requestBody.schema.properties).filter(
+                key => requestBody.schema.properties[key].format === 'json' && cleanBody[key] !== undefined
+              );
 
-            if (jsonTypes.length) {
-              try {
-                jsonTypes.forEach(prop => {
-                  try {
-                    cleanBody[prop] = JSON.parse(cleanBody[prop]);
-                  } catch (e) {
-                    // leave the prop as a string value
+              if (jsonTypes.length) {
+                try {
+                  jsonTypes.forEach(prop => {
+                    try {
+                      cleanBody[prop] = JSON.parse(cleanBody[prop]);
+                    } catch (e) {
+                      // leave the prop as a string value
+                    }
+                  });
+
+                  if (typeof cleanBody.RAW_BODY !== 'undefined') {
+                    cleanBody = cleanBody.RAW_BODY;
                   }
-                });
 
-                if (typeof cleanBody.RAW_BODY !== 'undefined') {
-                  cleanBody = cleanBody.RAW_BODY;
+                  har.postData.text = JSON.stringify(cleanBody);
+                } catch (e) {
+                  har.postData.text = stringify(formData.body);
                 }
-
-                har.postData.text = JSON.stringify(cleanBody);
-              } catch (e) {
+              } else {
                 har.postData.text = stringify(formData.body);
               }
-            } else {
-              har.postData.text = stringify(formData.body);
             }
           }
         } catch (e) {

--- a/packages/oas-to-har/src/index.js
+++ b/packages/oas-to-har/src/index.js
@@ -303,7 +303,7 @@ module.exports = (
           } else {
             har.postData.mimeType = contentType;
 
-            // Handle arbitraty JSON input via a string.
+            // Handle arbitrary JSON input via a string.
             // In OAS you usually find this in an application/json content type.
             //   with a schema type=string, format=json.
             // In the UI this is represented by an arbitrary text input


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

When your request body has a type of `string` and format of `json`, the exact value was showing up as the user inputted string (with any included formatting (such as newlines)), passed through JSON.stringify .

e.g.

`--data='"{\n    \"foo\": \"bar\"\n}"'`

This changes that field to now appear as a JSON object passed thorugh JSON.stringify

e.g.
`--data='{"foo":"bar"}'`

## 🧬 Testing

Check the tests, or message me and I'll send you an example OAS file.