### PR TITLE
feat: updating httpsnippet and httpsnippet-client-api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,6 @@
       "version": "7.14.2",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.2.tgz",
       "integrity": "sha512-OgC1mON+l4U4B4wiohJlQNUU3H73mpTyYY3j/c8U9dr9UagGGSm+WFpzjy/YLdoyjiG++c1kIDgxCo/mLwQJeQ==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.14.2",
@@ -193,7 +192,6 @@
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
           "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.12.13"
           }
@@ -201,14 +199,12 @@
         "@babel/compat-data": {
           "version": "7.14.0",
           "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.0.tgz",
-          "integrity": "sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q==",
-          "dev": true
+          "integrity": "sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q=="
         },
         "@babel/generator": {
           "version": "7.14.2",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.2.tgz",
           "integrity": "sha512-OnADYbKrffDVai5qcpkMxQ7caomHOoEwjkouqnN2QhydAjowFAZcsdecFIRUBdb+ZcruwYE4ythYmF1UBZU5xQ==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.14.2",
             "jsesc": "^2.5.1",
@@ -219,7 +215,6 @@
           "version": "7.13.16",
           "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
           "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
-          "dev": true,
           "requires": {
             "@babel/compat-data": "^7.13.15",
             "@babel/helper-validator-option": "^7.12.17",
@@ -231,7 +226,6 @@
           "version": "7.14.2",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
           "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.12.13",
             "@babel/template": "^7.12.13",
@@ -242,7 +236,6 @@
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
           "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
           }
@@ -251,7 +244,6 @@
           "version": "7.13.12",
           "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
           "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.13.12"
           }
@@ -260,7 +252,6 @@
           "version": "7.13.12",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
           "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.13.12"
           }
@@ -269,7 +260,6 @@
           "version": "7.14.2",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
           "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
-          "dev": true,
           "requires": {
             "@babel/helper-module-imports": "^7.13.12",
             "@babel/helper-replace-supers": "^7.13.12",
@@ -285,7 +275,6 @@
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
           "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
           }
@@ -294,7 +283,6 @@
           "version": "7.13.12",
           "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
           "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
-          "dev": true,
           "requires": {
             "@babel/helper-member-expression-to-functions": "^7.13.12",
             "@babel/helper-optimise-call-expression": "^7.12.13",
@@ -306,7 +294,6 @@
           "version": "7.13.12",
           "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
           "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.13.12"
           }
@@ -315,7 +302,6 @@
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
           "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
           }
@@ -323,20 +309,17 @@
         "@babel/helper-validator-identifier": {
           "version": "7.14.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-          "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
-          "dev": true
+          "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
         },
         "@babel/helper-validator-option": {
           "version": "7.12.17",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-          "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
-          "dev": true
+          "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
         },
         "@babel/highlight": {
           "version": "7.14.0",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
           "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.0",
             "chalk": "^2.0.0",
@@ -346,14 +329,12 @@
         "@babel/parser": {
           "version": "7.14.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.2.tgz",
-          "integrity": "sha512-IoVDIHpsgE/fu7eXBeRWt8zLbDrSvD7H1gpomOkPpBoEN8KCruCqSDdqo8dddwQQrui30KSvQBaMUOJiuFu6QQ==",
-          "dev": true
+          "integrity": "sha512-IoVDIHpsgE/fu7eXBeRWt8zLbDrSvD7H1gpomOkPpBoEN8KCruCqSDdqo8dddwQQrui30KSvQBaMUOJiuFu6QQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
           "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/parser": "^7.12.13",
@@ -364,7 +345,6 @@
           "version": "7.14.2",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
           "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.14.2",
@@ -380,7 +360,6 @@
           "version": "7.14.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.2.tgz",
           "integrity": "sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.0",
             "to-fast-properties": "^2.0.0"
@@ -390,7 +369,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -399,7 +377,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -410,7 +387,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -418,20 +394,17 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "json5": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
           "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-          "dev": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -439,20 +412,17 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -581,6 +551,7 @@
       "version": "7.12.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
       "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.12.7"
       }
@@ -589,6 +560,7 @@
       "version": "7.12.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
       "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.12.5"
       }
@@ -597,6 +569,7 @@
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
       "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.12.1",
         "@babel/helper-replace-supers": "^7.12.1",
@@ -613,6 +586,7 @@
       "version": "7.12.10",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
       "integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.12.10"
       }
@@ -637,6 +611,7 @@
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
       "integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+      "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.12.7",
         "@babel/helper-optimise-call-expression": "^7.12.10",
@@ -648,6 +623,7 @@
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
       "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.12.1"
       }
@@ -696,7 +672,6 @@
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
       "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.14.0",
@@ -707,7 +682,6 @@
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
           "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.12.13"
           }
@@ -716,7 +690,6 @@
           "version": "7.14.2",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.2.tgz",
           "integrity": "sha512-OnADYbKrffDVai5qcpkMxQ7caomHOoEwjkouqnN2QhydAjowFAZcsdecFIRUBdb+ZcruwYE4ythYmF1UBZU5xQ==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.14.2",
             "jsesc": "^2.5.1",
@@ -727,7 +700,6 @@
           "version": "7.14.2",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
           "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.12.13",
             "@babel/template": "^7.12.13",
@@ -738,7 +710,6 @@
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
           "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
           }
@@ -747,7 +718,6 @@
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
           "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
           }
@@ -755,14 +725,12 @@
         "@babel/helper-validator-identifier": {
           "version": "7.14.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-          "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
-          "dev": true
+          "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
         },
         "@babel/highlight": {
           "version": "7.14.0",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
           "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.0",
             "chalk": "^2.0.0",
@@ -772,14 +740,12 @@
         "@babel/parser": {
           "version": "7.14.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.2.tgz",
-          "integrity": "sha512-IoVDIHpsgE/fu7eXBeRWt8zLbDrSvD7H1gpomOkPpBoEN8KCruCqSDdqo8dddwQQrui30KSvQBaMUOJiuFu6QQ==",
-          "dev": true
+          "integrity": "sha512-IoVDIHpsgE/fu7eXBeRWt8zLbDrSvD7H1gpomOkPpBoEN8KCruCqSDdqo8dddwQQrui30KSvQBaMUOJiuFu6QQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
           "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/parser": "^7.12.13",
@@ -790,7 +756,6 @@
           "version": "7.14.2",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
           "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.14.2",
@@ -806,7 +771,6 @@
           "version": "7.14.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.2.tgz",
           "integrity": "sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.0",
             "to-fast-properties": "^2.0.0"
@@ -816,7 +780,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -825,7 +788,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -836,7 +798,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -844,26 +805,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -5578,9 +5535,9 @@
       "integrity": "sha512-w1k5sqdvr63abdeAyGzDBjMXkr9V2mpGpgYVIDX3yHASnx9z3wgsaiiiBux6I44CZVj2pzfVgsKNSsBu5CSYFg=="
     },
     "@readme/httpsnippet": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.4.5.tgz",
-      "integrity": "sha512-S95cBmAJ912rPHBgh24Z37CVlyTUlxuntnSzdpaBwTWJ0nAaMYWA43vAoXLK98spoTeHebpNVqJWqOW8jc6Hzg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.5.0.tgz",
+      "integrity": "sha512-Jdb2WFzRe+ulpaIuCfgBQcyglblZ1yBIbvHB/9ZGZhGN8mD24G8qV6VxrzPZDjgEXSfnAee30ASesVC2/SF68A==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",
@@ -5781,6 +5738,14 @@
             "path-to-regexp": "^6.2.0",
             "request": "^2.88.0",
             "swagger-inline": "3.2.2"
+          }
+        },
+        "parse-data-url": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-3.0.0.tgz",
+          "integrity": "sha512-U72k3mbLzeTiPgVbMIJKG+LROejvsniSMwAgz8EM+DhP0C2HYAmXu65uq2IWjYLffgZndFa42E9TCOHJCi37uA==",
+          "requires": {
+            "valid-data-url": "^3.0.1"
           }
         }
       }
@@ -7597,7 +7562,6 @@
       "version": "4.16.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.1.tgz",
       "integrity": "sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001173",
         "colorette": "^1.2.1",
@@ -7821,8 +7785,7 @@
     "caniuse-lite": {
       "version": "1.0.30001173",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz",
-      "integrity": "sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==",
-      "dev": true
+      "integrity": "sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -8211,8 +8174,7 @@
     "colorette": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
-      "dev": true
+      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
     },
     "colors": {
       "version": "1.4.0",
@@ -9973,8 +9935,7 @@
     "electron-to-chromium": {
       "version": "1.3.635",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.635.tgz",
-      "integrity": "sha512-RRriZOLs9CpW6KTLmgBqyUdnY0QNqqWs0HOtuQGGEMizOTNNn1P7sGRBxARnUeLejOsgwjDyRqT3E/CSst02ZQ==",
-      "dev": true
+      "integrity": "sha512-RRriZOLs9CpW6KTLmgBqyUdnY0QNqqWs0HOtuQGGEMizOTNNn1P7sGRBxARnUeLejOsgwjDyRqT3E/CSst02ZQ=="
     },
     "elliptic": {
       "version": "6.5.3",
@@ -11529,6 +11490,16 @@
       "integrity": "sha512-x3K4zFjuQS7wrMfN0858oE2SAq8ibTT8/L0UkBztXQsambbWtKPvGnuLxNqrmdnVZct75PhvFOn0dFyFU9rPlQ==",
       "requires": {
         "parse-data-url": "^3.0.0"
+      },
+      "dependencies": {
+        "parse-data-url": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-3.0.0.tgz",
+          "integrity": "sha512-U72k3mbLzeTiPgVbMIJKG+LROejvsniSMwAgz8EM+DhP0C2HYAmXu65uq2IWjYLffgZndFa42E9TCOHJCi37uA==",
+          "requires": {
+            "valid-data-url": "^3.0.1"
+          }
+        }
       }
     },
     "figgy-pudding": {
@@ -14527,9 +14498,9 @@
       }
     },
     "jest-expect-har": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/jest-expect-har/-/jest-expect-har-1.0.3.tgz",
-      "integrity": "sha512-JSKjVnaMIh1apH/x2wLylbOa1Vx7GO18GenPuf2EX0UzHbJA8cQKgunojBMnpj3USyDkoRL7JQZO34F9S8JezQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-expect-har/-/jest-expect-har-2.0.0.tgz",
+      "integrity": "sha512-SWG60nySfaG/uBAMN3jGWEyyEBruavd4NZQDJ8L/FgW6TYVMSMk+mwj+7GpyeZU6lThKyNHnwIZv6rCUlCqONQ==",
       "requires": {
         "har-validator": "^5.1.3"
       }
@@ -16385,8 +16356,7 @@
     "node-releases": {
       "version": "1.1.69",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.69.tgz",
-      "integrity": "sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==",
-      "dev": true
+      "integrity": "sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA=="
     },
     "node-sass": {
       "version": "4.14.1",
@@ -17618,11 +17588,18 @@
       }
     },
     "parse-data-url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-3.0.0.tgz",
-      "integrity": "sha512-U72k3mbLzeTiPgVbMIJKG+LROejvsniSMwAgz8EM+DhP0C2HYAmXu65uq2IWjYLffgZndFa42E9TCOHJCi37uA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-4.0.1.tgz",
+      "integrity": "sha512-W+ZgeHPkG2Awbj2RCGG3zALoKGoKucIWXRp8jPgTVNmRgiftXbwXXzzaXXH4L1+OdxeSXC6C8G+hzlcv41f24A==",
       "requires": {
-        "valid-data-url": "^3.0.1"
+        "valid-data-url": "^4.0.0"
+      },
+      "dependencies": {
+        "valid-data-url": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-4.0.0.tgz",
+          "integrity": "sha512-mV5E0AG/F2yPiJzYlhyooI83BLIV0i4h/ueZwdxr1Mh8ZeKKpcFZLbZbAAedL/PLd11sqIgppJBrb4SNXA0PMQ=="
+        }
       }
     },
     "parse-entities": {

--- a/packages/oas-to-snippet/package-lock.json
+++ b/packages/oas-to-snippet/package-lock.json
@@ -2454,9 +2454,9 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.4.5.tgz",
-      "integrity": "sha512-S95cBmAJ912rPHBgh24Z37CVlyTUlxuntnSzdpaBwTWJ0nAaMYWA43vAoXLK98spoTeHebpNVqJWqOW8jc6Hzg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.5.0.tgz",
+      "integrity": "sha512-Jdb2WFzRe+ulpaIuCfgBQcyglblZ1yBIbvHB/9ZGZhGN8mD24G8qV6VxrzPZDjgEXSfnAee30ASesVC2/SF68A==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",
@@ -5492,9 +5492,9 @@
       }
     },
     "httpsnippet-client-api": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-3.0.3.tgz",
-      "integrity": "sha512-1k1vqXlVW7YENqqAVGaXm27fuA1Ug7OYak1UDExi4lMemgxeN5QVaPUR0GWpsdGv1GaQCpVfled5aWU5NXLuHQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-3.1.0.tgz",
+      "integrity": "sha512-rwNbdjbKeViO1VlnYlRu1OwwVNq+K2jfSEzXCtBifkZr5FAnuukxSc3wXNi4HIzMZxnsp4Vz6kwKA9UNZQ01qw==",
       "requires": {
         "content-type": "^1.0.4",
         "path-to-regexp": "^6.1.0",

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -17,11 +17,11 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@readme/httpsnippet": "^2.4.5",
+    "@readme/httpsnippet": "^2.5.0",
     "@readme/oas-extensions": "^13.4.5",
     "@readme/oas-to-har": "^13.4.5",
     "@readme/syntax-highlighter": "^10.7.0",
-    "httpsnippet-client-api": "^3.0.3",
+    "httpsnippet-client-api": "^3.1.0",
     "oas": "^11.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

* [x] Upgrades `@readme/httpsnippet` to adjust how cURL snippets are generated to give ones that contain JSON more room to breathe. https://github.com/readmeio/httpsnippet/pull/44
* [x] Upgrades `httpsnippet-client-api` to support server variables. https://github.com/readmeio/api/pull/284

[demo]: https://deployment_url
