### PR TITLE
fix: removing undefined formData before processing it into postData

### DIFF
--- a/packages/oas-to-har/__tests__/index.test.js
+++ b/packages/oas-to-har/__tests__/index.test.js
@@ -1404,6 +1404,36 @@ describe('requestBody', () => {
       ).toBe(JSON.stringify({ a: 'value' }));
     });
 
+    it('should not add undefined formData into postData', () => {
+      expect(
+        oasToHar(
+          oas,
+          {
+            path: '/',
+            method: 'get',
+            requestBody: {
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      foo: {
+                        type: 'string',
+                      },
+                      bar: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          { formData: { foo: undefined, bar: undefined } }
+        ).log.entries[0].request.postData
+      ).toBeUndefined();
+    });
+
     it('should pass in value if one is set and prioritise provided values', () => {
       expect(
         oasToHar(

--- a/packages/oas-to-har/src/index.js
+++ b/packages/oas-to-har/src/index.js
@@ -246,15 +246,18 @@ module.exports = (
   if (requestBody.schema && Object.keys(requestBody.schema).length) {
     if (operation.isFormUrlEncoded()) {
       if (Object.keys(formData.formData).length) {
-        har.postData.params = [];
-        har.postData.mimeType = 'application/x-www-form-urlencoded';
+        const cleanFormData = removeUndefinedObjects(JSON.parse(JSON.stringify(formData.formData)));
+        if (cleanFormData !== undefined) {
+          har.postData.params = [];
+          har.postData.mimeType = 'application/x-www-form-urlencoded';
 
-        Object.keys(formData.formData).forEach(name => {
-          har.postData.params.push({
-            name,
-            value: String(formData.formData[name]),
+          Object.keys(cleanFormData).forEach(name => {
+            har.postData.params.push({
+              name,
+              value: String(cleanFormData[name]),
+            });
           });
-        });
+        }
       }
     } else if (
       'body' in formData &&


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a bug with `application/x-www-url-formencoded` handling within `@readme/oas-to-har` where we weren't properly filtering out `undefined` values from `formData` before processing it into `postData` resulting in a case where if you added and removed data from the form we'd send `'undefined'` into the HAR (and thus into code snippets).

https://user-images.githubusercontent.com/33762/115469756-1617a680-a1ea-11eb-8f0c-abb48ef60e2c.mov

## 🧬 Testing

You can see this in action on https://preview.readme.io/?selected=swagger-files%2Fformdata.json

With this fix:

https://user-images.githubusercontent.com/33762/115469860-3cd5dd00-a1ea-11eb-8f7e-35a9f4c2bb9f.mov