### PR TITLE
feat: allowing for a HAR override to be passed in for snippet creation

### DIFF
--- a/packages/oas-to-snippet/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/oas-to-snippet/__tests__/__snapshots__/index.test.js.snap
@@ -18,7 +18,7 @@ Object {
 
 const url = 'https://dash.readme.io/api/v1/categories/';
 
-const options = {method: 'GET'};
+const options = {method: 'GET', headers: {authorization: 'Basic xxx'}};
 
 fetch(url, options)
   .then(res => res.json())

--- a/packages/oas-to-snippet/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/oas-to-snippet/__tests__/__snapshots__/index.test.js.snap
@@ -11,3 +11,19 @@ Object {
   "highlightMode": "shell",
 }
 `;
+
+exports[`should be able to accept a har override 1`] = `
+Object {
+  "code": "const fetch = require('node-fetch');
+
+const url = 'https://dash.readme.io/api/v1/categories/';
+
+const options = {method: 'GET'};
+
+fetch(url, options)
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error('error:' + err));",
+  "highlightMode": "javascript",
+}
+`;

--- a/packages/oas-to-snippet/__tests__/index.test.js
+++ b/packages/oas-to-snippet/__tests__/index.test.js
@@ -31,22 +31,16 @@ test('should be able to accept a har override', () => {
       entries: [
         {
           request: {
-            creator: {
-              name: 'readmeio',
-              version: '4.0.2',
-              comment: 'linux/v14.15.1',
-            },
             method: 'GET',
             url: 'https://dash.readme.io/api/v1/categories/',
             httpVersion: 'HTTPS/1.1',
-            requestHeaders: [
+            headers: [
               {
                 name: 'authorization',
                 value: 'Basic xxx',
               },
             ],
             queryString: [],
-            requestBody: { params: [] },
           },
         },
       ],

--- a/packages/oas-to-snippet/__tests__/index.test.js
+++ b/packages/oas-to-snippet/__tests__/index.test.js
@@ -25,6 +25,38 @@ const operation = {
 
 const formData = { path: { id: 123 } };
 
+test('should be able to accept a har override', () => {
+  const harOverride = {
+    log: {
+      entries: [
+        {
+          request: {
+            creator: {
+              name: 'readmeio',
+              version: '4.0.2',
+              comment: 'linux/v14.15.1',
+            },
+            method: 'GET',
+            url: 'https://dash.readme.io/api/v1/categories/',
+            httpVersion: 'HTTPS/1.1',
+            requestHeaders: [
+              {
+                name: 'authorization',
+                value: 'Basic xxx',
+              },
+            ],
+            queryString: [],
+            requestBody: { params: [] },
+          },
+        },
+      ],
+    },
+  };
+
+  const codeSnippet = generateCodeSnippet(oas, operation, {}, {}, 'node', oasUrl, harOverride);
+  expect(codeSnippet).toMatchSnapshot();
+});
+
 test('should return falsy values for an unknown language', () => {
   const codeSnippet = generateCodeSnippet(oas, operation, {}, {}, 'css', oasUrl);
 

--- a/packages/oas-to-snippet/src/index.js
+++ b/packages/oas-to-snippet/src/index.js
@@ -11,9 +11,10 @@ const supportedLanguages = require('./supportedLanguages');
  * @param {Object} auth
  * @param {String} lang
  * @param {String} oasUrl
+ * @param {Object|undefined} harOverride
  */
-module.exports = (oas, operation, values, auth, lang, oasUrl) => {
-  const har = generateHar(oas, operation, values, auth);
+module.exports = (oas, operation, values, auth, lang, oasUrl, harOverride) => {
+  const har = harOverride || generateHar(oas, operation, values, auth);
 
   // API SDK client needs additional runtime information on the API definition we're showing the user so it can
   // generate an appropriate snippet.


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

Allows for a separate HAR to be supplied to `@readme/oas-to-snippet` to create a code snippet for that passed in HAR object.

## 🧬 Testing

See unit tests.

[demo]: https://deployment_url
