### PR TITLE
fix: re-export SelectedAppContext

### DIFF
--- a/packages/variable/index.jsx
+++ b/packages/variable/index.jsx
@@ -163,3 +163,4 @@ module.exports.Variable = Variable;
 // - <<glossary:glossary items>> - glossary
 module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-\w:.\s]+)(?:\\)?>>/.source;
 module.exports.VariablesContext = VariablesContext;
+module.exports.SelectedAppContext = SelectedAppContext;


### PR DESCRIPTION
| [☁️ &nbsp; CI App][demo] |
| --- |

## 🧰 What's being changed?

The SelectedAppContext provider needs to be re-exported from variable as the provider is now coming from readme and not the explorer - without the re-export it will always use SelectedAppContext's empty default state in the context consumer.

[Other half of this PR is in readme](https://github.com/readmeio/readme/pull/4616)

## 🧬 Testing
Requires a link to the changes in the api-explorer:
1. In the api-explorer, `cd packages/variable` and run `npm link`
2. Run `npm link @readme/variable` in `readme`
3. Run `npm run build` in the `api-explorer` before running start in readme
1. Create a new project with the subdomain 'developers' that is not an enterprise/enterprise child project
2. Create a new page in the guides section and add a code block to the page with the language 'javascript'
3. Add the following in the code block: 
          `app.use(readme.metrics('<<user>>', req => ({
            id: req.<userId>,
            label: req.<userNameToShowInDashboard>,
            email: req.<userEmailAddress>,
          })));`
1. Open the hub, and navigate to the page with the code block
2. The dropdown with your API keys should now be able to change the selection


[demo]: https://explorer-pr-1322.herokuapp.com/
