### PR TITLE
feat: allow periods in variable regex

### DIFF
--- a/packages/variable/__tests__/index.test.jsx
+++ b/packages/variable/__tests__/index.test.jsx
@@ -114,3 +114,31 @@ describe('multiple variables', () => {
 
   it.todo('should render auth dropdown if default and oauth enabled');
 });
+
+describe('variable with periods', () => {
+  const props = {
+    variable: 'api.key',
+    user: { 'api.key': '123456' },
+    defaults: [],
+    changeSelected: () => {},
+    selected: '',
+  };
+
+  it('should render value', () => {
+    const variable = shallow(<Variable {...props} />);
+
+    expect(variable.text()).toBe('123456');
+  });
+
+  it('should render default if value not set', () => {
+    const variable = shallow(<Variable {...props} defaults={[{ name: 'api.key', default: 'default' }]} user={{}} />);
+
+    expect(variable.text()).toBe('default');
+  });
+
+  it('should render uppercase if no value and no default', () => {
+    const variable = shallow(<Variable {...props} defaults={[]} user={{}} />);
+
+    expect(variable.text()).toBe('API.KEY');
+  });
+});

--- a/packages/variable/__tests__/index.test.jsx
+++ b/packages/variable/__tests__/index.test.jsx
@@ -1,7 +1,7 @@
 const React = require('react');
 const { shallow } = require('enzyme');
 
-const { Variable } = require('../index.jsx');
+const { Variable, VARIABLE_REGEXP } = require('../index.jsx');
 
 describe('single variable', () => {
   const props = {
@@ -115,30 +115,8 @@ describe('multiple variables', () => {
   it.todo('should render auth dropdown if default and oauth enabled');
 });
 
-describe('variable with periods', () => {
-  const props = {
-    variable: 'api.key',
-    user: { 'api.key': '123456' },
-    defaults: [],
-    changeSelected: () => {},
-    selected: '',
-  };
-
-  it('should render value', () => {
-    const variable = shallow(<Variable {...props} />);
-
-    expect(variable.text()).toBe('123456');
-  });
-
-  it('should render default if value not set', () => {
-    const variable = shallow(<Variable {...props} defaults={[{ name: 'api.key', default: 'default' }]} user={{}} />);
-
-    expect(variable.text()).toBe('default');
-  });
-
-  it('should render uppercase if no value and no default', () => {
-    const variable = shallow(<Variable {...props} defaults={[]} user={{}} />);
-
-    expect(variable.text()).toBe('API.KEY');
+describe('VARIABLE_REGEXP', () => {
+  it('should match against periods', () => {
+    expect('<<api.key>>').toMatch(new RegExp(VARIABLE_REGEXP));
   });
 });

--- a/packages/variable/index.jsx
+++ b/packages/variable/index.jsx
@@ -161,5 +161,5 @@ module.exports.Variable = Variable;
 // - \<<apiKey\>> - escaped variables
 // - <<apiKey>> - regular variables
 // - <<glossary:glossary items>> - glossary
-module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-\w:\s]+)(?:\\)?>>/.source;
+module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-\w:.\s]+)(?:\\)?>>/.source;
 module.exports.VariablesContext = VariablesContext;


### PR DESCRIPTION
| Fixes CX-166 |
| --- |

## 🧰 What's being changed?

Allows variables to contain periods `.`.

## 🧬 Testing

[Broken on prod](https://kjp.readme.io/docs/variables-with-periods)