### PR TITLE
fix: fatal error where basic auth scheme might be missing

### DIFF
--- a/packages/oas-to-har/src/lib/configure-security.js
+++ b/packages/oas-to-har/src/lib/configure-security.js
@@ -14,6 +14,7 @@ module.exports = function configureSecurity(oas, values, scheme) {
   if (security.type === 'http') {
     if (security.scheme === 'basic') {
       // Return with no header if user and password are blank
+      if (!values[scheme]) return false;
       if (!values[scheme].user && !values[scheme].pass) return false;
 
       return harValue('headers', {


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a bug in `@readme/oas-to-har`'s `configure-security` library where if an OAS with a basic auth scheme does not exist within the provided auth data, and that auth data is **not** an empty object, we'd throw a fatal error when attempting to access `.user` on `undefined`

## 🧬 Testing

See tests