### PR TITLE
chore(deps): upgrading httpsnippet-client-api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5372,6 +5372,47 @@
         "oas": "^6.1.1"
       },
       "dependencies": {
+        "httpsnippet-client-api": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.7.1.tgz",
+          "integrity": "sha512-/cJxQWv+oJJl5SOac1jiKyUudIiMu6OoEv9kliL1s8qjiBuds6sm+NmknIWE6pBu0oTKGX9sNgQqp66XGeyeGQ==",
+          "requires": {
+            "@readme/httpsnippet": "^2.4.1",
+            "content-type": "^1.0.4",
+            "oas": "^10.0.0",
+            "path-to-regexp": "^6.1.0",
+            "stringify-object": "^3.3.0"
+          },
+          "dependencies": {
+            "oas": {
+              "version": "10.4.0",
+              "resolved": "https://registry.npmjs.org/oas/-/oas-10.4.0.tgz",
+              "integrity": "sha512-J264FPUGCDVTiugHp26oN2PAaz/TDbOd2RZRoFIjLPd6/N0Zd9mX0iSPKOXWz48KqRedGkBdhl1ggEoYNRS4RQ==",
+              "requires": {
+                "@apidevtools/json-schema-ref-parser": "^9.0.6",
+                "cardinal": "^2.1.1",
+                "colors": "^1.1.2",
+                "figures": "^3.0.0",
+                "glob": "^7.1.2",
+                "inquirer": "^7.0.1",
+                "json-schema-merge-allof": "^0.7.0",
+                "json2yaml": "^1.1.0",
+                "jsonfile": "^6.0.0",
+                "jsonpointer": "^4.1.0",
+                "lodash": "^4.17.11",
+                "lodash.kebabcase": "^4.1.1",
+                "memoizee": "^0.4.14",
+                "minimist": "^1.2.0",
+                "node-status": "^1.0.0",
+                "oas-normalize": "2.3.1",
+                "open": "^7.0.0",
+                "path-to-regexp": "^6.2.0",
+                "request": "^2.88.0",
+                "swagger-inline": "3.2.2"
+              }
+            }
+          }
+        },
         "json-schema-merge-allof": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.7.0.tgz",
@@ -12845,13 +12886,11 @@
       }
     },
     "httpsnippet-client-api": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.7.1.tgz",
-      "integrity": "sha512-/cJxQWv+oJJl5SOac1jiKyUudIiMu6OoEv9kliL1s8qjiBuds6sm+NmknIWE6pBu0oTKGX9sNgQqp66XGeyeGQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-3.0.0.tgz",
+      "integrity": "sha512-lVTWhOo7kB78x677zJAIxbzgQTv0QI+J8EMxMIpEGJUSfcWohArjsb3yUFZ9TVotEi4FlgUZa4N2Zqk5fEfWKg==",
       "requires": {
-        "@readme/httpsnippet": "^2.4.1",
         "content-type": "^1.0.4",
-        "oas": "^10.0.0",
         "path-to-regexp": "^6.1.0",
         "stringify-object": "^3.3.0"
       }

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -2474,21 +2474,6 @@
       "integrity": "sha512-MSm5mJoNa9AJ6PfKFOSO4BBzC3oQn0CdJHfP5l6v1ATVX3LUy/+X2Xgx5RZNcefRkJ7TWlfPoCiphjiEDSaAVQ==",
       "dev": true
     },
-    "@readme/oas-extensions": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-12.0.0.tgz",
-      "integrity": "sha512-gBCJFep7WqiI+jDj0dKdxAjvJxIDu3aZON0OMneuETB5dMjKPoKzuOk/KzY6rIZ5AOlbCJn8VIBdKDlsLho1Jg=="
-    },
-    "@readme/oas-to-har": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-12.2.1.tgz",
-      "integrity": "sha512-EHeFdqHiYUyDAyq7AIQxyQUh7NmOJr1Z2ou0tjhKNXRvjO7HzZwHWYfHvnWPMvf4CUMGwWFHr/bpC22J0tUO9g==",
-      "requires": {
-        "@readme/oas-extensions": "^12.0.0",
-        "oas": "^10.2.0",
-        "parse-data-url": "^3.0.0"
-      }
-    },
     "@readme/syntax-highlighter": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.4.5.tgz",
@@ -5525,13 +5510,11 @@
       }
     },
     "httpsnippet-client-api": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-2.7.1.tgz",
-      "integrity": "sha512-/cJxQWv+oJJl5SOac1jiKyUudIiMu6OoEv9kliL1s8qjiBuds6sm+NmknIWE6pBu0oTKGX9sNgQqp66XGeyeGQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-3.0.0.tgz",
+      "integrity": "sha512-lVTWhOo7kB78x677zJAIxbzgQTv0QI+J8EMxMIpEGJUSfcWohArjsb3yUFZ9TVotEi4FlgUZa4N2Zqk5fEfWKg==",
       "requires": {
-        "@readme/httpsnippet": "^2.4.1",
         "content-type": "^1.0.4",
-        "oas": "^10.0.0",
         "path-to-regexp": "^6.1.0",
         "stringify-object": "^3.3.0"
       }
@@ -8316,14 +8299,6 @@
         "callsites": "^3.0.0"
       }
     },
-    "parse-data-url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-3.0.0.tgz",
-      "integrity": "sha512-U72k3mbLzeTiPgVbMIJKG+LROejvsniSMwAgz8EM+DhP0C2HYAmXu65uq2IWjYLffgZndFa42E9TCOHJCi37uA==",
-      "requires": {
-        "valid-data-url": "^3.0.1"
-      }
-    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -9997,11 +9972,6 @@
           "dev": true
         }
       }
-    },
-    "valid-data-url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-3.0.1.tgz",
-      "integrity": "sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -21,7 +21,7 @@
     "@readme/oas-extensions": "^13.0.0",
     "@readme/oas-to-har": "^13.0.0",
     "@readme/syntax-highlighter": "^10.4.1",
-    "httpsnippet-client-api": "^2.7.0",
+    "httpsnippet-client-api": "^3.0.0",
     "oas": "^10.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🧰 What's being changed?

Upgrading `httpsnippet-client-api` to 3.0 to pull in some changes that were done here: https://github.com/readmeio/api/pull/240
