### PR TITLE
fix: stop adding `null` basic auth passwords into base64 encoded auth headers

### DIFF
--- a/packages/oas-to-har/__tests__/lib/configure-security.test.js
+++ b/packages/oas-to-har/__tests__/lib/configure-security.test.js
@@ -56,6 +56,27 @@ describe('configure-security', () => {
         });
       });
 
+      it('should work if the password is empty or null', () => {
+        const user = 'user';
+        const pass = null;
+
+        expect(
+          configureSecurity(
+            {
+              components: { securitySchemes: { schemeName: { type: 'http', scheme: 'basic' } } },
+            },
+            { schemeName: { user, pass } },
+            'schemeName'
+          )
+        ).toStrictEqual({
+          type: 'headers',
+          value: {
+            name: 'Authorization',
+            value: `Basic ${Buffer.from(`${user}:`).toString('base64')}`,
+          },
+        });
+      });
+
       it('should return with no header if wanted scheme is missing', () => {
         expect(
           configureSecurity(

--- a/packages/oas-to-har/src/lib/configure-security.js
+++ b/packages/oas-to-har/src/lib/configure-security.js
@@ -17,9 +17,15 @@ module.exports = function configureSecurity(oas, values, scheme) {
       if (!values[scheme]) return false;
       if (!values[scheme].user && !values[scheme].pass) return false;
 
+      const user = values[scheme].user;
+      let pass = values[scheme].pass;
+      if (pass === null || pass.length === 0) {
+        pass = '';
+      }
+
       return harValue('headers', {
         name: 'Authorization',
-        value: `Basic ${Buffer.from(`${values[scheme].user}:${values[scheme].pass}`).toString('base64')}`,
+        value: `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`,
       });
     } else if (security.scheme === 'bearer') {
       if (!values[scheme]) return false;


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] Fixes a bug in the basic auth handling in `@readme/oas-to-har` where if a password was `null`, the user+password would be encoded into the header as `user:null`.
