### PR TITLE
feat: adding an extension to control `api` simple mode

### DIFF
--- a/packages/oas-extensions/__tests__/index.test.js
+++ b/packages/oas-extensions/__tests__/index.test.js
@@ -10,6 +10,7 @@ test.each([
   ['SAMPLES_ENABLED'],
   ['SAMPLES_LANGUAGES'],
   ['SEND_DEFAULTS'],
+  ['SIMPLE_MODE'],
 ])('`%s` extension should have a default value', extension => {
   expect(extensions[extension] in extensions.defaults).toBe(true);
 });
@@ -100,6 +101,7 @@ describe('#isExtensionValid()', () => {
     ['SAMPLES_ENABLED', true, 'no', 'Boolean'],
     ['SAMPLES_LANGUAGES', ['swift'], {}, 'Array'],
     ['SEND_DEFAULTS', true, 'absolutely not', 'Boolean'],
+    ['SIMPLE_MODE', true, 'absolutely not', 'Boolean'],
   ])('%s', (extension, validValue, invalidValue, expectedType) => {
     describe('should allow valid extensions', () => {
       it('should allow at the root level', () => {

--- a/packages/oas-extensions/index.js
+++ b/packages/oas-extensions/index.js
@@ -8,6 +8,7 @@ const PROXY_ENABLED = 'proxy-enabled';
 const SAMPLES_ENABLED = 'samples-enabled';
 const SAMPLES_LANGUAGES = 'samples-languages';
 const SEND_DEFAULTS = 'send-defaults';
+const SIMPLE_MODE = 'simple-mode';
 
 module.exports = {
   CODE_SAMPLES,
@@ -17,6 +18,7 @@ module.exports = {
   SAMPLES_ENABLED,
   SAMPLES_LANGUAGES,
   SEND_DEFAULTS,
+  SIMPLE_MODE,
 };
 
 module.exports.defaults = {
@@ -27,6 +29,7 @@ module.exports.defaults = {
   [SAMPLES_ENABLED]: true,
   [SAMPLES_LANGUAGES]: ['curl', 'node', 'ruby', 'php', 'python'],
   [SEND_DEFAULTS]: false,
+  [SIMPLE_MODE]: true,
 };
 
 /**


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] Adds a new extension to `oas-extensions` to support disabling our upcoming [api](http://npm.im/api) simple mode Node request snippets
