### PR TITLE
feat: adding support to oas-to-snippet for alternative language targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12279,6 +12279,11 @@
         }
       }
     },
+    "har-examples": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/har-examples/-/har-examples-1.0.6.tgz",
+      "integrity": "sha512-fPrJvANRBqCcQPK/xk+ehxkmVFdwaLXeL47ZnuOvbj2eHcK7FaBmAVOqXKBT3SaKCiOHB/rEKFvSwON8LHyfQw=="
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",

--- a/packages/oas-to-snippet/README.md
+++ b/packages/oas-to-snippet/README.md
@@ -38,6 +38,10 @@ const auth = {
 }
 
 // This is the language to generate a snippet to. See below for supported languages.
+//
+// For supplying an alternative language target (like `axios` for `node`), you can do so by
+// changing this variable to an array: `['node', 'axios']`. For the full list of alternative
+// language targets that we support, see below.
 const language = 'node';
 
 // This URL parameter is only necessary when using the `node-simple` language and it should be an
@@ -53,22 +57,42 @@ const { code, highlightMode } = generateSnippet(apiDefinition, operation, formDa
 
 ## Supported Languages
 
-Since this library uses [HTTP Snippet](https://github.com/Kong/httpsnippet), we support most languages that does which are the following:
+Since this library uses [HTTP Snippet](https://github.com/Kong/httpsnippet), we support most of its languages, and their associated targets, which are the following:
 
 * `c`
+* `clojure`
 * `cplusplus`
 * `csharp`
+  * `httpclient`
+  * `restsharp`
 * `curl`
 * `go`
 * `java`
+  * `asynchttp`
+  * `nethttp`
+  * `okhttp`
+  * `unirest`
 * `javascript`
+  * `axios`
+  * `fetch`
+  * `jquery`
+  * `xhr`
 * `kotlin`
+  * `okhttp`
 * `node`
+  * `api`: This is our OpenAPI-powered SDK generation library; see https://npm.im/api for more info.
+  * `axios`
+  * `fetch`
+  * `native`
+  * `request`
+* `node-simple`: This is a shortcut for supplying `['node', 'api']` as the `lang` argument.
 * `objectivec`
+* `ocaml`
 * `php`
+  * `curl`
 * `powershell`
 * `python`
+  * `requests`
+* `r`
 * `ruby`
 * `swift`
-
-We also support `node-simple`, which is a custom Node snippet wrapper we have for our [api](https://www.npmjs.com/package/api) package that facilitates the easy usage of calling an API from an OpenAPI definition.

--- a/packages/oas-to-snippet/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/oas-to-snippet/__tests__/__snapshots__/index.test.js.snap
@@ -14,10 +14,22 @@ Object {
 
 exports[`should be able to accept a har override 1`] = `
 Object {
-  "code": "const fetch = require('node-fetch');
+  "code": "const { URLSearchParams } = require('url');
+const fetch = require('node-fetch');
+const encodedParams = new URLSearchParams();
 
-const url = 'https://dash.readme.io/api/v1/categories/';
-const options = {method: 'GET', headers: {authorization: 'Basic xxx'}};
+encodedParams.set('foo', 'bar');
+
+const url = 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value';
+const options = {
+  method: 'POST',
+  headers: {
+    accept: 'application/json',
+    'content-type': 'application/x-www-form-urlencoded',
+    cookie: 'foo=bar; bar=baz; '
+  },
+  body: encodedParams
+};
 
 fetch(url, options)
   .then(res => res.json())
@@ -27,7 +39,7 @@ fetch(url, options)
 }
 `;
 
-exports[`supported languages should support c 1`] = `
+exports[`supported languages c should generate code for the default target 1`] = `
 Object {
   "code": "CURL *hnd = curl_easy_init();
 
@@ -39,7 +51,23 @@ CURLcode ret = curl_easy_perform(hnd);",
 }
 `;
 
-exports[`supported languages should support clojure 1`] = `
+exports[`supported languages c targets c 1`] = `
+Object {
+  "code": "CURL *hnd = curl_easy_init();
+
+curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, \\"GET\\");
+curl_easy_setopt(hnd, CURLOPT_URL, \\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\");
+
+struct curl_slist *headers = NULL;
+headers = curl_slist_append(headers, \\"Accept: application/xml\\");
+curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
+
+CURLcode ret = curl_easy_perform(hnd);",
+  "highlightMode": "text/x-csrc",
+}
+`;
+
+exports[`supported languages clojure should generate code for the default target 1`] = `
 Object {
   "code": "(require '[clj-http.client :as client])
 
@@ -48,7 +76,18 @@ Object {
 }
 `;
 
-exports[`supported languages should support cplusplus 1`] = `
+exports[`supported languages clojure targets clojure 1`] = `
+Object {
+  "code": "(require '[clj-http.client :as client])
+
+(client/get \\"http://petstore.swagger.io/v2/user/login\\" {:headers {:Accept \\"application/xml\\"}
+                                                        :query-params {:username \\"woof\\"
+                                                                       :password \\"barkbarkbark\\"}})",
+  "highlightMode": "clojure",
+}
+`;
+
+exports[`supported languages cplusplus should generate code for the default target 1`] = `
 Object {
   "code": "CURL *hnd = curl_easy_init();
 
@@ -60,7 +99,23 @@ CURLcode ret = curl_easy_perform(hnd);",
 }
 `;
 
-exports[`supported languages should support csharp 1`] = `
+exports[`supported languages cplusplus targets c 1`] = `
+Object {
+  "code": "CURL *hnd = curl_easy_init();
+
+curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, \\"GET\\");
+curl_easy_setopt(hnd, CURLOPT_URL, \\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\");
+
+struct curl_slist *headers = NULL;
+headers = curl_slist_append(headers, \\"Accept: application/xml\\");
+curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
+
+CURLcode ret = curl_easy_perform(hnd);",
+  "highlightMode": "text/x-c++src",
+}
+`;
+
+exports[`supported languages csharp should generate code for the default target 1`] = `
 Object {
   "code": "var client = new RestClient(\\"https://example.com/path/123\\");
 var request = new RestRequest(Method.GET);
@@ -69,7 +124,39 @@ IRestResponse response = client.Execute(request);",
 }
 `;
 
-exports[`supported languages should support curl 1`] = `
+exports[`supported languages csharp targets httpclient 1`] = `
+Object {
+  "code": "var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Get,
+    RequestUri = new Uri(\\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\"),
+    Headers =
+    {
+        { \\"Accept\\", \\"application/xml\\" },
+    },
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}",
+  "highlightMode": "text/x-csharp",
+}
+`;
+
+exports[`supported languages csharp targets restsharp 1`] = `
+Object {
+  "code": "var client = new RestClient(\\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\");
+var request = new RestRequest(Method.GET);
+request.AddHeader(\\"Accept\\", \\"application/xml\\");
+IRestResponse response = client.Execute(request);",
+  "highlightMode": "text/x-csharp",
+}
+`;
+
+exports[`supported languages curl should generate code for the default target 1`] = `
 Object {
   "code": "curl --request GET \\\\
   --url https://example.com/path/123",
@@ -77,7 +164,16 @@ Object {
 }
 `;
 
-exports[`supported languages should support go 1`] = `
+exports[`supported languages curl targets curl 1`] = `
+Object {
+  "code": "curl --request GET \\\\
+  --url 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' \\\\
+  --header 'Accept: application/xml'",
+  "highlightMode": "shell",
+}
+`;
+
+exports[`supported languages go should generate code for the default target 1`] = `
 Object {
   "code": "package main
 
@@ -106,7 +202,38 @@ func main() {
 }
 `;
 
-exports[`supported languages should support java 1`] = `
+exports[`supported languages go targets native 1`] = `
+Object {
+  "code": "package main
+
+import (
+	\\"fmt\\"
+	\\"net/http\\"
+	\\"io/ioutil\\"
+)
+
+func main() {
+
+	url := \\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\"
+
+	req, _ := http.NewRequest(\\"GET\\", url, nil)
+
+	req.Header.Add(\\"Accept\\", \\"application/xml\\")
+
+	res, _ := http.DefaultClient.Do(req)
+
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+
+	fmt.Println(res)
+	fmt.Println(string(body))
+
+}",
+  "highlightMode": "go",
+}
+`;
+
+exports[`supported languages java should generate code for the default target 1`] = `
 Object {
   "code": "OkHttpClient client = new OkHttpClient();
 
@@ -120,7 +247,59 @@ Response response = client.newCall(request).execute();",
 }
 `;
 
-exports[`supported languages should support javascript 1`] = `
+exports[`supported languages java targets asynchttp 1`] = `
+Object {
+  "code": "AsyncHttpClient client = new DefaultAsyncHttpClient();
+client.prepare(\\"GET\\", \\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\")
+  .setHeader(\\"Accept\\", \\"application/xml\\")
+  .execute()
+  .toCompletableFuture()
+  .thenAccept(System.out::println)
+  .join();
+
+client.close();",
+  "highlightMode": "java",
+}
+`;
+
+exports[`supported languages java targets nethttp 1`] = `
+Object {
+  "code": "HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create(\\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\"))
+    .header(\\"Accept\\", \\"application/xml\\")
+    .method(\\"GET\\", HttpRequest.BodyPublishers.noBody())
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());",
+  "highlightMode": "java",
+}
+`;
+
+exports[`supported languages java targets okhttp 1`] = `
+Object {
+  "code": "OkHttpClient client = new OkHttpClient();
+
+Request request = new Request.Builder()
+  .url(\\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\")
+  .get()
+  .addHeader(\\"Accept\\", \\"application/xml\\")
+  .build();
+
+Response response = client.newCall(request).execute();",
+  "highlightMode": "java",
+}
+`;
+
+exports[`supported languages java targets unirest 1`] = `
+Object {
+  "code": "HttpResponse<String> response = Unirest.get(\\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\")
+  .header(\\"Accept\\", \\"application/xml\\")
+  .asString();",
+  "highlightMode": "java",
+}
+`;
+
+exports[`supported languages javascript should generate code for the default target 1`] = `
 Object {
   "code": "const options = {method: 'GET'};
 
@@ -132,7 +311,79 @@ fetch('https://example.com/path/123', options)
 }
 `;
 
-exports[`supported languages should support kotlin 1`] = `
+exports[`supported languages javascript targets axios 1`] = `
+Object {
+  "code": "import axios from \\"axios\\";
+
+const options = {
+  method: 'GET',
+  url: 'http://petstore.swagger.io/v2/user/login',
+  params: {username: 'woof', password: 'barkbarkbark'},
+  headers: {Accept: 'application/xml'}
+};
+
+axios.request(options).then(function (response) {
+  console.log(response.data);
+}).catch(function (error) {
+  console.error(error);
+});",
+  "highlightMode": "javascript",
+}
+`;
+
+exports[`supported languages javascript targets fetch 1`] = `
+Object {
+  "code": "const options = {method: 'GET', headers: {Accept: 'application/xml'}};
+
+fetch('http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark', options)
+  .then(response => response.json())
+  .then(response => console.log(response))
+  .catch(err => console.error(err));",
+  "highlightMode": "javascript",
+}
+`;
+
+exports[`supported languages javascript targets jquery 1`] = `
+Object {
+  "code": "const settings = {
+  \\"async\\": true,
+  \\"crossDomain\\": true,
+  \\"url\\": \\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\",
+  \\"method\\": \\"GET\\",
+  \\"headers\\": {
+    \\"Accept\\": \\"application/xml\\"
+  }
+};
+
+$.ajax(settings).done(function (response) {
+  console.log(response);
+});",
+  "highlightMode": "javascript",
+}
+`;
+
+exports[`supported languages javascript targets xhr 1`] = `
+Object {
+  "code": "const data = null;
+
+const xhr = new XMLHttpRequest();
+xhr.withCredentials = true;
+
+xhr.addEventListener(\\"readystatechange\\", function () {
+  if (this.readyState === this.DONE) {
+    console.log(this.responseText);
+  }
+});
+
+xhr.open(\\"GET\\", \\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\");
+xhr.setRequestHeader(\\"Accept\\", \\"application/xml\\");
+
+xhr.send(data);",
+  "highlightMode": "javascript",
+}
+`;
+
+exports[`supported languages kotlin should generate code for the default target 1`] = `
 Object {
   "code": "OkHttpClient client = new OkHttpClient();
 
@@ -146,7 +397,22 @@ Response response = client.newCall(request).execute();",
 }
 `;
 
-exports[`supported languages should support node 1`] = `
+exports[`supported languages kotlin targets okhttp 1`] = `
+Object {
+  "code": "OkHttpClient client = new OkHttpClient();
+
+Request request = new Request.Builder()
+  .url(\\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\")
+  .get()
+  .addHeader(\\"Accept\\", \\"application/xml\\")
+  .build();
+
+Response response = client.newCall(request).execute();",
+  "highlightMode": "java",
+}
+`;
+
+exports[`supported languages node should generate code for the default target 1`] = `
 Object {
   "code": "const fetch = require('node-fetch');
 
@@ -161,7 +427,106 @@ fetch(url, options)
 }
 `;
 
-exports[`supported languages should support objectivec 1`] = `
+exports[`supported languages node targets api 1`] = `
+Object {
+  "code": "const sdk = require('api')('https://example.com/openapi.json');
+
+sdk.loginUser({username: 'woof', password: 'barkbarkbark', Accept: 'application/xml'})
+  .then(res => console.log(res))
+  .catch(err => console.error(err));",
+  "highlightMode": "javascript",
+}
+`;
+
+exports[`supported languages node targets axios 1`] = `
+Object {
+  "code": "var axios = require(\\"axios\\").default;
+
+var options = {
+  method: 'GET',
+  url: 'http://petstore.swagger.io/v2/user/login',
+  params: {username: 'woof', password: 'barkbarkbark'},
+  headers: {Accept: 'application/xml'}
+};
+
+axios.request(options).then(function (response) {
+  console.log(response.data);
+}).catch(function (error) {
+  console.error(error);
+});",
+  "highlightMode": "javascript",
+}
+`;
+
+exports[`supported languages node targets fetch 1`] = `
+Object {
+  "code": "const fetch = require('node-fetch');
+
+const url = 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark';
+const options = {method: 'GET', headers: {Accept: 'application/xml'}};
+
+fetch(url, options)
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error('error:' + err));",
+  "highlightMode": "javascript",
+}
+`;
+
+exports[`supported languages node targets native 1`] = `
+Object {
+  "code": "const http = require(\\"http\\");
+
+const options = {
+  \\"method\\": \\"GET\\",
+  \\"hostname\\": \\"petstore.swagger.io\\",
+  \\"port\\": null,
+  \\"path\\": \\"/v2/user/login?username=woof&password=barkbarkbark\\",
+  \\"headers\\": {
+    \\"Accept\\": \\"application/xml\\"
+  }
+};
+
+const req = http.request(options, function (res) {
+  const chunks = [];
+
+  res.on(\\"data\\", function (chunk) {
+    chunks.push(chunk);
+  });
+
+  res.on(\\"end\\", function () {
+    const body = Buffer.concat(chunks);
+    console.log(body.toString());
+  });
+});
+
+req.end();",
+  "highlightMode": "javascript",
+}
+`;
+
+exports[`supported languages node targets request 1`] = `
+Object {
+  "code": "const request = require('request');
+
+const options = {
+  method: 'GET',
+  url: 'http://petstore.swagger.io/v2/user/login',
+  qs: {username: 'woof', password: 'barkbarkbark'},
+  headers: {Accept: 'application/xml'}
+};
+
+request(options, function (error, response, body) {
+  if (error) throw new Error(error);
+
+  console.log(body);
+});
+",
+  "highlightMode": "javascript",
+}
+`;
+
+exports[`supported languages objectivec should generate code for the default target 1`] = `
 Object {
   "code": "#import <Foundation/Foundation.h>
 
@@ -185,7 +550,34 @@ NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
 }
 `;
 
-exports[`supported languages should support ocaml 1`] = `
+exports[`supported languages objectivec targets nsurlsession 1`] = `
+Object {
+  "code": "#import <Foundation/Foundation.h>
+
+NSDictionary *headers = @{ @\\"Accept\\": @\\"application/xml\\" };
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@\\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@\\"GET\\"];
+[request setAllHTTPHeaderFields:headers];
+
+NSURLSession *session = [NSURLSession sharedSession];
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                                                if (error) {
+                                                    NSLog(@\\"%@\\", error);
+                                                } else {
+                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
+                                                    NSLog(@\\"%@\\", httpResponse);
+                                                }
+                                            }];
+[dataTask resume];",
+  "highlightMode": "objectivec",
+}
+`;
+
+exports[`supported languages ocaml should generate code for the default target 1`] = `
 Object {
   "code": "open Cohttp_lwt_unix
 open Cohttp
@@ -200,7 +592,23 @@ Client.call \`GET uri
 }
 `;
 
-exports[`supported languages should support php 1`] = `
+exports[`supported languages ocaml targets ocaml 1`] = `
+Object {
+  "code": "open Cohttp_lwt_unix
+open Cohttp
+open Lwt
+
+let uri = Uri.of_string \\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\" in
+let headers = Header.add (Header.init ()) \\"Accept\\" \\"application/xml\\" in
+
+Client.call ~headers \`GET uri
+>>= fun (res, body_stream) ->
+  (* Do stuff with the result *)",
+  "highlightMode": "ocaml",
+}
+`;
+
+exports[`supported languages php should generate code for the default target 1`] = `
 Object {
   "code": "<?php
 
@@ -230,14 +638,56 @@ if ($err) {
 }
 `;
 
-exports[`supported languages should support powershell 1`] = `
+exports[`supported languages php targets curl 1`] = `
+Object {
+  "code": "<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, [
+  CURLOPT_URL => \\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\",
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => \\"\\",
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 30,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => \\"GET\\",
+  CURLOPT_HTTPHEADER => [
+    \\"Accept: application/xml\\"
+  ],
+]);
+
+$response = curl_exec($curl);
+$err = curl_error($curl);
+
+curl_close($curl);
+
+if ($err) {
+  echo \\"cURL Error #:\\" . $err;
+} else {
+  echo $response;
+}",
+  "highlightMode": "php",
+}
+`;
+
+exports[`supported languages powershell should generate code for the default target 1`] = `
 Object {
   "code": "$response = Invoke-WebRequest -Uri 'https://example.com/path/123' -Method GET ",
   "highlightMode": "powershell",
 }
 `;
 
-exports[`supported languages should support python 1`] = `
+exports[`supported languages powershell targets powershell 1`] = `
+Object {
+  "code": "$headers=@{}
+$headers.Add(\\"Accept\\", \\"application/xml\\")
+$response = Invoke-WebRequest -Uri 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' -Method GET -Headers $headers",
+  "highlightMode": "powershell",
+}
+`;
+
+exports[`supported languages python should generate code for the default target 1`] = `
 Object {
   "code": "import requests
 
@@ -250,7 +700,24 @@ print(response.text)",
 }
 `;
 
-exports[`supported languages should support r 1`] = `
+exports[`supported languages python targets requests 1`] = `
+Object {
+  "code": "import requests
+
+url = \\"http://petstore.swagger.io/v2/user/login\\"
+
+querystring = {\\"username\\":\\"woof\\",\\"password\\":\\"barkbarkbark\\"}
+
+headers = {\\"Accept\\": \\"application/xml\\"}
+
+response = requests.request(\\"GET\\", url, headers=headers, params=querystring)
+
+print(response.text)",
+  "highlightMode": "python",
+}
+`;
+
+exports[`supported languages r should generate code for the default target 1`] = `
 Object {
   "code": "library(httr)
 
@@ -263,7 +730,25 @@ content(response, \\"text\\")",
 }
 `;
 
-exports[`supported languages should support ruby 1`] = `
+exports[`supported languages r targets r 1`] = `
+Object {
+  "code": "library(httr)
+
+url <- \\"http://petstore.swagger.io/v2/user/login\\"
+
+queryString <- list(
+  username = \\"woof\\"
+  password = \\"barkbarkbark\\",
+)
+
+response <- VERB(\\"GET\\", url, query = queryString, content_type(\\"application/octet-stream\\"), accept(\\"application/xml\\"))
+
+content(response, \\"text\\")",
+  "highlightMode": "r",
+}
+`;
+
+exports[`supported languages ruby should generate code for the default target 1`] = `
 Object {
   "code": "require 'uri'
 require 'net/http'
@@ -282,7 +767,25 @@ puts response.read_body",
 }
 `;
 
-exports[`supported languages should support swift 1`] = `
+exports[`supported languages ruby targets ruby 1`] = `
+Object {
+  "code": "require 'uri'
+require 'net/http'
+
+url = URI(\\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\")
+
+http = Net::HTTP.new(url.host, url.port)
+
+request = Net::HTTP::Get.new(url)
+request[\\"Accept\\"] = 'application/xml'
+
+response = http.request(request)
+puts response.read_body",
+  "highlightMode": "ruby",
+}
+`;
+
+exports[`supported languages swift should generate code for the default target 1`] = `
 Object {
   "code": "import Foundation
 
@@ -290,6 +793,33 @@ let request = NSMutableURLRequest(url: NSURL(string: \\"https://example.com/path
                                         cachePolicy: .useProtocolCachePolicy,
                                     timeoutInterval: 10.0)
 request.httpMethod = \\"GET\\"
+
+let session = URLSession.shared
+let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
+  if (error != nil) {
+    print(error)
+  } else {
+    let httpResponse = response as? HTTPURLResponse
+    print(httpResponse)
+  }
+})
+
+dataTask.resume()",
+  "highlightMode": "swift",
+}
+`;
+
+exports[`supported languages swift targets nsurlsession 1`] = `
+Object {
+  "code": "import Foundation
+
+let headers = [\\"Accept\\": \\"application/xml\\"]
+
+let request = NSMutableURLRequest(url: NSURL(string: \\"http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark\\")! as URL,
+                                        cachePolicy: .useProtocolCachePolicy,
+                                    timeoutInterval: 10.0)
+request.httpMethod = \\"GET\\"
+request.allHTTPHeaderFields = headers
 
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -5343,6 +5343,12 @@
       "dev": true,
       "optional": true
     },
+    "har-examples": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/har-examples/-/har-examples-1.0.6.tgz",
+      "integrity": "sha512-fPrJvANRBqCcQPK/xk+ehxkmVFdwaLXeL47ZnuOvbj2eHcK7FaBmAVOqXKBT3SaKCiOHB/rEKFvSwON8LHyfQw==",
+      "dev": true
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -29,6 +29,7 @@
     "@readme/oas-examples": "^4.0.0",
     "datauri": "^3.0.0",
     "eslint": "^7.0.0",
+    "har-examples": "^1.0.6",
     "jest": "^26.0.1",
     "prettier": "^2.0.1"
   },

--- a/packages/oas-to-snippet/src/index.js
+++ b/packages/oas-to-snippet/src/index.js
@@ -9,16 +9,52 @@ const supportedLanguages = require('./supportedLanguages');
  * @param {Operation} operation
  * @param {Object} values
  * @param {Object} auth
- * @param {String} lang
+ * @param {String|Array} lang
  * @param {String} oasUrl
  * @param {Object|undefined} harOverride
  */
 module.exports = (oas, operation, values, auth, lang, oasUrl, harOverride) => {
+  let config;
+  let language;
+  let target;
+
+  // If `lang` is an array, then it's a mixture of language and targets like `[php, guzzle]` or `[javascript, axios]` so
+  // we need to a bit of work to pull out the necessary information needed to build the snippet. For backwards
+  // compatibility sake we still need to support supplying `node-simple` as the language even though `node-simple` does
+  // not exist within the list of `supportedLanguages`.
+  if (lang === 'node-simple') {
+    config = supportedLanguages.node;
+    language = 'node';
+    target = 'api';
+  } else if (Array.isArray(lang)) {
+    if (lang[0] in supportedLanguages) {
+      if (lang[1] in supportedLanguages[lang[0]].httpsnippet.targets) {
+        config = supportedLanguages[lang[0]];
+        language = config.httpsnippet.lang;
+        target = lang[1];
+      }
+    }
+  } else if (lang in supportedLanguages) {
+    config = supportedLanguages[lang];
+    language = config.httpsnippet.lang;
+    target = config.httpsnippet.default;
+  }
+
+  // Prevents errors if non-generated code snippet is selected and there isn't a way to generate a code snippet for it
+  // (like for example `shell`).
+  if (!language || !target) {
+    return { code: '', highlightMode: false };
+  }
+
   const har = harOverride || generateHar(oas, operation, values, auth);
+  const snippet = new HTTPSnippet(har, { escapeQueryStrings: false });
+
+  const targetOpts = config.httpsnippet.targets[target].opts || {};
+  const highlightMode = config.highlight;
 
   // API SDK client needs additional runtime information on the API definition we're showing the user so it can
   // generate an appropriate snippet.
-  if (lang === 'node-simple') {
+  if (language === 'node' && target === 'api') {
     try {
       HTTPSnippet.addTargetClient('node', HTTPSnippetSimpleApiClient);
     } catch (e) {
@@ -26,28 +62,14 @@ module.exports = (oas, operation, values, auth, lang, oasUrl, harOverride) => {
         throw e;
       }
     }
-  }
 
-  const snippet = new HTTPSnippet(har, { escapeQueryStrings: false });
-
-  const language = supportedLanguages[lang];
-
-  // Prevents errors if non-generated code snippet is selected and there isn't a way to generate a code snippet for it
-  // (like for example `shell`).
-  if (!language) {
-    return { code: '', highlightMode: false };
-  }
-
-  if (lang === 'node-simple') {
-    language.httpsnippet[2] = {
-      apiDefinitionUri: oasUrl,
-      apiDefinition: oas,
-    };
+    targetOpts.apiDefinition = oas;
+    targetOpts.apiDefinitionUri = oasUrl;
   }
 
   return {
-    code: snippet.convert(...language.httpsnippet),
-    highlightMode: language.highlight,
+    code: snippet.convert(language, target, targetOpts),
+    highlightMode,
   };
 };
 

--- a/packages/oas-to-snippet/src/supportedLanguages.js
+++ b/packages/oas-to-snippet/src/supportedLanguages.js
@@ -1,80 +1,212 @@
-const supportedLanguages = {
+module.exports = {
   c: {
-    httpsnippet: ['c'],
     highlight: 'text/x-csrc',
+    httpsnippet: {
+      lang: 'c',
+      default: 'c',
+      targets: {
+        c: {},
+      },
+    },
   },
   clojure: {
-    httpsnippet: ['clojure'],
     highlight: 'clojure',
+    httpsnippet: {
+      lang: 'clojure',
+      default: 'clojure',
+      targets: {
+        clojure: {},
+      },
+    },
   },
   cplusplus: {
-    httpsnippet: ['c'],
     highlight: 'text/x-c++src',
+    httpsnippet: {
+      lang: 'c',
+      default: 'c',
+      targets: {
+        c: {},
+      },
+    },
   },
   csharp: {
-    httpsnippet: ['csharp', 'restsharp'],
     highlight: 'text/x-csharp',
+    httpsnippet: {
+      lang: 'csharp',
+      default: 'restsharp',
+      targets: {
+        httpclient: {},
+        restsharp: {},
+      },
+    },
   },
   curl: {
-    httpsnippet: ['shell', 'curl'],
     highlight: 'shell',
+    httpsnippet: {
+      lang: 'shell',
+      default: 'curl',
+      targets: {
+        curl: {},
+      },
+    },
   },
   go: {
-    httpsnippet: ['go', 'native'],
     highlight: 'go',
+    httpsnippet: {
+      lang: 'go',
+      default: 'native',
+      targets: {
+        native: {},
+      },
+    },
   },
   java: {
-    httpsnippet: ['java', 'okhttp'],
     highlight: 'java',
+    httpsnippet: {
+      lang: 'java',
+      default: 'okhttp',
+      targets: {
+        asynchttp: {},
+        nethttp: {},
+        okhttp: {},
+        unirest: {},
+      },
+    },
   },
   javascript: {
-    httpsnippet: ['javascript', 'fetch', { useObjectBody: true }],
     highlight: 'javascript',
+    httpsnippet: {
+      lang: 'javascript',
+      default: 'fetch',
+      targets: {
+        axios: {
+          install: 'npm install axios --save',
+        },
+        fetch: {
+          opts: { useObjectBody: true },
+        },
+        jquery: {},
+        xhr: {},
+      },
+    },
   },
   kotlin: {
-    httpsnippet: ['java', 'okhttp'],
     highlight: 'java',
+    httpsnippet: {
+      lang: 'java',
+      default: 'okhttp',
+      targets: {
+        okhttp: {},
+      },
+    },
   },
   node: {
-    httpsnippet: ['node', 'fetch', { useObjectBody: true }],
     highlight: 'javascript',
-  },
-  'node-simple': {
-    httpsnippet: ['node', 'api'],
-    highlight: 'javascript',
+    httpsnippet: {
+      lang: 'node',
+      default: 'fetch',
+      targets: {
+        api: {
+          opts: {
+            apiDefinition: null,
+            apiDefinitionUri: null,
+          },
+          install: 'npm install api --save',
+        },
+        axios: {
+          install: 'npm install axios --save',
+        },
+        fetch: {
+          opts: { useObjectBody: true },
+          install: 'npm install node-fetch --save',
+        },
+        native: {},
+        request: {
+          install: 'npm install request --save',
+        },
+      },
+    },
   },
   objectivec: {
-    httpsnippet: ['objc', 'NSURLSession'],
     highlight: 'objectivec',
+    httpsnippet: {
+      lang: 'objc',
+      default: 'nsurlsession',
+      targets: {
+        nsurlsession: {},
+      },
+    },
   },
   ocaml: {
-    httpsnippet: ['ocaml'],
     highlight: 'ocaml',
+    httpsnippet: {
+      lang: 'ocaml',
+      default: 'ocaml',
+      targets: {
+        ocaml: {},
+      },
+    },
   },
   php: {
-    httpsnippet: ['php', 'curl'],
     highlight: 'php',
+    httpsnippet: {
+      lang: 'php',
+      default: 'curl',
+      targets: {
+        curl: {},
+      },
+    },
   },
   powershell: {
-    httpsnippet: ['powershell'],
     highlight: 'powershell',
+    httpsnippet: {
+      lang: 'powershell',
+      default: 'powershell',
+      targets: {
+        powershell: {},
+      },
+    },
   },
   python: {
-    httpsnippet: ['python', 'requests'],
     highlight: 'python',
-  },
-  ruby: {
-    httpsnippet: ['ruby'],
-    highlight: 'ruby',
+    httpsnippet: {
+      lang: 'python',
+      default: 'requests',
+      targets: {
+        requests: {
+          install: 'python -m pip install requests',
+        },
+      },
+    },
   },
   r: {
-    httpsnippet: ['r'],
     highlight: 'r',
+    httpsnippet: {
+      lang: 'r',
+      default: 'r',
+      targets: {
+        r: {},
+      },
+    },
+  },
+  ruby: {
+    highlight: 'ruby',
+    httpsnippet: {
+      lang: 'ruby',
+      default: 'ruby',
+      targets: {
+        ruby: {},
+      },
+    },
   },
   swift: {
-    httpsnippet: ['swift', 'nsurlsession'],
     highlight: 'swift',
+    httpsnippet: {
+      lang: 'swift',
+      default: 'nsurlsession',
+      targets: {
+        nsurlsession: {},
+      },
+    },
   },
 };
-
-module.exports = supportedLanguages;


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

This updates `@readme/oas-to-snippet` to add support alternative language targets! 

Previously if you wanted to generate a Node snippet, you'd do:

```js
generateCodeSnippet(oas, operation, formData, authData, 'node', oasUrl);
```

This would generate you a `node-fetch` snippet and that's great but [HTTPSnippet](https://npm.im/@readme/httpsnippet) offers all sorts of other Node targets like `axios` or `request` that you couldn't use &mdash; with this change you can now do the following:

```js
generateCodeSnippet(oas, operation, formData, authData, ['node', 'axios'], oasUrl);
```

With the `language` argument as an array we'll now do a lookup in our supported targets for `node` and if `axios` is there we'll generate an Axios snippet!

## 🧬 Testing

I've mostly rewritten `supportedLanguages` and the core language determination in this library along with a ton of new tests for this and all of the new targets we're now exposing, but with that there's a few points:

* Backwards compatibility remains intact so `node` will continue to map to `node-fetch`.
  * https://explorer-pr-1261.herokuapp.com/?selected=swagger-files%2Fpetstore.json
* I've also removed `node-simple` from the list of `supportedLanguages` in favor of treating it as a proper alternative target for `node`. To retain backwards compatibility with the rest of these changes, supplying `node-simple` as the language arg (and having it within your OAS in `x-samples-languages`) will continue to work.
  * https://explorer-pr-1261.herokuapp.com/?selected=swagger-files%2Fauth-types.json 
* I've dug through how we use `supportedLanguages` within ReadMe and thankfully the overhauls to the structure of this object won't affect anything there.

[demo]: https://explorer-pr-1261.herokuapp.com/
