### PR TITLE
feat: adding new extensions for code and response samples

### DIFF
--- a/packages/oas-extensions/__tests__/index.test.js
+++ b/packages/oas-extensions/__tests__/index.test.js
@@ -11,7 +11,7 @@ test.each([
   ['SAMPLES_ENABLED'],
   ['SAMPLES_LANGUAGES'],
   ['SEND_DEFAULTS'],
-])("`%s` extension should have a default value", (extension) => {
+])('`%s` extension should have a default value', extension => {
   expect(extensions[extension] in extensions.defaults).toBe(true);
 });
 

--- a/packages/oas-extensions/__tests__/index.test.js
+++ b/packages/oas-extensions/__tests__/index.test.js
@@ -2,63 +2,78 @@ const extensions = require('..');
 const petstore = require('@readme/oas-examples/3.0/json/petstore.json');
 const Oas = require('oas/tooling');
 
-describe('oas-level extensions', () => {
-  it('should use the default extension value if the extension is not present', () => {
-    const oas = new Oas(petstore);
-    expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas)).toStrictEqual([
-      'curl',
-      'node',
-      'ruby',
-      'javascript',
-      'python',
-    ]);
-  });
-
-  it('should locate an extensions under `x-readme`', () => {
-    const oas = new Oas({
-      ...petstore,
-      'x-readme': {
-        [extensions.SAMPLES_LANGUAGES]: ['swift'],
-      },
-    });
-
-    expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas)).toStrictEqual(['swift']);
-  });
-
-  it('should locate an extensions listed at the root', () => {
-    const oas = new Oas({ ...petstore, [`x-${extensions.EXPLORER_ENABLED}`]: false });
-    expect(extensions.getExtension(extensions.EXPLORER_ENABLED, oas)).toBe(false);
-  });
+test.each([
+  ['CODE_SAMPLES'],
+  ['EXPLORER_ENABLED'],
+  ['HEADERS'],
+  ['PROXY_ENABLED'],
+  ['RESPONSE_SAMPLES'],
+  ['SAMPLES_ENABLED'],
+  ['SAMPLES_LANGUAGES'],
+  ['SEND_DEFAULTS'],
+])("`%s` extension should have a default value", (extension) => {
+  expect(extensions[extension] in extensions.defaults).toBe(true);
 });
 
-describe('operation-level', () => {
-  const oas = new Oas(petstore);
+describe('#getExtension', () => {
+  describe('oas-level extensions', () => {
+    it('should use the default extension value if the extension is not present', () => {
+      const oas = new Oas(petstore);
+      expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas)).toStrictEqual([
+        'curl',
+        'node',
+        'ruby',
+        'javascript',
+        'python',
+      ]);
+    });
 
-  it('should use the default extension value if the extension is not present', () => {
-    const operation = oas.operation('/pet', 'post');
+    it('should locate an extensions under `x-readme`', () => {
+      const oas = new Oas({
+        ...petstore,
+        'x-readme': {
+          [extensions.SAMPLES_LANGUAGES]: ['swift'],
+        },
+      });
 
-    expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas, operation)).toStrictEqual([
-      'curl',
-      'node',
-      'ruby',
-      'javascript',
-      'python',
-    ]);
+      expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas)).toStrictEqual(['swift']);
+    });
+
+    it('should locate an extensions listed at the root', () => {
+      const oas = new Oas({ ...petstore, [`x-${extensions.EXPLORER_ENABLED}`]: false });
+      expect(extensions.getExtension(extensions.EXPLORER_ENABLED, oas)).toBe(false);
+    });
   });
 
-  it('should locate an extensions under `x-readme`', () => {
-    const operation = oas.operation('/pet', 'post');
-    operation.schema['x-readme'] = {
-      [extensions.SAMPLES_LANGUAGES]: ['swift'],
-    };
+  describe('operation-level', () => {
+    const oas = new Oas(petstore);
 
-    expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas, operation)).toStrictEqual(['swift']);
-  });
+    it('should use the default extension value if the extension is not present', () => {
+      const operation = oas.operation('/pet', 'post');
 
-  it('should locate an extensions listed at the root', () => {
-    const operation = oas.operation('/pet', 'post');
-    operation.schema[`x-${extensions.EXPLORER_ENABLED}`] = false;
+      expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas, operation)).toStrictEqual([
+        'curl',
+        'node',
+        'ruby',
+        'javascript',
+        'python',
+      ]);
+    });
 
-    expect(extensions.getExtension(extensions.EXPLORER_ENABLED, oas, operation)).toBe(false);
+    it('should locate an extensions under `x-readme`', () => {
+      const operation = oas.operation('/pet', 'post');
+      operation.schema['x-readme'] = {
+        [extensions.SAMPLES_LANGUAGES]: ['swift'],
+      };
+
+      expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas, operation)).toStrictEqual(['swift']);
+    });
+
+    it('should locate an extensions listed at the root', () => {
+      const operation = oas.operation('/pet', 'post');
+      operation.schema[`x-${extensions.EXPLORER_ENABLED}`] = false;
+
+      expect(extensions.getExtension(extensions.EXPLORER_ENABLED, oas, operation)).toBe(false);
+    });
   });
 });

--- a/packages/oas-extensions/index.js
+++ b/packages/oas-extensions/index.js
@@ -2,18 +2,22 @@
 // https://readme.readme.io/v2.0/docs/swagger-extensions
 
 module.exports = {
+  CODE_SAMPLES: 'code-samples',
   EXPLORER_ENABLED: 'explorer-enabled',
   HEADERS: 'headers',
   PROXY_ENABLED: 'proxy-enabled',
+  RESPONSE_SAMPLES: 'response-examples',
   SAMPLES_ENABLED: 'samples-enabled',
   SAMPLES_LANGUAGES: 'samples-languages',
   SEND_DEFAULTS: 'send-defaults',
 };
 
 module.exports.defaults = {
+  'code-samples': undefined,
   'explorer-enabled': true,
   headers: undefined,
   'proxy-enabled': true,
+  'response-examples': undefined,
   'samples-enabled': true,
   'samples-languages': ['curl', 'node', 'ruby', 'javascript', 'python'],
   'send-defaults': false,


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] Adds new extensions to `@readme/oas-extensions` for `CODE_SAMPLES` and `RESPONSE_SAMPLES`. Shape of these extensions is still in flight, but they will be undocumented on https://docs.readme.com/docs/openapi-extensions for now.