### PR TITLE
fix: dont put copy buttons schema descriptions

### DIFF
--- a/packages/api-explorer/src/block-types/Content.jsx
+++ b/packages/api-explorer/src/block-types/Content.jsx
@@ -137,6 +137,7 @@ Content.propTypes = {
 
 Content.defaultProps = {
   body: '',
+  copyButtons: false,
   flags: {},
   isThreeColumn: true,
   splitReferenceDocs: false,


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] | Fix CX-281 |
| --- | --- |

## 🧰 What's being changed?

Revert adding copy buttons to schema descriptions. 

https://github.com/readmeio/api-explorer/pull/1258#discussion_r622393687

## 🧬 Testing

Provide as much information as you can on how to test what you've done.

[demo]: https://deployment_url
